### PR TITLE
Use autovariables to reduce redundancy in rule definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,28 +45,16 @@ macos-keybase:
 	ln -sf /Volumes/Keybase .keybase
 
 # Terraform
-tf-init:
-	terraform -chdir=terraform init
-tf-plan:
-	terraform -chdir=terraform plan
-tf-apply:
-	terraform -chdir=terraform apply
+tf-init tf-plan tf-apply:
+	terraform -chdir=terraform $(patsubst tf-%,%,$@)
+
 
 # Checks only
-check-rtk-prod: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow --check --diff
-check-rtk-staging: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow-staging --check --diff
-check-planningalerts: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l planningalerts --check
+check-rtk check-righttoknow check-rtk-staging check-righttoknow-staging check-planningalerts: $(PRODUCTION)
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l $(patsubst check-%,%,$(subst rtk,righttoknow,$@)) --check --diff
 
-# These make changes 
-apply-rtk-prod: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l righttoknow
-apply-rtk-staging: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i site.yml -l righttoknow-staging
-apply-planningalerts: $(PRODUCTION)
-	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l planningalerts
+apply-rtk-prod apply-righttoknow apply-rtk-staging apply-righttoknow-staging apply-planningalerts: $(PRODUCTION)
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l $(patsubst check-%,%,$(subst rtk,righttoknow,$@))
 
 update-github-ssh-keys: $(PRODUCTION)
 	.venv/bin/ansible-playbook site.yml --tags userkeys


### PR DESCRIPTION
depends-on: #245 

The intention here is to reduce redundancy in rule definitions, so that it's easier to ensure that any change that applies to all the related targets does apply to all of them.

The way it achieves this is via the $@ [auto-variable](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html) so that we can have one rule with multiple targets, and run the command only on the target that was invoked.
 - Because the targets have prefixes (check-, apply-, tf-), [patsubst](https://www.gnu.org/software/make/manual/html_node/Text-Functions.html#index-patsubst-1) is used to trim the prefix. This is most clearly seen in the tf- rules - `$(patsubst tf-%,%,$@)`
- Additionally, I didn't want to break the use of "rtk" as shorthand for "righttoknow", so I've added a [subst](https://www.gnu.org/software/make/manual/html_node/Text-Functions.html#index-subst-1) call to handle that expansion.

 However, I'm not sure if the outcome is good. On the plus side - it does remove redundancy. On the minus side - it loses readability, and I'm not sure that the reduction in redundancy justifies the loss of readability.

Feedback requested!