### PR TITLE
Update Makefile with enhanced commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv roles production ALL letsencrypt check-rtk
+.PHONY: venv roles production ALL letsencrypt
 
 ALL: venv roles .vagrant
 
@@ -44,13 +44,31 @@ clean:
 clean-all: clean
 	rm -rf .vagrant
 
-check-righttoknow:
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow --check
+# Configure Keybase for MacOS
+macos-keybase:
+	ln -sf /Volumes/Keybase .keybase
+
+# Terraform
+tf-init:
+	terraform -chdir=terraform init
+tf-plan:
+	terraform -chdir=terraform plan
+tf-apply:
+	terraform -chdir=terraform apply
+
+# Checks only
+check-rtk-prod:
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow --check --diff
+check-rtk-staging:
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow-staging --check --diff
 check-planningalerts:
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l planningalerts --check
 
-apply-righttoknow:
+# These make changes 
+apply-rtk-prod:
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow
+apply-rtk-staging:
+	.venv/bin/ansible-playbook -i site.yml -l righttoknow-staging
 apply-planningalerts:
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l planningalerts
 

--- a/README.md
+++ b/README.md
@@ -221,10 +221,12 @@ windows; or a remote Ubuntu VM running headless - there's a helper script
 at `bin/headless-keybase.sh` which will help you run the Keybase services
 as user-space systemd units.
 
-The first time you run `make`, `.keybase` will be created as a symlink to the
-place where Keybase makes the files available. This is often `/keybase` on 
-linux desktops, or `/Volumes/Keybase` on MacOS. On headless systems it might
-be under `/run/user/`.
+The first time you run `make`, it will try to create `.keybase` as a symlink to 
+the place where Keybase makes the files available. This is often `/keybase` on 
+linux desktops. On headless systems it might be under `/run/user/`.
+
+For Mac users, you may need to run `make macos-keybase`, which forces the `.keybase` 
+folder to symlink to `/Volumes/Keybase`.
 
 Once this is done, the symlinks to .*-vault-pass inside the repo
 should point to the password files. If this doesn't work you may need to update these files yourself.


### PR DESCRIPTION
This pull request updates the `Makefile` and `README.md` to improve infrastructure management and clarify Keybase setup instructions, especially for Mac users. The changes introduce new Makefile targets for Terraform workflows, split Ansible commands for production and staging environments, and provide clearer documentation for Keybase symlink creation on different platforms.

**Makefile improvements:**

* Added new targets for Terraform (`tf-init`, `tf-plan`, `tf-apply`) to streamline infrastructure provisioning workflows.
* Split Ansible playbook commands into separate targets for production and staging environments for both checking (`check-rtk-prod`, `check-rtk-staging`) and applying changes (`apply-rtk-prod`, `apply-rtk-staging`), improving clarity and safety.
* Added a `macos-keybase` target to explicitly create the `.keybase` symlink for MacOS users.

**Documentation updates:**

* Updated `README.md` to clarify Keybase symlink setup, including instructions for Mac users to run `make macos-keybase` if needed.