### PR TITLE
Update Metabase from v0.47.9 to 0.56.6

### DIFF
--- a/roles/internal/metabase/templates/docker-compose.yml
+++ b/roles/internal/metabase/templates/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase:v0.47.9
+    image: metabase/metabase:0.56.6
     # Using 8000 as the port on the host to be consistent with planningalerts
     ports:
       - 8000:3000


### PR DESCRIPTION
This pull request updates the Metabase service to use a newer version of the Metabase image in the `docker-compose.yml` file.

* Upgraded the Metabase Docker image from `v0.47.9` to `0.56.6` in `roles/internal/metabase/templates/docker-compose.yml` to ensure the service uses the latest features and security updates.

This can be deployed with Ansible without any customisation required on the server - refer to the [documentation](https://www.metabase.com/docs/v0.56/installation-and-operation/upgrading-metabase#what-happens-during-an-upgrade-or-downgrade) for confirmation.