### PR TITLE
Update ruby version to 2.7.8 in production

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for righttoknow
 ruby_version_staging: 2.7.8
-ruby_version_production: 2.6.6
+ruby_version_production: 2.7.8


### PR DESCRIPTION
Updates Ruby to version 2.7.8 on Right to Know Production.