### PR TITLE
switch to working gpg key server (and ssl)

### DIFF
--- a/roles/internal/openaustralia/meta/main.yml
+++ b/roles/internal/openaustralia/meta/main.yml
@@ -135,7 +135,7 @@ dependencies:
     # Don't want us updating rvm on every run by default
     # rvm1_rvm_check_for_updates: false
     # Use round-robin pool of gpg key servers to avoid timeout
-    rvm1_gpg_key_server: "hkp://pool.sks-keyservers.net"
+    rvm1_gpg_key_server: "hkps://keyserver.ubuntu.com"
     rvm1_bundler_install: true
   - role: Stouts.backup
     backup_profiles:

--- a/roles/internal/planningalerts/meta/main.yml
+++ b/roles/internal/planningalerts/meta/main.yml
@@ -6,12 +6,12 @@ dependencies:
       - ruby-3.3.4
     # The stable release is almost two years old at this stage and doesn't
     # contain ruby 3.1 or 3.2. So we have to use head instead.
-    rvm1_rvm_version: 'head'
-    rvm1_install_flags: '--auto-dotfiles'      # Remove --user-install from defaults
-    rvm1_install_path: /usr/local/rvm          # Set to system location
-    rvm1_user: root                            # Need root account to access system location
+    rvm1_rvm_version: "head"
+    rvm1_install_flags: "--auto-dotfiles" # Remove --user-install from defaults
+    rvm1_install_path: /usr/local/rvm # Set to system location
+    rvm1_user: root # Need root account to access system location
     # Use round-robin pool of gpg key servers to avoid timeout
-    rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
+    rvm1_gpg_key_server: 'rvm1_gpg_key_server: "hkps://keyserver.ubuntu.com"'
   - role: nickhammond.logrotate
     logrotate_scripts:
       - name: production

--- a/roles/internal/theyvoteforyou/meta/main.yml
+++ b/roles/internal/theyvoteforyou/meta/main.yml
@@ -5,11 +5,11 @@ dependencies:
     # Last listed ruby here is the default one
     rvm1_rubies:
       - ruby-3.4.4
-    rvm1_install_flags: '--auto-dotfiles'      # Remove --user-install from defaults
-    rvm1_install_path: /usr/local/rvm          # Set to system location
-    rvm1_user: root                            # Need root account to access system location
+    rvm1_install_flags: "--auto-dotfiles" # Remove --user-install from defaults
+    rvm1_install_path: /usr/local/rvm # Set to system location
+    rvm1_user: root # Need root account to access system location
     # Use round-robin pool of gpg key servers to avoid timeout
-    rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
+    rvm1_gpg_key_server: "hkps://keyserver.ubuntu.com"
   - role: nickhammond.logrotate
     logrotate_scripts:
       - name: production


### PR DESCRIPTION
## Relevant issue(s)
applying ansible is reporting one failure: a timeout getting the rvm gpg key

```
failed: [theyvoteforyou.org.au] (item=hkp://ipv4.pool.sks-keyservers.net) => {"ansible_loop_var": "item", "changed": false, "cmd": "gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB", "delta": "0:00:09.640052", "end": "2025-11-03 18:50:44.753151", "item": "hkp://ipv4.pool.sks-keyservers.net", "msg": "non-zero return code", "rc": 2, "start": "2025-11-03 18:50:35.113099", "stderr": "gpg: keyserver receive failed: Server indicated a failure", "stderr_lines": ["gpg: keyserver receive failed: Server indicated a failure"], "stdout": "", "stdout_lines": []}
```

## What does this do?
Change to a server that's responding.

## Why was this needed?
So the error goes away
