### PR TITLE
Morph Terraform Improvement

### DIFF
--- a/terraform/morph/main.tf
+++ b/terraform/morph/main.tf
@@ -16,7 +16,7 @@ resource "linode_instance" "main" {
   label            = "morph"
   group            = "morph"
   booted           = true
-  backups_enabled  = false
+  backups_enabled  = true
   watchdog_enabled = true
   private_ip       = false
   resize_disk      = false

--- a/terraform/morph/main.tf
+++ b/terraform/morph/main.tf
@@ -19,7 +19,6 @@ resource "linode_instance" "main" {
   backups_enabled  = true
   watchdog_enabled = true
   private_ip       = false
-  resize_disk      = false
   # We can't set the image below because it would force replacement
   # image            = "linode/ubuntu16.04lts"
 


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
- Enabled automatic backups for the Linode instance by setting `backups_enabled` to `true` in `main.tf`.
- Removed resize Disk Option from main.tf


## Why was this needed?
These changes have been manually made in production without updaitng terraform. 

## Implementation/Deploy Steps (Optional)
No steps required

## Notes to reviewer (Optional)
