### PR TITLE
Move xapiandbs folder from the main drive to the data drive

### DIFF
--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -77,7 +77,7 @@
     state: directory
   with_nested:
     - "{{ ['staging'] if (standalone_staging | default(false)) else (['production'] if (standalone_production | default(false)) else ['production', 'staging']) }}"
-    - ['files', 'cache', 'bundle', 'storage']
+    - ['files', 'cache', 'bundle', 'storage', 'xapaindbs']
 
 - name: Ensure that deploy owns application directories
   file:
@@ -96,7 +96,7 @@
     dest: "/srv/www/{{ item[0] }}/shared/{{ item[1] }}"
   with_nested:
     - "{{ ['staging'] if (standalone_staging | default(false)) else (['production'] if (standalone_production | default(false)) else ['production', 'staging']) }}"
-    - ['files', 'cache', 'bundle', 'storage']
+    - ['files', 'cache', 'bundle', 'storage', 'xapaindbs']
 
 - name: Set the ruby version for the alaveteli deploy (production)
   copy:


### PR DESCRIPTION
## Relevant issue(s)
Fixes #271

## What does this do?
Ensures that the xapiandbs folder is created on the data drive, not on the main drive, and that relevant symlinks are created

## Why was this needed?
It takes hours to rebuild the xapiandbs - doing this will ensure that we can recover an older version and run an update instead of trying to rebuild it.

## Implementation/Deploy Steps (Optional)
Deployment steps have already been completed - when running `make check-righttoknow-all` no changes should be required.

## Notes to reviewer (Optional)
