### PR TITLE
[Feature] Enable Capistrano Maintenance Mode option on Right to Know

### DIFF
--- a/roles/internal/righttoknow/templates/nginx/stage
+++ b/roles/internal/righttoknow/templates/nginx/stage
@@ -34,6 +34,16 @@ server {
   root /srv/www/{{ stage }}/current/public;
   passenger_enabled on;
   passenger_ruby /home/deploy/.rbenv/shims/ruby;
+
+  # Serve maintenance page when present
+  if (-f $document_root/system/maintenance.html) {
+    return 503;
+  }
+  error_page 503 @maintenance;
+  location @maintenance {
+    rewrite  ^(.*)$  /system/maintenance.html break;
+    break;
+  }
 }
 
 # HTTPS


### PR DESCRIPTION
Fixes #203

Updates the nginx config file to allow for a maintenance page to be displayed.

To enable the maintenance page, run the below command from your alaveteli folder:

```ruby
cap deploy:web:disable \
        REASON="Software Upgrade" \
        UNTIL="10:30pm Sydney time"
```

To remove the maintenance page and restore the site to full operation, run the below command:
```ruby
cap deploy:web:enable
```