### PR TITLE
Right to Know - Update Staging Ruby to 2.7.8

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for righttoknow
-ruby_version_staging: 2.6.6
+ruby_version_staging: 2.7.8
 ruby_version_production: 2.6.6


### PR DESCRIPTION
This is already running on the server. This change updates the infrastructure configuration to show that Ruby is running version 2.7.8 on the staging environment.