### PR TITLE
Block aggressive bot from crawling RTK

### DIFF
--- a/roles/internal/righttoknow/templates/nginx/stage
+++ b/roles/internal/righttoknow/templates/nginx/stage
@@ -74,6 +74,14 @@ server {
   {% endif %}
 
   location / {
+
+    # Block overly aggressive bot that isn't giving a sensible user agent
+    deny 47.79.0.0/21;
+    deny 47.79.112.0/20;
+    deny 47.82.0.0/19;
+    deny 47.82.12.0/23;
+    deny 47.82.14.0/23;
+
     # Pass the request on to Varnish.
     proxy_pass  http://127.0.0.1;
 


### PR DESCRIPTION
List of IPs copied from https://github.com/openaustralia/infrastructure/commit/3279f93379d6df38029334dc19ca5213ace49fa4 as the same IPs now seem to be hitting RTK.