### PR TITLE
Add missing dependency + docs re packer build

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,18 @@ bundle exec cap development deploy
 
 #### Deploying PlanningAlerts to production
 
+We now have two productions servers, and a blue/green deployment process driven
+out of Terraform. We use this only for major updates, when we're being cautious
+and want to ensure no downtime. For smaller changes, just use capistrano as usual.
+
+AMI images for the servers are built with Packer - look in the `packer/`
+subdirectory for more details on how to build.
+
+Once you have a new image, you'll need to adjust the `_ami_name` variables in
+`terraform/main.tf` to update the not-currently-used cluster; then tweak
+values in the blue/green modules in `terraform/planningalerts/main.tf` to
+adjust where traffic is going. Don't forget that you'll need to
+`terraform apply` at each stage of the change.
 ```
 bundle exec cap production deploy
 ```
@@ -348,19 +360,6 @@ bundle exec cap development deploy
 ```
 
 #### Deploying They Vote For You to production
-
-We now have two productions servers, and a blue/green deployment process driven
-out of Terraform. We use this only for major updates, when we're being cautious
-and want to ensure no downtime. For smaller changes, just use capistrano as usual.
-
-AMI images for the servers are built with Packer - look in the `packer/`
-subdirectory for more details on how to build.
-
-Once you have a new image, you'll need to adjust the `_ami_name` variables in
-`terraform/main.tf` to update the not-currently-used cluster; then tweak
-values in the blue/green modules in `terraform/planningalerts/main.tf` to
-adjust where traffic is going. Don't forget that you'll need to
-`terraform apply` at each stage of the change.
 
 ```
 bundle exec cap production deploy

--- a/README.md
+++ b/README.md
@@ -349,6 +349,19 @@ bundle exec cap development deploy
 
 #### Deploying They Vote For You to production
 
+We now have two productions servers, and a blue/green deployment process driven
+out of Terraform. We use this only for major updates, when we're being cautious
+and want to ensure no downtime. For smaller changes, just use capistrano as usual.
+
+AMI images for the servers are built with Packer - look in the `packer/`
+subdirectory for more details on how to build.
+
+Once you have a new image, you'll need to adjust the `_ami_name` variables in
+`terraform/main.tf` to update the not-currently-used cluster; then tweak
+values in the blue/green modules in `terraform/planningalerts/main.tf` to
+adjust where traffic is going. Don't forget that you'll need to
+`terraform apply` at each stage of the change.
+
 ```
 bundle exec cap production deploy
 ```

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,7 +1,9 @@
 # How to build the "golden" image for the PlanningAlerts service
 
-First install packer then:
+First [install packer](https://developer.hashicorp.com/packer/install) then:
 
-$ cd packer
-$ packer init .
-$ packer build planningalerts.pkr.hcl
+```shell
+cd packer
+packer init .
+packer build planningalerts.pkr.hcl
+```

--- a/packer/planningalerts.pkr.hcl
+++ b/packer/planningalerts.pkr.hcl
@@ -4,8 +4,14 @@ packer {
       version = "~> 1"
       source = "github.com/hashicorp/ansible"
     }
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
   }
 }
+
+
 
 source "amazon-ebs" "planningalerts-ruby33" {
   ami_name = "planningalerts-ruby-3.3-v1"


### PR DESCRIPTION
- Amazon plugin is required to use the `amazon-ebs` source
- Adding notes to docs to show where to install packer, and a brief mention in the main README