### PR TITLE
Add Txt Record for Microsoft Domain Verification

### DIFF
--- a/terraform/oaf-dns.tf
+++ b/terraform/oaf-dns.tf
@@ -236,6 +236,14 @@ resource "cloudflare_record" "oaf_github_challenge2" {
   value   = "209f2b7179"
 }
 
+# Microsoft 365 Domain verification
+resource "cloudflare_record" "oaf_microsoft_domain" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "oaf.org.au"
+  type    = "TXT"
+  value   = "MS=ms62560359"
+}
+
 ## openaustraliafoundation.org.au
 
 # A records


### PR DESCRIPTION
Kat agreed to register us for Microsoft 365 for NonProfits. This is my attempt to create a TXT record on oaf.org.au with the below variables:

<img width="309" alt="image" src="https://user-images.githubusercontent.com/6841582/157036761-6f92f23e-1993-48c0-a0a5-0e29d257808f.png">