### PR TITLE
Include puma.log in Planningalerts logs shipped to cloudwatch

### DIFF
--- a/group_vars/planningalerts.yml
+++ b/group_vars/planningalerts.yml
@@ -60,3 +60,9 @@ logs:
     log_group_name: /srv/www/production/shared/log/production.log
     log_stream_name: "{{ inventory_hostname }}"
     timestamp_format: "%Y-%m-%dT%H:%M:%S.%f"
+  
+  - file_path: /srv/www/production/shared/log/puma.log
+    log_group_name: /srv/www/production/shared/log/puma.log
+    log_stream_name: "{{ inventory_hostname }}"
+    timestamp_format: "%Y-%m-%dT%H:%M:%S.%f"
+  


### PR DESCRIPTION
Adds the puma log to those shipped to cloudwatch, as it seems to be where errors go now.