### PR TITLE
Add terraform lock

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -54,6 +54,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = "~> 2.3.5"
   hashes = [
     "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -72,6 +73,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/google" {
   version = "7.2.0"
   hashes = [
+    "h1:CxA714vkxOLC7EEKF3rQNfHteGIAIVNqygDDRn8iyY8=",
     "h1:rx4REBgSS0Bs5OQ9wEjR85a/cjKqQXYtgke6l4ORfEs=",
     "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
     "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",


### PR DESCRIPTION
As discussed in #245, this file is a[ dependency version locking mechanism introduced in terraform 0.14](https://developer.hashicorp.com/terraform/language/files/dependency-lock)

> Terraform automatically creates or updates the dependency lock file each time you run [the terraform init command](https://developer.hashicorp.com/terraform/cli/commands/init). You should include this file in your version control repository so that you can discuss potential changes to your external dependencies via code review, just as you would discuss potential changes to your configuration itself.

As per the suggestion from the documentation, I'm adding the file created just now when I ran `terraform init`. 