### PR TITLE
Add benrfairless to github_users

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -23,4 +23,4 @@ certbot_webserver: apache
 
 # Part of the default value "--quiet" appears not to be valid
 certbot_auto_renew_options: "--no-self-upgrade"
-github_users: ['mlandauer', 'henare', 'jamezpolley', 'simonzippy', 'br3nda']
+github_users: ['mlandauer', 'henare', 'jamezpolley', 'simonzippy', 'br3nda', 'benrfairless']


### PR DESCRIPTION
Updates github_users to include benrfairless.

Once merged, someone with relevant permissions will need to run `make ssh` from the infrastruture repo.
