### PR TITLE
fix install of google chrome

### DIFF
--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -297,7 +297,7 @@
 # will hopefully stay in sync at the risk of chrome updating when not necessarily expected.
 
 - name: Get Google key for install Chrome
-  become: yes
+  become: true
   apt_key:
     url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
     state: present


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
fixed installing google chrome on machines that need it for scraping

## Why was this needed?
wrong syntax used in the ansible. should be "true" not "yes"

