### PR TITLE
WIP: Remove bind_host setting

### DIFF
--- a/roles/internal/theyvoteforyou/meta/main.yml
+++ b/roles/internal/theyvoteforyou/meta/main.yml
@@ -30,5 +30,4 @@ dependencies:
           - missingok
           - copytruncate
   - role: azavea.elasticsearch
-    elasticsearch_bind_host: 127.0.0.1
     java_version: "8u151*"


### PR DESCRIPTION
STATUS: WIP - Do Not Merge

Observed behaviour matches description at
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html;
that is, when bind_host is set to 127.0.0.1, publish_host will be
picked from the "best" address in network.host, which may not match
bind_host, which may result in situations where other members of the
cluster are trying to connect to an interface where elasticsearch
isn't bound.

Remvoing this setting means that the "best" value will be used for
both bind_host and publish_host.

This seems to work okay for me in my dev instance but I'm not sure
it's appropriate in prod. For there, maybe specifying both bind_host
and publish_host would be better?

Before this change, /var/log/elasticsearch.log contains lots of:

[2018-03-04 11:48:35,342][WARN ][cluster.service          ] [Carl "Crusher" Creel] failed to reconnect to node [Carl "Crusher" Creel][W9vKL-bBRGuw-h
JARk-FDg][theyvoteforyou][inet[/10.0.2.15:9300]]
org.elasticsearch.transport.ConnectTransportException: [Carl "Crusher"
Creel][inet[/10.0.2.15:9300]] connect_timeout[30s]

after this change, not seen.

---

I'm flagging this as WIP because I'm not sure if this change makes sense in production. If it does, it's easy to update this change request and merge. If it doesn't, we can abandon this.