### PR TITLE
Updates the Stouts.backup role condition to support both Ubuntu 18.04

### DIFF
--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -140,7 +140,7 @@ dependencies:
         target: "s3://s3.amazonaws.com/oaf-backups/righttoknow/{{ inventory_hostname }}/data"
         exclude:
           - "*/bundle"
-    when: ansible_distribution_release == 'bionic'
+    when: ansible_distribution_release in ['bionic', 'jammy']
     
   - role: nickhammond.logrotate
     logrotate_scripts:


### PR DESCRIPTION
(bionic) and Ubuntu 22.04 (jammy). This enables automated backups to S3 for Right to Know servers running on Ubuntu 22.04.


## Relevant issue(s)
* https://github.com/openaustralia/infrastructure/issues/241

## What does this do?

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
