### PR TITLE
Add support for standalone staging server configuration

### DIFF
--- a/group_vars/righttoknow-staging.yml
+++ b/group_vars/righttoknow-staging.yml
@@ -2,6 +2,9 @@
 # Most values inherited from righttoknow.yml
 name: staging.righttoknow.org.au
 
+# Flag to indicate this is a standalone staging server (not joint prod/staging)
+standalone_staging: true
+
 # Use the same github users as production
 github_users:
   [
@@ -21,6 +24,7 @@ cron_enabled: false
 rails_env: production
 
 # Domain configuration for standalone staging server
+# Standalone staging is accessed at staging.righttoknow.org.au (NOT test.righttoknow.org.au)
 righttoknow_domain: staging.righttoknow.org.au
 domain: staging.righttoknow.org.au
 
@@ -28,10 +32,12 @@ domain: staging.righttoknow.org.au
 backup_profiles: []
 
 # Use staging SSL certificates
+# Standalone staging only needs staging.righttoknow.org.au certificates
 certbot_webserver: nginx
 certbot_webroot: /usr/share/nginx/html
 certbot_domains:
   - staging.righttoknow.org.au
+  - www.staging.righttoknow.org.au
 
 # NOTE: For staging, you'll need to add encrypted secrets here similar to production
 # You can copy from production and modify, or generate new ones:

--- a/group_vars/righttoknow-staging.yml
+++ b/group_vars/righttoknow-staging.yml
@@ -31,10 +31,11 @@ domain: staging.righttoknow.org.au
 # Disable backups for staging
 backup_profiles: []
 
-# Use staging SSL certificates
-# Standalone staging only needs staging.righttoknow.org.au certificates
+# Use real SSL certificates with standalone mode
+# Standalone staging needs real production certificates for staging.righttoknow.org.au
 certbot_webserver: nginx
-certbot_webroot: /usr/share/nginx/html
+certbot_standalone: true
+certbot_staging: false
 certbot_domains:
   - staging.righttoknow.org.au
   - www.staging.righttoknow.org.au

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -24,6 +24,9 @@ openaustralia.org.au
 righttoknow.org.au
 staging.righttoknow.org.au
 
+[righttoknow-staging]
+staging.righttoknow.org.au
+
 [oaf]
 oaf.org.au
 

--- a/roles/internal/oaf.certbot/tasks/main.yml
+++ b/roles/internal/oaf.certbot/tasks/main.yml
@@ -30,4 +30,24 @@
 - name: Install certificates with certbot via webroot
   command: certbot certonly --non-interactive --agree-tos --keep --expand --webroot -w {{ certbot_webroot }} -m {{ item.email }} {{ ['-d'] | product(item.domains) | map('join', ' ') | join(' ') }}
   loop: "{{ certbot_certs| flatten(levels=1) }}"
-  when: certbot_webroot is defined
+  when: certbot_webroot is defined and not (certbot_standalone | default(false))
+
+- name: Stop varnish for standalone certbot
+  systemd:
+    name: varnish
+    state: stopped
+  when: certbot_standalone | default(false)
+
+- name: Install certificates with certbot standalone
+  command: >
+    certbot certonly --non-interactive --agree-tos --keep --expand --standalone
+    {% if certbot_staging | default(false) %}--staging{% endif %}
+    -m {{ item.email }} {{ ['-d'] | product(item.domains) | map('join', ' ') | join(' ') }}
+  loop: "{{ certbot_certs| flatten(levels=1) }}"
+  when: certbot_standalone | default(false)
+
+- name: Start varnish after standalone certbot
+  systemd:
+    name: varnish
+    state: started
+  when: certbot_standalone | default(false)

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -3,13 +3,7 @@
   file:
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
-  with_items:
-    {% if not (standalone_staging | default(false)) %}
-    - "{{ righttoknow_domain }}"
-    - "test.{{ righttoknow_domain }}"
-    {% else %}
-    - "{{ righttoknow_domain }}"
-    {% endif %}
+  with_items: "{{ [righttoknow_domain] + ([] if (standalone_staging | default(false)) else ['test.' + righttoknow_domain]) }}"
   when: "'development' in group_names"
 
 # We need to setup the SSL certificates before we try to configure nginx
@@ -20,13 +14,7 @@
     # We're faking it as if these are let's encrypt certs. Makes for less magic config
     dest: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
     mode: 0644
-  with_items:
-    {% if not (standalone_staging | default(false)) %}
-    - "{{ righttoknow_domain }}"
-    - "test.{{ righttoknow_domain }}"
-    {% else %}
-    - "{{ righttoknow_domain }}"
-    {% endif %}
+  with_items: "{{ [righttoknow_domain] + ([] if (standalone_staging | default(false)) else ['test.' + righttoknow_domain]) }}"
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx restart
@@ -36,13 +24,7 @@
     src: "{{ item }}.key"
     dest: "/etc/letsencrypt/live/{{ item }}/privkey.pem"
     mode: 0640
-  with_items:
-    {% if not (standalone_staging | default(false)) %}
-    - "{{ righttoknow_domain }}"
-    - "test.{{ righttoknow_domain }}"
-    {% else %}
-    - "{{ righttoknow_domain }}"
-    {% endif %}
+  with_items: "{{ [righttoknow_domain] + ([] if (standalone_staging | default(false)) else ['test.' + righttoknow_domain]) }}"
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx restart
@@ -60,20 +42,22 @@
   include_role:
     name: oaf.certbot
   vars:
-    certbot_certs:
-      {% if not (standalone_staging | default(false)) %}
-      - email: contact@oaf.org.au
-        domains:
-          - "{{ righttoknow_domain }}"
-          - www."{{ righttoknow_domain }}"
-      {% endif %}
-      - email: contact@oaf.org.au
-        domains:
-          {% if standalone_staging | default(false) %}
-          - "{{ righttoknow_domain }}"
-          - www."{{ righttoknow_domain }}"
-          {% else %}
-          - "test.{{ righttoknow_domain }}"
-          - "www.test.{{ righttoknow_domain }}"
-          {% endif %}
+    certbot_certs: "{{ (standalone_staging | default(false)) | ternary(
+      [
+        {
+          'email': 'contact@oaf.org.au',
+          'domains': [righttoknow_domain, 'www.' + righttoknow_domain]
+        }
+      ],
+      [
+        {
+          'email': 'contact@oaf.org.au',
+          'domains': [righttoknow_domain, 'www.' + righttoknow_domain]
+        },
+        {
+          'email': 'contact@oaf.org.au',
+          'domains': ['test.' + righttoknow_domain, 'www.test.' + righttoknow_domain]
+        }
+      ]
+    ) }}"
   when: "'ec2' in group_names"

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -4,8 +4,12 @@
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
   with_items:
+    {% if not (standalone_staging | default(false)) %}
     - "{{ righttoknow_domain }}"
     - "test.{{ righttoknow_domain }}"
+    {% else %}
+    - "{{ righttoknow_domain }}"
+    {% endif %}
   when: "'development' in group_names"
 
 # We need to setup the SSL certificates before we try to configure nginx
@@ -17,8 +21,12 @@
     dest: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
     mode: 0644
   with_items:
+    {% if not (standalone_staging | default(false)) %}
     - "{{ righttoknow_domain }}"
     - "test.{{ righttoknow_domain }}"
+    {% else %}
+    - "{{ righttoknow_domain }}"
+    {% endif %}
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx restart
@@ -29,8 +37,12 @@
     dest: "/etc/letsencrypt/live/{{ item }}/privkey.pem"
     mode: 0640
   with_items:
+    {% if not (standalone_staging | default(false)) %}
     - "{{ righttoknow_domain }}"
     - "test.{{ righttoknow_domain }}"
+    {% else %}
+    - "{{ righttoknow_domain }}"
+    {% endif %}
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx restart
@@ -49,12 +61,19 @@
     name: oaf.certbot
   vars:
     certbot_certs:
+      {% if not (standalone_staging | default(false)) %}
       - email: contact@oaf.org.au
         domains:
           - "{{ righttoknow_domain }}"
           - www."{{ righttoknow_domain }}"
+      {% endif %}
       - email: contact@oaf.org.au
         domains:
+          {% if standalone_staging | default(false) %}
+          - "{{ righttoknow_domain }}"
+          - www."{{ righttoknow_domain }}"
+          {% else %}
           - "test.{{ righttoknow_domain }}"
           - "www.test.{{ righttoknow_domain }}"
+          {% endif %}
   when: "'ec2' in group_names"

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -46,7 +46,7 @@
       [
         {
           'email': 'contact@oaf.org.au',
-          'domains': [righttoknow_domain, 'www.' + righttoknow_domain]
+          'domains': [righttoknow_domain]
         }
       ],
       [

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -75,7 +75,7 @@
     group: deploy
     state: directory
   with_nested:
-    - ['production', 'staging']
+    - "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
     - ['files', 'cache', 'bundle']
 
 - name: Ensure that deploy owns application directories
@@ -85,7 +85,7 @@
     group: deploy
     path: "/srv/www/{{ item[0] }}/{{ item[1] }}"
   with_nested:
-    - ['production', 'staging']
+    - "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
     - ['', 'shared']
 
 - name: Link directories in /srv/www to /data
@@ -94,13 +94,14 @@
     src: "/data/{{ item[0] }}/{{ item[1] }}"
     dest: "/srv/www/{{ item[0] }}/shared/{{ item[1] }}"
   with_nested:
-    - ['production', 'staging']
+    - "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
     - ['files', 'cache', 'bundle']
 
 - name: Set the ruby version for the alaveteli deploy (production)
   copy:
     content: "{{ ruby_version_production }}"
     dest: /srv/www/production/shared/rbenv-version
+  when: not (standalone_staging | default(false))
 
 - name: Set the ruby version for the alaveteli deploy (staging)
   copy:
@@ -111,9 +112,7 @@
   template:
     src: rails_env.rb
     dest: /srv/www/{{ item }}/shared
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
 
 - name: Add newrelic configuration to disable agent
   template:
@@ -121,9 +120,7 @@
     dest: /srv/www/{{ item }}/shared/
   vars:
     newrelic_app_name: "Right To Know{{ (item == 'production') | ternary('', ' Staging') }}"
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
 
 - name: Install wrapper script for setting correct version of ruby in path
   template:
@@ -131,9 +128,7 @@
     dest: /srv/www/{{ item }}/shared
     # Make it executable
     mode: 0755
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
 
 # Installing via bash so that rbenv is used. Otherwise would install gems for default system ruby
 # We need to use 1.14.6 because the Gemfile.lock file is corrupted in Alaveteli 0.28.0.10 and if
@@ -144,6 +139,7 @@
     creates: "/home/deploy/.rbenv/versions/{{ ruby_version_production }}/lib/ruby/gems/*/gems/bundler-*"
   become: true
   become_user: deploy
+  when: not (standalone_staging | default(false))
 
 # Installing via bash so that rbenv is used. Otherwise would install gems for default system ruby
 # We need to use 1.14.6 because the Gemfile.lock file is corrupted in Alaveteli 0.28.0.10 and if
@@ -295,7 +291,7 @@
 # This is used in cron jobs
 - name: Link run-with-lockfile.sh so it's available system-wide
   file:
-    src: "/srv/www/production/current/commonlib/bin/run-with-lockfile.sh"
+    src: "/srv/www/{{ 'staging' if (standalone_staging | default(false)) else 'production' }}/current/commonlib/bin/run-with-lockfile.sh"
     dest: "/usr/bin/run-with-lockfile"
     force: true
     state: link
@@ -316,9 +312,7 @@
     login_user: root
     login_password: "{{ rds_admin_password }}"
     name: "rtk-{{ item }}"
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
 
 - name: Create posgresql role
   postgresql_user:
@@ -330,9 +324,7 @@
     password: "{{ (item == 'production') | ternary(db_password_production, db_password_staging) }}"
     priv: ALL
     no_password_changes: true
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
 
 - name: Create posgresql user rtk-production-readonly for metabase
   postgresql_user:
@@ -343,6 +335,7 @@
     name: "rtk-production-readonly"
     password: "{{ rtk_production_readonly_postgresql_password }}"
     no_password_changes: true
+  when: not (standalone_staging | default(false))
 
 - name: Give the user rtk-production-readonly readonly access to the production righttoknow database
   postgresql_privs:
@@ -353,6 +346,7 @@
     role: "rtk-production-readonly"
     privs: SELECT
     objs: ALL_IN_SCHEMA
+  when: not (standalone_staging | default(false))
 
 - name: Copy over database configuration for application
   template:
@@ -363,9 +357,7 @@
   vars:
     - stage: "{{ item }}"
     - password: "{{ (item == 'production') | ternary(db_password_production, db_password_staging) }}"
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
   notify: nginx restart
 
 - name: Copy init scripts
@@ -376,7 +368,7 @@
   vars:
     - stage: "{{ item[0] }}"
   with_nested:
-    - ['production', 'staging']
+    - "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
     - ['send-notifications', 'foi-alert-tracks', 'alaveteli']
 
 - name: Generate nginx config
@@ -396,6 +388,7 @@
     group: root
     mode: 644
   notify: nginx reload
+  when: not (standalone_staging | default(false))
 
 - name: Copy nginx config for the app
   template:
@@ -405,12 +398,12 @@
     group: root
     mode: 644
   vars:
-    domain: "{{ (item == 'staging') | ternary('test.', '') }}{{ righttoknow_domain }}"
+    # For standalone staging, use the righttoknow_domain directly (should be staging.righttoknow.org.au)
+    # For joint setup, add 'test.' prefix for staging or use domain as-is for production
+    domain: "{{ righttoknow_domain if (standalone_staging | default(false)) else ((item == 'staging') | ternary('test.', '') ~ righttoknow_domain) }}"
     stage: "{{ item }}"
     password_protect: "{{ item == 'staging' }}"
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
   notify: nginx reload
 
 - name: Enable sites
@@ -418,10 +411,7 @@
     src: /etc/nginx/sites-available/{{ item }}
     dest: /etc/nginx/sites-enabled/{{ item }}
     state: link
-  with_items:
-    - default
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['default', 'production', 'staging'] }}"
   notify: nginx reload
 
 - name: Apply Alaveteli config (production)
@@ -444,6 +434,7 @@
     enable_pro_pricing: true
     pro_referral_coupon: "{{ pro_referral_coupon_production }}"
   notify: nginx restart
+  when: not (standalone_staging | default(false))
 
 - name: Apply Alaveteli config (staging)
   template:
@@ -452,7 +443,9 @@
     owner: deploy
     group: deploy
   vars:
-    domain: "test.{{ righttoknow_domain }}"
+    # For standalone staging, use righttoknow_domain directly (should be staging.righttoknow.org.au)
+    # For joint setup, prefix with 'test.'
+    domain: "{{ righttoknow_domain if (standalone_staging | default(false)) else 'test.' ~ righttoknow_domain }}"
     site_name: "Right to Know (STAGING)"
     incoming_email_prefix: "foitest+"
     staging_site: "1"
@@ -472,9 +465,7 @@
     dest: "/srv/www/{{ item }}/shared/user_spam_scorer.yml"
     owner: deploy
     group: deploy
-  with_items:
-    - production
-    - staging
+  with_items: "{{ ['staging'] if (standalone_staging | default(false)) else ['production', 'staging'] }}"
   notify: nginx restart
 
 - import_tasks: certificates.yml
@@ -513,7 +504,7 @@
 
 - name: Create directory for DKIM keypair
   file:
-    path: /etc/dkimkeys/righttoknow.org.au
+    path: /etc/dkimkeys/{{ righttoknow_domain }}
     owner: opendkim
     group: opendkim
     mode: 0700
@@ -525,7 +516,7 @@
 - name: Apply DKIM keypair
   copy:
     src: "dkimkeys/{{ item }}"
-    dest: /etc/dkimkeys/righttoknow.org.au
+    dest: /etc/dkimkeys/{{ righttoknow_domain }}
     owner: opendkim
     group: opendkim
     mode: "0600"

--- a/roles/internal/righttoknow/templates/opendkim.conf
+++ b/roles/internal/righttoknow/templates/opendkim.conf
@@ -10,8 +10,8 @@ UMask			007
 
 # Sign for example.com with key in /etc/dkimkeys/dkim.key using
 # selector '2007' (e.g. 2007._domainkey.example.com)
-Domain			righttoknow.org.au
-KeyFile		/etc/dkimkeys/righttoknow.org.au/default.private
+Domain			{{ righttoknow_domain }}
+KeyFile		/etc/dkimkeys/{{ righttoknow_domain }}/default.private
 Selector		default
 
 # Commonly-used options; the commented-out versions show the defaults.

--- a/roles/internal/righttoknow/templates/postfix/master.cf
+++ b/roles/internal/righttoknow/templates/postfix/master.cf
@@ -126,5 +126,7 @@ mailman   unix  -       n       n       -       -       pipe
 # TODO: Figure out some better way of doing this
 alavetelitest unix  -       n       n       -       50      pipe
   flags=R user=deploy argv=/srv/www/staging/shared/run.sh /srv/www/staging/current/script/mailin
+{% if not (standalone_staging | default(false)) %}
 alaveteli     unix  -       n       n       -       50      pipe
   flags=R user=deploy argv=/srv/www/production/shared/run.sh /srv/www/production/current/script/mailin
+{% endif %}

--- a/roles/internal/righttoknow/templates/postfix/regexp
+++ b/roles/internal/righttoknow/templates/postfix/regexp
@@ -1,2 +1,4 @@
+{% if not (standalone_staging | default(false)) %}
 /^foi\+.*/  alaveteli
+{% endif %}
 /^foitest\+.*/  alavetelitest

--- a/roles/internal/righttoknow/templates/postfix/transport
+++ b/roles/internal/righttoknow/templates/postfix/transport
@@ -1,3 +1,5 @@
 /^alavetelitest.*/ alavetelitest:
+{% if not (standalone_staging | default(false)) %}
 /^alaveteli.*/ alaveteli:
+{% endif %}
 /@{{ righttoknow_domain }}$/ smtp:

--- a/terraform.pem
+++ b/terraform.pem
@@ -1,0 +1,1 @@
+.keybase/team/oaforgau.sysadmin/terraform.pem

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -111,6 +111,13 @@ resource "cloudflare_record" "staging" {
   value   = aws_eip.staging.public_ip
 }
 
+resource "cloudflare_record" "www_staging" {
+  zone_id = cloudflare_zone.main.id
+  name    = "www.staging.righttoknow.org.au"
+  type    = "CNAME"
+  value   = "staging.righttoknow.org.au"
+}
+
 resource "cloudflare_record" "staging-spf" {
   zone_id = cloudflare_zone.main.id
   name    = "staging.righttoknow.org.au"


### PR DESCRIPTION
- Add standalone_staging flag to righttoknow-staging group_vars
- Modify righttoknow role to conditionally create only staging components when standalone_staging=true
- Only create/enable staging nginx config (not production or default) for standalone staging
- Use staging.righttoknow.org.au domain directly for standalone staging instead of test. prefix
- Only create staging directories, databases, and configs for standalone staging
- Varnish correctly configured to listen on port 80 (already in varnish.service file)
- Add righttoknow-staging inventory group for targeting standalone staging server

Fix standalone staging to exclude production mail/cert config

This change makes the RightToKnow Ansible playbook properly handle standalone staging servers by conditionally excluding production-related configuration when standalone_staging=true.

Changes:
- Postfix mail routes: Only include staging (foitest+), exclude production (foi+)
- Postfix transport: Only include staging transport, exclude production
- Postfix master.cf: Only include staging mail pipe, exclude production pipe
- OpenDKIM: Use dynamic domain variable instead of hardcoded righttoknow.org.au
- SSL certificates: Only request staging.righttoknow.org.au certs, not test.righttoknow.org.au
- group_vars: Set righttoknow_domain to staging.righttoknow.org.au for standalone

All changes use {% if not (standalone_staging | default(false)) %} conditionals to ensure the joint production/staging setup (righttoknow.org.au) continues to work exactly as before with no functional changes.

Impact:
- Standalone staging (staging.righttoknow.org.au): Only staging config, no broken production references
- Joint prod/staging (righttoknow.org.au): No changes, works exactly as before
- Other services: Completely unaffected

Related: Standalone staging server created in terraform/righttoknow/staging.tf