### PR TITLE
Add user spam scoring configuration and deployment tasks

### DIFF
--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -395,6 +395,17 @@
     pro_referral_coupon: "{{ pro_referral_coupon_staging }}"
   notify: nginx restart
 
+- name: Apply user spam scorer config
+  template:
+    src: user_spam_scorer.yml
+    dest: "/srv/www/{{ item }}/shared/user_spam_scorer.yml"
+    owner: deploy
+    group: deploy
+  with_items:
+    - production
+    - staging
+  notify: nginx restart
+
 - import_tasks: certificates.yml
 - import_tasks: cron.yml
 

--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -836,6 +836,7 @@ SHARED_FILES_PATH: ''
 SHARED_FILES:
   - config/database.yml
   - config/general.yml
+  - config/user_spam_scorer.yml
   - config/rails_env.rb
   - config/newrelic.yml
   - config/httpd.conf

--- a/roles/internal/righttoknow/templates/user_spam_scorer.yml
+++ b/roles/internal/righttoknow/templates/user_spam_scorer.yml
@@ -1,0 +1,59 @@
+# The DEFAULT_* values defined in lib/user_spam_scorer.rb will still apply
+# unless you override their key in this optional file.
+#
+# Unfortunately at this time you can't override the regular expressions defined
+# for DEFAULT_SPAM_NAME_FORMAT or DEFAULT_SPAM_ABOUT_ME_FORMAT.
+
+user_spam_scorer:
+  currency_symbols:
+    - £
+    - $
+    - €
+    - ¥
+    - ¢
+  suspicious_domains:
+    - mail.ru
+    - temp-mail.de
+    - tempmail.de
+    - shitmail.de
+    - yopmail.com
+    - yandex.com
+  spam_domains:
+    - 7x.cz
+    - allemaling.com
+    - brmailing.com
+    - businessmailsystem.com
+    - checknowmail.com
+    - colde-mail.com
+    - consimail.com
+    - continumail.com
+    - contumail.com
+    - emailber.com
+    - grow-mail.com
+    - inemaling.com
+    - inmailing.com
+    - itemailing.com
+    - itmailing.com
+    - kod-emailing.com
+    - kod-maling.com
+    - kodemailing.com
+    - kodmailing.com
+    - left-mail.com
+    - mabermail.com
+    - mailphar.com
+    - out-email.com
+    - semi-mile.com
+    - sin-mailing.com
+    - sinemailing.com
+    - sinmailing.com
+    - takmailing.com
+    - themailemail.com
+    - visitinbox.com
+    - webgarden.com
+    - webgarden.cz
+    - wgz.cz
+    - wowmailing.com
+  suspicious_user_agents:
+    - curl
+  suspicious_ip_ranges:
+    - 127.0.0.0/8

--- a/roles/internal/righttoknow/templates/user_spam_scorer.yml
+++ b/roles/internal/righttoknow/templates/user_spam_scorer.yml
@@ -18,9 +18,6 @@ user_spam_scorer:
     - shitmail.de
     - yopmail.com
     - yandex.com
-    - sharklasers.com
-    - guerrillamail.com
-    - mailinator.com
   spam_domains:
     - 7x.cz
     - allemaling.com
@@ -56,7 +53,9 @@ user_spam_scorer:
     - webgarden.cz
     - wgz.cz
     - wowmailing.com
-    
+    - sharklasers.com
+    - guerrillamail.com
+    - mailinator.comx
   suspicious_user_agents:
     - curl
   suspicious_ip_ranges:

--- a/roles/internal/righttoknow/templates/user_spam_scorer.yml
+++ b/roles/internal/righttoknow/templates/user_spam_scorer.yml
@@ -30,6 +30,7 @@ user_spam_scorer:
     - contumail.com
     - emailber.com
     - grow-mail.com
+    - guerrillamail.com
     - inemaling.com
     - inmailing.com
     - itemailing.com
@@ -40,9 +41,11 @@ user_spam_scorer:
     - kodmailing.com
     - left-mail.com
     - mabermail.com
+    - mailinator.com
     - mailphar.com
     - out-email.com
     - semi-mile.com
+    - sharklasers.com
     - sin-mailing.com
     - sinemailing.com
     - sinmailing.com
@@ -53,9 +56,6 @@ user_spam_scorer:
     - webgarden.cz
     - wgz.cz
     - wowmailing.com
-    - sharklasers.com
-    - guerrillamail.com
-    - mailinator.comx
   suspicious_user_agents:
     - curl
   suspicious_ip_ranges:

--- a/roles/internal/righttoknow/templates/user_spam_scorer.yml
+++ b/roles/internal/righttoknow/templates/user_spam_scorer.yml
@@ -18,6 +18,9 @@ user_spam_scorer:
     - shitmail.de
     - yopmail.com
     - yandex.com
+    - sharklasers.com
+    - guerrillamail.com
+    - mailinator.com
   spam_domains:
     - 7x.cz
     - allemaling.com
@@ -53,6 +56,7 @@ user_spam_scorer:
     - webgarden.cz
     - wgz.cz
     - wowmailing.com
+    
   suspicious_user_agents:
     - curl
   suspicious_ip_ranges:


### PR DESCRIPTION
This change:
- Creates user_spam_scorer.yml from the Alaveteli template
- Adds some disposable domains to spam
- Updates the general.yml template to reference the new user_spam_scorer.yml file
- Updates the Ansible task to deploy the new user_spam_scorer.yml template

This change is urgently required to address a large number of user accounts that are using disposable email addresses to make single requests to an authority.