### PR TITLE
[RTK] Update staging Ruby version to 3.2.5

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for righttoknow
-ruby_version_staging: 2.7.8
+ruby_version_staging: 3.2.5
 ruby_version_production: 2.7.8


### PR DESCRIPTION
Change the staging Ruby version from 2.7.8 to 3.2.5 in the defaults configuration.