### PR TITLE
Github pages are now github.io rather than github.com

### DIFF
--- a/roles/internal/openaustralia/templates/apache/software.conf
+++ b/roles/internal/openaustralia/templates/apache/software.conf
@@ -5,5 +5,5 @@
     ServerName software.{{ openaustralia_domain }}
     ServerAlias software.openaustralia.org
     
-    RedirectMatch permanent / http://openaustralia.github.com/openaustralia/
+    RedirectMatch permanent / http://openaustralia.github.io/openaustralia/
 </VirtualHost>


### PR DESCRIPTION
Fixes openaustralia/openaustralia#688
