### PR TITLE
Add a rough script for rekeying all encrypted values in a file

### DIFF
--- a/rekey.rb
+++ b/rekey.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/ruby
+
+# Usage: ./rekey.rb > new.yaml; cp new.yaml group_vars/righttoknow.yaml
+
+INFILE="group_vars/ec2.yml"
+NEWID="ec2"
+
+require 'psych'
+data = Psych.load_file(INFILE)
+
+data.each_pair { | key, value |
+  if value =~ /.*ANSIBLE_VAULT.*/
+    decrypted = `echo '#{value}' | ansible-vault decrypt`
+    decrypted = decrypted.strip
+    rekeyed = `echo -n '#{decrypted}' | ansible-vault --encrypt-vault-id #{NEWID} encrypt_string --stdin-name #{key}` 
+    $stdout.puts rekeyed
+  else
+    $stdout.puts Psych.dump_stream( {key => value} ).gsub!(/---\n/, "")
+  end
+}


### PR DESCRIPTION
- For encrypted values, be careful not to let a yaml parser touch the
  string Ansible returns as the `!vault: ` tag - although a standard
  part of the YAML spec - is not handled the way we'd like and so it
  will disappear.
- For everything else, invoke the yaml parser to dump out something
  close to the input
- In practice, I've selectively committed just the hunks I want to
  minimise changes to the files being updated

Feedback on how to make this less terrible are welcome.