### PR TITLE
Tidy Makefile - dependencies, phony targets, clean .keybase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ retry: venv roles site.retry
 	.venv/bin/ansible-playbook site.yml -l @site.retry
 
 clean:
-	rm -rf .venv roles/external site.retry collections 
+	rm -rf .venv roles/external site.retry collections .keybase
 	
 clean-all: clean
 	rm -rf .vagrant

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ALL venv roles production letsencrypt ssh retry clean clean-all macos-keybase tf-init tf-plan tf-apply check-rtk-prod check-rtk-staging check-planningalerts apply-rtk-prod apply-rtk-staging apply-planningalerts update-github-ssh-keys
+.PHONY: ALL venv roles production letsencrypt retry clean clean-all macos-keybase tf-init tf-plan tf-apply check-rtk-prod check-rtk-staging check-planningalerts apply-rtk-prod apply-rtk-staging apply-planningalerts update-github-ssh-keys
 ALL: roles .vagrant
 PRODUCTION := .keybase roles
 
@@ -30,10 +30,6 @@ production: $(PRODUCTION)
 
 letsencrypt: $(PRODUCTION)
 	.venv/bin/ansible-playbook update-ssl-certs.yml
-
-#Just updates the SSH keys for the deploy user on all hosts.
-ssh: $(PRODUCTION)
-	.venv/bin/ansible-playbook deploy_user.yml
 
 retry: $(PRODUCTION) site.retry
 	.venv/bin/ansible-playbook site.yml -l @site.retry

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv roles production ALL letsencrypt
+.PHONY: ALL venv roles production letsencrypt ssh retry clean clean-all macos-keybase tf-init tf-plan tf-apply check-rtk-prod check-rtk-staging check-planningalerts apply-rtk-prod apply-rtk-staging apply-planningalerts update-github-ssh-keys
 
 ALL: venv roles .vagrant
 

--- a/deploy_user.yml
+++ b/deploy_user.yml
@@ -1,6 +1,0 @@
-- hosts: all
-  become: true
-  tasks:
-    - name: Configure deploy user
-      include_role:
-        name: deploy-user


### PR DESCRIPTION
Several tidyups to the Makefile. I've grouped these together because they're all fairly straightforward

- Added all phony targets to .PHONY
- Tidied dependencies
    - lots of places referenced both venv and roles. Roles already depends on venv, so this isn't needed.
    - Lots of places now need to reference both .keybase and roles.
        - I considered making roles depend on .keybase. But there can be times when make roles is run and .keybase is not going to be needed - eg, if the user is just making roles to push into vagrant. So instead I'm setting $PRODUCTION and using that throughout the file.
- Remove the `ssh` target as it's been superseded. Also remove the deploy_user.yml file that's no longer needed.

Fixes identified in #243 