### PR TITLE
Create new Right to Know production environment in Terraform

### DIFF
--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -27,6 +27,9 @@ staging.righttoknow.org.au
 [righttoknow-staging]
 staging.righttoknow.org.au
 
+[righttoknow-production]
+prod.righttoknow.org.au
+
 [oaf]
 oaf.org.au
 

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -4,6 +4,9 @@ resource "cloudflare_zone" "main" {
   zone       = "righttoknow.org.au"
 }
 
+# TODO: Update any values from "aws_eip.main" to "aws_eip.production" when we
+# are ready to move to the production environment
+
 # A records
 resource "cloudflare_record" "root" {
   zone_id = cloudflare_zone.main.id
@@ -11,6 +14,15 @@ resource "cloudflare_record" "root" {
   type    = "A"
   value   = aws_eip.main.public_ip
 }
+
+resource "cloudflare_record" "production" {
+  zone_id = cloudflare_zone.main.id
+  name    = "prod.righttoknow.org.au"
+  type    = "A"
+  value   = aws_eip.production.public_ip
+  
+}
+
 
 # CNAME records
 resource "cloudflare_record" "www" {

--- a/terraform/righttoknow/outputs.tf
+++ b/terraform/righttoknow/outputs.tf
@@ -13,3 +13,19 @@ output "staging_dns" {
   value       = "staging.righttoknow.org.au"
   description = "Main DNS name for staging"
 }
+
+# Output production server details for use with Ansible
+output "production_public_ip" {
+  value       = aws_eip.production.public_ip
+  description = "Public IP address of the production server"
+}
+
+output "production_instance_id" {
+  value       = aws_instance.production.id
+  description = "Instance ID of the production server"
+}
+
+output "production_dns" {
+  value       = "righttoknow.org.au"
+  description = "Main DNS name for production"
+}

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -17,8 +17,8 @@ resource "aws_instance" "production" {
     var.security_group_webserver.name,
     var.security_group_incoming_email.name,
   ]
-  
-  availability_zone       = aws_ebs_volume.data.availability_zone
+
+  availability_zone       = aws_ebs_volume.production_data.availability_zone
   iam_instance_profile    = var.instance_profile.name
 
 # Disable termination to protect production

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 4.4.0"
-    }
-  }
-}
-
 # New Right to Know Production Server on Ubuntu 22.04
 # This creates a parallel production environment for Right to Know 
 

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.4.0"
+    }
+  }
+}
+
+# New Right to Know Production Server on Ubuntu 22.04
+# This creates a parallel production environment for Right to Know 
+
+resource "aws_instance" "production" {
+  ami = var.ubuntu_22_ami
+  instance_type = "t3.large"
+  ebs_optimized = true
+  key_name      = "terraform"
+
+  tags = {
+    Name = "righttoknow-production"
+    Environment = "production"
+    Purpose = "Ubuntu 22.04 Production Server"
+  }
+  
+  security_groups = [
+    var.security_group_webserver.name,
+    var.security_group_incoming_email.name,
+  ]
+  
+  availability_zone       = aws_ebs_volume.data.availability_zone
+  iam_instance_profile    = var.instance_profile.name
+
+# Disable termination to protect production
+  disable_api_termination = true
+}
+
+resource "aws_eip" "production" {
+  instance = aws_instance.production.id
+  tags = {
+    Name = "righttoknow-production"
+    Environment = "production"
+  }
+}
+
+resource "aws_ebs_volume" "production_data" {
+  availability_zone = "ap-southeast-2c"
+
+  size = 240
+  type = "gp3"
+  tags = {
+    Name = "righttoknow_production_data"
+    Environment = "production"
+  }
+}
+
+resource "aws_volume_attachment" "production_data" {
+  device_name = "/dev/sdi"
+  volume_id   = aws_ebs_volume.production_data.id
+  instance_id = aws_instance.production.id
+}

--- a/terraform/righttoknow/staging.tf
+++ b/terraform/righttoknow/staging.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "staging" {
   tags = {
     Name        = "righttoknow-staging"
     Environment = "staging"
-    Purpose     = "Ubuntu 22.04 migration testing"
+    Purpose     = "Ubuntu 22.04 Staging Server"
   }
   
   security_groups = [


### PR DESCRIPTION
Introduce a new production server configuration for Right to Know, update DNS records, and refine staging server tags. Remove duplicate provider configuration and fix availability zone references.