### PR TITLE
Add notes and a helper for running keybase headless

### DIFF
--- a/.all-vault-pass
+++ b/.all-vault-pass
@@ -1,1 +1,1 @@
-/keybase/team/oaforgau.sysadmin/.all-vault-pass
+.keybase/team/oaforgau.sysadmin/.all-vault-pass

--- a/.ec2-vault-pass
+++ b/.ec2-vault-pass
@@ -1,1 +1,1 @@
-/keybase/team/oaforgau.sysadmin/.ec2-vault-pass
+.keybase/team/oaforgau.sysadmin/.ec2-vault-pass

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .vagrant
+.keybase
 roles/external
 collections/
 test.pem

--- a/.rtk-vault-pass
+++ b/.rtk-vault-pass
@@ -1,1 +1,1 @@
-/keybase/team/oaforgau.righttoknow/.rtk-vault-pass
+.keybase/team/oaforgau.righttoknow/.rtk-vault-pass

--- a/.vault_pass.txt
+++ b/.vault_pass.txt
@@ -1,1 +1,1 @@
-/keybase/team/oaforgau.sysadmin/.vault_pass.txt
+.keybase/team/oaforgau.sysadmin/.vault_pass.txt

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 ALL: venv roles .vagrant
 
+.keybase:
+	ln -sf $(shell keybase config get -d -b mountdir) .keybase
+	
 .vagrant:
 	VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install vagrant-hostsupdater
 	touch .vagrant
@@ -9,7 +12,7 @@ ALL: venv roles .vagrant
 venv: .venv/bin/activate
 
 .venv/bin/activate: requirements.txt
-	test -d .venv || virtualenv .venv
+	test -d .venv || python3 -m virtualenv .venv
 	.venv/bin/pip install --upgrade pip virtualenv
 	.venv/bin/pip install -Ur requirements.txt
 	touch .venv/bin/activate
@@ -22,7 +25,7 @@ roles/external: venv collections roles/requirements.yml
 
 roles: roles/external
 
-production: venv roles
+production: .keybase venv roles
 	.venv/bin/ansible-playbook site.yml
 
 letsencrypt: venv roles

--- a/README.md
+++ b/README.md
@@ -211,13 +211,23 @@ Ansible Vault secrets are distributed via
 servers, you'll need to be added to the appropriate teams.
 
 You'll need to have Keybase installed on the machine where you run
-ansible. You'll need to enable "Finder integration" or the equivalent
-on your platform, under Settings -> Files.
+ansible. 
+
+If this system has a gui, you'll need to enable "Finder integration"
+or the equivalent on your platform, under Settings -> Files.
+
+If your system does *not* have a GUI - for instance, it's a WSL instance on
+windows; or a remote Ubuntu VM running headless - there's a helper script
+at `bin/headless-keybase.sh` which will help you run the Keybase services
+as user-space systemd units.
+
+The first time you run `make`, `.keybase` will be created as a symlink to the
+place where Keybase makes the files available. This is often `/keybase` on 
+linux desktops, or `/Volumes/Keybase` on MacOS. On headless systems it might
+be under `/run/user/`.
 
 Once this is done, the symlinks to .*-vault-pass inside the repo
-should point to the password files.
-
-(Note on OS X and keybase 5.3.0 the symlinks point to the wrong place. The keybase filesystem now starts at /Volumes/Keybase rather than /keybase)
+should point to the password files. If this doesn't work you may need to update these files yourself.
 
 ## <a name='GeneratingSSLcertificatesfordevelopment'></a>Generating SSL certificates for development
 See certificates/README.md for more information.

--- a/bin/headless-keybase.sh
+++ b/bin/headless-keybase.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+run_keybase -k
+keybase ctl autostart --disable
+systemctl --user set-environment KEYBASE_AUTOSTART=1
+
+for service in keybase kbfs keybase-redirector; do
+    systemctl --user enable "${service}.service"
+    systemctl --user start "${service}.service"
+done
+
+if (systemctl --user --no-pager status keybase kbfs keybase-redirector >/dev/null); then
+    echo "Keybase services seem to be running"
+else
+    echo "Keybase services don't seem to be running."
+    systemctl --user status keybase kbfs keybase-redirector
+    exit 1
+fi
+
+echo "The following should show your Keybase identity.:"
+keybase id
+echo
+echo "If your identiy is not shown, please run 'keybase unlock'"


### PR DESCRIPTION
On a few occasions, I've run into problems running keybase on a headless system. Today it happens to be related to running inside WSL; last time it was running in a VM running on a remote machine that didn't have a desktop environment installed.

The problems I see have been annoyingly hard to diagnose. Things try to read from `/keybase` and just hang. It's often not obvious what's going on - especially because quite a lot of the time the thing that hands is shell autocompletion.

As a secondary issue - we know that the default symlinks (pointing to /keybase) don't work on OS X.

This changes does a few related things:

- the Makefile is updated to create `.keybase` if it doesn't already exist. It figures out where to point `.keybase` by asking Keybase where the magic keybase root is located - `keybase config get -d -b mountdir`. I haven't been able to test this on OS X yet (maybe @simonzippy or @benrfairless could check this for me?) but I think it should work there.
- symlinks are updated so that they now point at `.keybase` rather than `/keybase`. 
  - When the first git checkout happens the symlinks will be dangling as `.keybase` won't exist; but the first run of `make` will correct this.
- Adds `bin/headless-keybase.sh` as a helper script which sets up keybase to run headless.
  - Most of this is sourced from https://book.keybase.io/docs/linux#systemd-and-running-headless-keybase or elsewhere on that page
- Updates the README to describe these changes and how they're used.

I haven't documented this in the README, but part of my thinking here is that for cases where keybase can't be run, people in the past have done various things to change the symlinks to point to some other place, or even just dumped the secrets into the files directly and tried to remember to not check them in to git. They can now `mkdir .keybase`, do whatever they like to put the secrets in the right files in there, and voila - they now have a working config, with no problems caused by git seeing the symlinks having changed, much lower risk of checking the secrets in, etc.