### PR TITLE
Update Cloudflare zones to business plan in terraform

### DIFF
--- a/terraform/cloudflare-zones.tf
+++ b/terraform/cloudflare-zones.tf
@@ -1,7 +1,7 @@
 
 resource "cloudflare_zone" "oaf_org_au" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "oaf.org.au"
 }
 

--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "main" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "morph.io"
 }
 

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -1,12 +1,12 @@
 resource "cloudflare_zone" "org" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "openaustralia.org"
 }
 
 resource "cloudflare_zone" "org_au" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "openaustralia.org.au"
 }
 

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "main" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "planningalerts.org.au"
 }
 

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zone" "org_au" {
   account_id = var.cloudflare_account_id
-  plan       = "free"
+  plan       = "business"
   zone       = "theyvoteforyou.org.au"
 }
 


### PR DESCRIPTION
Updates the following domains to reflect their current business plan status:
- oaf.org.au
- morph.io
- openaustralia.org
- openaustralia.org.au
- planningalerts.org.au
- theyvoteforyou.org.au

Fixes #226