### PR TITLE
Fix duplicity backup exclude pattern for Ubuntu 22.04

### DIFF
--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -139,7 +139,7 @@ dependencies:
         # TODO: Duplicity will be very confused if two different machines from the same stage try to backup
         target: "s3://s3.amazonaws.com/oaf-backups/righttoknow/{{ inventory_hostname }}/data"
         exclude:
-          - "*/bundle"
+          - "**/bundle"
     when: ansible_distribution_release in ['bionic', 'jammy']
     
   - role: nickhammond.logrotate


### PR DESCRIPTION
Changes the exclude pattern from */bundle to **/bundle to fix backup failures on Ubuntu 22.04 (duplicity 0.8.21).

Duplicity 0.8.21 enforces stricter pattern validation and requires exclude patterns to either start with the base directory or use ** to match from the base directory. The */bundle pattern was rejected with: "cannot match any files in the base directory /data".

The older duplicity 0.7.17 (Ubuntu 18.04) was likely more lenient and didn't enforce the strict validation that 0.8.21 does. So while */bundle fails on 22.04's duplicity 0.8.21, it might have worked (or been silently ignored) on 18.04's duplicity 0.7.17.

The **/bundle pattern is backward compatible with both Ubuntu 18.04 (duplicity 0.7.17) and Ubuntu 22.04 (duplicity 0.8.21), and correctly matches bundle directories at any nesting level under /data.
