### PR TITLE
Multiple Ansible Updates to provision new servers

### DIFF
--- a/group_vars/ec2.yml
+++ b/group_vars/ec2.yml
@@ -6,7 +6,7 @@ oaf_domain: oaf.org.au
 opengovernment_domain: opengovernment.org.au
 electionleaflets_domain: electionleaflets.org.au
 ansible_user: ubuntu
-ansible_ssh_private_key_file: 'test.pem'
+ansible_ssh_private_key_file: 'terraform.pem'
 ec2_region: 'ap-southeast-2'
 # TODO: We only need this key to have limited privileges. It currently has too many privileges.
 aws_access_key: !vault |

--- a/roles/internal/deploy-user/tasks/main.yml
+++ b/roles/internal/deploy-user/tasks/main.yml
@@ -1,8 +1,10 @@
 - name: Ensure we have a deploy group
+  become: true
   group:
     name: deploy
 
 - name: Ensure we have a deploy user
+  become: true
   user:
     name: deploy
     comment: "Deploy user"
@@ -13,6 +15,7 @@
 ## but it does not remove other keys. If we have a need to revoke
 ## access we'll have to do something different.
 - name: Create authorized_keys files for local accounts
+  become: true
   authorized_key:
     user: "{{ item[0] }}"
     key: https://github.com/{{ item[1] }}.keys
@@ -25,6 +28,7 @@
   register: add_authorized_keys
 
 - name: Only allow ssh access with keys
+  become: true
   lineinfile:
     dest: /etc/ssh/sshd_config
     state: present

--- a/site.yml
+++ b/site.yml
@@ -39,12 +39,12 @@
 - hosts: ec2
   become: true
   tasks:
-    - name: Install pip
+    - name: Install python-pip
       apt:
         pkg: python-pip
       when: ansible_distribution_release != 'focal' and ansible_distribution_release != 'jammy'
 
-    - name: Install pip
+    - name: Install python3-pip
       apt:
         pkg: python3-pip
       when: ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy'

--- a/site.yml
+++ b/site.yml
@@ -44,11 +44,13 @@
     - name: Install python-pip
       apt:
         pkg: python-pip
+        cache_valid_time: 300
       when: ansible_distribution_release != 'focal' and ansible_distribution_release != 'jammy'
 
     - name: Install python3-pip
       apt:
         pkg: python3-pip
+        cache_valid_time: 300
       when: ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy'
 
     - name: Install boto which is required for EC2 stuff (Python 2)

--- a/site.yml
+++ b/site.yml
@@ -31,10 +31,12 @@
   become: true
   gather_facts: False
 
-  tasks:
-  - name: install python 2 (or python 3 on Ubuntu 20.04)
-    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal) || apt install -y python-is-python3
-    changed_when: False
+## Disable this for the moment as it doesn't work when deploying new servers
+
+#  tasks:
+#  - name: install python 2 (or python 3 on Ubuntu 20.04)
+#    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal) || apt install -y python-is-python3
+#    changed_when: False
 
 - hosts: ec2
   become: true

--- a/site.yml
+++ b/site.yml
@@ -31,12 +31,10 @@
   become: true
   gather_facts: False
 
-## Disable this for the moment as it doesn't work when deploying new servers
-
-#  tasks:
-#  - name: install python 2 (or python 3 on Ubuntu 20.04)
-#    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal) || apt install -y python-is-python3
-#    changed_when: False
+  tasks:
+  - name: install python 2 (or python 3 on Ubuntu 20.04)
+    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal) || apt install -y python-is-python3
+    changed_when: False
 
 - hosts: ec2
   become: true

--- a/update_ubuntu_keys.yml
+++ b/update_ubuntu_keys.yml
@@ -18,6 +18,6 @@
 
 - hosts: ec2
   vars:
-    ansible_user: root
+    ansible_user: ubuntu
   roles:
     - deploy-user


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Makes the below changes:
- Disable python installation task for the moment as it doesn't work with new server builds
- Rename pip installation tasks for clarity and specify conditions based on Ubuntu releases
- Update ansible_user to 'ubuntu' in update_ubuntu_keys.yml task
- Update ansible_ssh_private_key_file from 'test.pem' to 'terraform.pem' for ec2 instances.
- Ensure all tasks in deploy-user ansible role are run with elevated permissions.

## Why was this needed?
These changes have been split from #252 as they affect Ansible provisioning across the board.

## Implementation/Deploy Steps (Optional)
No deployment steps required

## Notes to reviewer (Optional)
These changes can be auto-merged once we are happy with them