### PR TITLE
Update election_web_root to use https

### DIFF
--- a/roles/internal/openaustralia/templates/parser_configuration.yml
+++ b/roles/internal/openaustralia/templates/parser_configuration.yml
@@ -31,7 +31,7 @@ qanda_electorate_url: "http://www.abc.net.au/tv/qanda/find-your-local-mp.htm"
 qanda_all_senators_url: "http://www.abc.net.au/tv/qanda/find-a-senate-member-by-a-z.htm"
 
 # ABC 2007 election results
-election_web_root: "http://www.abc.net.au/elections/federal/2007"
+election_web_root: "https://www.abc.net.au/elections/federal/2007"
 
 # Selectively allows us to turn off and on the writing of the XML
 write_xml_representatives: true


### PR DESCRIPTION
hpricot seems to object to being redirected from http to https; so use
the https version and avoid the redirect.

Blocks https://github.com/openaustralia/openaustralia/issues/654