### PR TITLE
Re-Add client_max_body_size 100M to Right to Know

### DIFF
--- a/roles/internal/righttoknow/templates/nginx/nginx.conf
+++ b/roles/internal/righttoknow/templates/nginx/nginx.conf
@@ -19,6 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
+	client_max_body_size 100M;
 	# server_tokens off;
 
 	# server_names_hash_bucket_size 64;


### PR DESCRIPTION
This re-adds the 100MB client_max_body_size limit to nginx.conf file for Right to Know.

Resolves #165 