### PR TITLE
Update Metabase image tag to use version range v0.56.x

### DIFF
--- a/roles/internal/metabase/templates/docker-compose.yml
+++ b/roles/internal/metabase/templates/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase:0.56.6
+    image: metabase/metabase:v0.56.x
     # Using 8000 as the port on the host to be consistent with planningalerts
     ports:
       - 8000:3000


### PR DESCRIPTION
Change the Metabase image tag to a version range for better flexibility in updates.