### PR TITLE
Change DMARC Policy on Right to Know to quarantine

### DIFF
--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -116,9 +116,7 @@ resource "cloudflare_record" "google_domainkey" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm30i+FaCipo1Eef8vrV66CRcdQGDfniuKP1ND2hj0VKiYf9LO15q7ZF9mE14zlOKmP//tS/EbdEXk6eAi0ps6oUf2jIvajyuDzLhz7Xn528LQDdxDRlh+2IdA+Z7jslLW7y0zJdYyp12X/Nx+mZrwbgoZJHplcmIZHQYWv00HX46ioR9eK8Yf6+0kU31ScAMcAphmjS4euYejsY0I0SoTlYDqJ/XNiiE2bl8wFfoG6/mgdHddpuPKKEs0cJc0Opt6ZzHuLdzQ+atnZJkqKQZWhkvrsMqeODBOoCE44SCW+5smT6TARDnGrnKTzvfEPZGoLQPojQHc3Ii+Bq3FtFsFwIDAQAB"
 }
 
-# For the time being we're just using DMARC records to get some data on what's
-# happening with email that we're sending (and whether anyone else is impersonating
-# us).
+## 2024-09-02 - Set DMARC to quarantine emails that don't meet the DMARC requirements.
 # We're using a free service provided by https://dmarc.postmarkapp.com/
 # This generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to webmaster@righttoknow.org.au
@@ -126,5 +124,5 @@ resource "cloudflare_record" "dmarc" {
   zone_id = var.righttoknow_org_au_zone_id
   name    = "_dmarc.righttoknow.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=quarantine; rua=mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; sp=none; pct=100; aspf=r;"
 }


### PR DESCRIPTION
I've confirmed that emails are meeting the required policy. Can we please increase the DMARC level from just reporting to quarantine now?