### PR TITLE
Update repository URLs to HTTPS and enhance README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ the top of `update-ssl-certs.yaml`.
 
 ### Deploying Right To Know to your local development server
 
-In your checked out copy (`production` branch) of the Alaveteli repo add the following to `config/deploy.yml`
+If you haven't already, check out our [Alaveteli Repo](https://github.com/openaustralia/alaveteli). 
+
+In your checked out (`production` branch) of the Alaveteli repo add the following to `config/deploy.yml`
 
 ```yaml
 production:

--- a/README.md
+++ b/README.md
@@ -240,15 +240,15 @@ In your checked out copy (`production` branch) of the Alaveteli repo add the fol
 ```yaml
 production:
   branch: production
-  repository: git://github.com/openaustralia/alaveteli.git
+  repository: https://github.com/openaustralia/alaveteli.git
   server: righttoknow.org.au
   user: deploy
   deploy_to: /srv/www/production
   rails_env: production
   daemon_name: alaveteli-production
 staging:
-  branch: 0.38.3.0
-  repository: git://github.com/mysociety/alaveteli.git
+  branch: staging
+  repository: https://github.com/openaustralia/alaveteli.git
   server: righttoknow.org.au
   user: deploy
   deploy_to: /srv/www/staging
@@ -256,7 +256,7 @@ staging:
   daemon_name: alaveteli-staging
 development:
   branch: production
-  repository: git://github.com/openaustralia/alaveteli.git
+  repository: https://github.com/openaustralia/alaveteli.git
   server: righttoknow.org.au.test
   user: deploy
   deploy_to: /srv/www/production


### PR DESCRIPTION
Change repository URLs in the deployment configuration to use HTTPS and point to the forked Alaveteli repository. Update README to include a link for local deployment instructions.