### PR TITLE
RTK: Increase Root volume size to 20GB

### DIFF
--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -12,7 +12,12 @@ resource "aws_instance" "production" {
     Environment = "production"
     Purpose = "Ubuntu 22.04 Production Server"
   }
-  
+
+  # Increase root volume size to 20GB to allow for more packages and data
+  root_block_device {
+    volume_size = 20
+  }
+
   security_groups = [
     var.security_group_webserver.name,
     var.security_group_incoming_email.name,

--- a/terraform/righttoknow/staging.tf
+++ b/terraform/righttoknow/staging.tf
@@ -12,6 +12,11 @@ resource "aws_instance" "staging" {
     Purpose     = "Ubuntu 22.04 Staging Server"
   }
   
+  # Increase root volume size to 20GB to allow for more packages and data
+  root_block_device {
+    volume_size = 20
+  }
+  
   security_groups = [
     var.security_group_webserver.name,
     var.security_group_incoming_email.name,


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Sets the default root volume size on righttoknow-production and righttoknow-staging to 20GB from their default of 12GB.

## Why was this needed?
12GB is not enough for the tasks these servers need to perform. 20GB ensures the disk doesn't run own of space.

## Implementation/Deploy Steps (Optional)
Nil

## Notes to reviewer (Optional)
Nil