### PR TITLE
Add missing symlink for  .vault_pass.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 
 .vagrant
-.vault_pass.txt
 roles/external
 test.pem
 set-aws-access-keys.sh

--- a/.vault_pass.txt
+++ b/.vault_pass.txt
@@ -1,0 +1,1 @@
+/keybase/team/oaforgau.sysadmin/.vault_pass.txt


### PR DESCRIPTION
Other vault passphrase files had symlinks, but this one was missing its symlink.