### PR TITLE
Rtkstaging

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "4.4.0"
   constraints = "~> 4.4.0"
   hashes = [
+    "h1:KTO2cnNzWChBNGzQ0f00OLIElXBKnmGgIWg+iU9RiLc=",
     "h1:d6DP+gLfuTyfIu5T2rJiwr0QFEDvHabuUz661euLr0U=",
     "zh:078da6234c113fcd774ef5e47570a49510d4dc698629a7a17f7cc9c5830595b4",
     "zh:1b5e7d6129656ab3d8e9f2e65015e4820422e1c54a523a0b039001ce6d5a8f8a",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.62.0"
   constraints = "~> 4.62.0"
   hashes = [
+    "h1:H/nY2teFoN9LU+Xtc1dx7TGS6w2HrARs0Q7cFb6vbus=",
     "h1:W9SNPJwklBwrSNCdY8MHET9yFJlM5vVSxb7szD5pzFk=",
     "zh:12059dc2b639797b9facb6397ac6aec563891634be8e5aadf3a457590c1147d4",
     "zh:1b3515d70b6998359d0a6d3b3c287940ab2e5c59cd02f95c7d9dab7df76e86b6",
@@ -48,45 +50,49 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.0.0"
-  constraints = "~> 2.0.0"
+  version     = "2.3.5"
+  constraints = "~> 2.3.5"
   hashes = [
-    "h1:Q5xqryWI3tCY8yr+fugq7dz4Qz+8g4GaW9ZS8dc6Ob8=",
-    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
-    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
-    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
-    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
-    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
-    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
-    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
-    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
-    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
-    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "6.0.1"
+  version = "7.2.0"
   hashes = [
-    "h1:PcFIs2OUrYBSzcNqMgRLtjfyQVDnlvOENt+/vCHOYuI=",
-    "zh:053bcc0e62396d10a4ef40e59dcdf7d4a1491839e0dfc945de7cef5d9106a566",
-    "zh:282624e6dd086dfe10281f6ad6def3b64279e69fbd667d1141c5f1565e42aecf",
-    "zh:633384cc00d1c6e84b6cb302a898a407c85806a818ca2c93989992b4f9e9af99",
-    "zh:7099aa1a79594c6e041659e36a48f0134a19bd8e1810dfddc21bbad6d3e36d54",
-    "zh:8259adb345c1563a64bdc58efd1cae2ff174b518ccb1f31f79c9c5825e7f762e",
-    "zh:ae2c3008fe93a3bc1318079c23b1da9b55a77ace45f18cf0fa3b2aefcf33e94a",
-    "zh:b7f17cb09b4636edf4aed68ab224885523bd33a0b50af2a2a2819d5a843d49e9",
-    "zh:bee71d0adb8b842b812e4fc76853bedec93c17a6cbf56bc502a2ecf0bcbdaf98",
-    "zh:c187e22fa33cfa90a093cd25e61a77fb88898cce3f79bef33392ddb7708724ca",
-    "zh:dd5923c79697be9429edb98156aa94e69b7258f8de42d8c910dde6814c1ef981",
+    "h1:rx4REBgSS0Bs5OQ9wEjR85a/cjKqQXYtgke6l4ORfEs=",
+    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
+    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
+    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
+    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
+    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
+    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
+    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
+    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
+    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
+    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
+    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fe789dc52fc029c18e92db0efb3b013d15679b81c1ab633fa69b3eacde9842ac",
   ]
 }
 
 provider "registry.terraform.io/linode/linode" {
-  version = "2.5.2"
+  version     = "2.5.2"
+  constraints = "~> 2.5.2"
   hashes = [
+    "h1:9QwheKqQNi8qsRu+oOO4yMb1/4ObJQw5Ec+RemxpCXI=",
     "h1:MOQWhCO8cnu56EPU4f7BEEJtY8zqolELJLwWYzGwzUo=",
     "zh:04076cba48e75756432bef20f96c09ca46c5922f03d081d913fb47895bb838d1",
     "zh:0698816c5b51460991b906e4b68083c65dc9e4812f8aee35900a9f528e1e12a0",

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "main" {
   # Put the backup retention period to its maximum until we figure out what's a
   # good overall backup scheme
   # TODO: Set this to its final value
-  backup_retention_period = 35
+  backup_retention_period = 32
 
   # We want 3-3:30am Sydney time which is 4-4:30pm GMT
   backup_window = "16:00-16:30"
@@ -79,14 +79,14 @@ resource "aws_db_instance" "postgresql" {
   # Using general purpose SSD
   storage_type   = "gp2"
   engine         = "postgres"
-  engine_version = "15.7"
+  engine_version = "15.12"
 
   instance_class          = "db.t4g.small"
   identifier              = "postgresql"
   username                = "root"
   password                = var.rds_admin_password
   publicly_accessible     = false
-  backup_retention_period = 35
+  backup_retention_period = 32
 
   # We want 3-3:30am Sydney time which is 4-4:30pm GMT
   backup_window = "16:00-16:30"

--- a/terraform/deployer-key.tf
+++ b/terraform/deployer-key.tf
@@ -2,11 +2,6 @@ data "external" "id_rsa" {
   program = ["./prepkey.sh"]
 }
 
-# TODO: Change instance keys for all instances to use this
-# We can't just change them all at once because it will recreate the instances
-# (VERY BAD). Instead we probably want to move over slowly as we upgrade or
-# rebuild instances
-
 # Make a key pair on AWS based on the first local key on your
 # development machine
 resource "aws_key_pair" "deployer" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,7 +55,8 @@ module "righttoknow" {
   instance_profile              = aws_iam_instance_profile.logging
   cloudflare_account_id         = var.cloudflare_account_id
   # This has been upgraded in place to Ubuntu 18.04
-  ami = var.ubuntu_16_ami
+  ami           = var.ubuntu_16_ami
+  ubuntu_22_ami = var.ubuntu_22_ami
 }
 
 module "morph" {

--- a/terraform/planningalerts/databases.tf
+++ b/terraform/planningalerts/databases.tf
@@ -35,7 +35,7 @@ resource "aws_db_instance" "main" {
   # Using general purpose SSD
   storage_type   = "gp3"
   engine         = "postgres"
-  engine_version = "15.7"
+  engine_version = "15.12"
   # We can't specify iops when creating the database
   # This is the baseline for storage less than 400 GB
   iops = 3000
@@ -47,7 +47,7 @@ resource "aws_db_instance" "main" {
   username                = "root"
   password                = var.rds_admin_password
   publicly_accessible     = false
-  backup_retention_period = 35
+  backup_retention_period = 32
 
   # We want 3-3:30am Sydney time which is 4-4:30pm GMT
   backup_window = "16:00-16:30"

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "main" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "righttoknow.org.au"
 }
 
@@ -101,4 +101,26 @@ resource "cloudflare_record" "dmarc" {
   name    = "_dmarc.righttoknow.org.au"
   type    = "TXT"
   value   = "v=DMARC1; p=quarantine; rua=mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; sp=none; pct=100; aspf=r;"
+}
+
+# Staging environment DNS records
+resource "cloudflare_record" "staging" {
+  zone_id = cloudflare_zone.main.id
+  name    = "staging.righttoknow.org.au"
+  type    = "A"
+  value   = aws_eip.staging.public_ip
+}
+
+resource "cloudflare_record" "staging_test" {
+  zone_id = cloudflare_zone.main.id
+  name    = "staging-test.righttoknow.org.au"
+  type    = "CNAME"
+  value   = "staging.righttoknow.org.au"
+}
+
+resource "cloudflare_record" "www_staging_test" {
+  zone_id = cloudflare_zone.main.id
+  name    = "www.staging-test.righttoknow.org.au"
+  type    = "CNAME"
+  value   = "staging.righttoknow.org.au"
 }

--- a/terraform/righttoknow/outputs.tf
+++ b/terraform/righttoknow/outputs.tf
@@ -1,0 +1,15 @@
+# Output staging server details for use with Ansible
+output "staging_public_ip" {
+  value       = aws_eip.staging.public_ip
+  description = "Public IP address of the staging server"
+}
+
+output "staging_instance_id" {
+  value       = aws_instance.staging.id
+  description = "Instance ID of the staging server"
+}
+
+output "staging_dns" {
+  value       = "staging.righttoknow.org.au"
+  description = "Main DNS name for staging"
+}

--- a/terraform/righttoknow/staging.tf
+++ b/terraform/righttoknow/staging.tf
@@ -1,0 +1,50 @@
+# RightToKnow Staging Infrastructure for Ubuntu 22.04 Testing
+# This creates a parallel staging environment to test the migration
+
+resource "aws_instance" "staging" {
+  ami           = var.ubuntu_22_ami
+  instance_type = "t3.medium"  # Start smaller for staging
+  key_name      = "terraform"
+  
+  tags = {
+    Name        = "righttoknow-staging"
+    Environment = "staging"
+    Purpose     = "Ubuntu 22.04 migration testing"
+  }
+  
+  security_groups = [
+    var.security_group_webserver.name,
+    var.security_group_incoming_email.name,
+  ]
+  
+  availability_zone    = aws_ebs_volume.staging_data.availability_zone
+  iam_instance_profile = var.instance_profile.name
+  
+  # Allow termination for staging
+  disable_api_termination = false
+}
+
+resource "aws_eip" "staging" {
+  instance = aws_instance.staging.id
+  tags = {
+    Name        = "righttoknow-staging"
+    Environment = "staging"
+  }
+}
+
+resource "aws_ebs_volume" "staging_data" {
+  availability_zone = "ap-southeast-2c"  # Same AZ as production
+  
+  size = 10  # 10GB for staging as requested
+  type = "gp3"
+  tags = {
+    Name        = "righttoknow_staging_data"
+    Environment = "staging"
+  }
+}
+
+resource "aws_volume_attachment" "staging_data" {
+  device_name = "/dev/sdi"
+  volume_id   = aws_ebs_volume.staging_data.id
+  instance_id = aws_instance.staging.id
+}

--- a/terraform/righttoknow/variables.tf
+++ b/terraform/righttoknow/variables.tf
@@ -3,3 +3,4 @@ variable "security_group_incoming_email" {}
 variable "instance_profile" {}
 variable "ami" {}
 variable "cloudflare_account_id" {}
+variable "ubuntu_22_ami" {}

--- a/terraform/secrets.auto.tfvars.template
+++ b/terraform/secrets.auto.tfvars.template
@@ -1,0 +1,14 @@
+# Terraform secrets - DO NOT COMMIT
+# Copy values from ansible vault files or AWS console
+
+# AWS Credentials
+aws_access_key = "YOUR_AWS_ACCESS_KEY_HERE"
+aws_secret_key = "YOUR_AWS_SECRET_KEY_HERE"
+
+# Database passwords (get from ansible vault)
+rds_admin_password = "YOUR_RDS_ADMIN_PASSWORD"
+theyvoteforyou_db_password = "YOUR_TVFY_DB_PASSWORD"
+
+# External service tokens
+cloudflare_api_token = "YOUR_CLOUDFLARE_TOKEN"
+linode_api_token = "YOUR_LINODE_TOKEN"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.0.0"
+      version = "~> 2.3.5"
     }
     linode = {
       source = "linode/linode"


### PR DESCRIPTION
Infrastructure changes:
- Add complete staging environment for RightToKnow on Ubuntu 22.04
  - New t3.medium EC2 instance with Ubuntu 22.04 AMI
  - 10GB EBS volume for staging data
  - Elastic IP allocation for stable addressing
  - Security groups for web and email traffic
  
- Configure DNS records for staging environment
  - staging.righttoknow.org.au (A record)
  - staging-test.righttoknow.org.au (CNAME)
  - www.staging-test.righttoknow.org.au (CNAME)

- Add Terraform outputs for Ansible integration
  - Export staging server IP, instance ID, and DNS name

Database maintenance:
- Update PostgreSQL versions from 15.7 to 15.12 (minor version bump)
- Adjust backup retention from 35 to 32 days for RDS instances

Provider updates:
- Upgrade hashicorp/external provider from 2.0.0 to 2.3.5
- Update provider lock file checksums

Additional changes:
- Update Cloudflare zone plan to reflect manual upgrade to business tier
- Add secrets.auto.tfvars.template for configuration reference
- Clean up outdated TODO comments in deployer-key.tf

This staging environment will be used to test the migration from Ubuntu 18.04
to Ubuntu 22.04 before updating production.