### PR TITLE
fixed syntax in rtk db config

### DIFF
--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -261,8 +261,8 @@
     owner: deploy
     group: deploy
   vars:
-    - stage: "{{ item }}"
-    - password: "{{ (item == 'production') | ternary(db_password_production, db_password_staging) }}"
+    stage: "{{ item }}"
+    password: "{{ (item == 'production') | ternary(db_password_production, db_password_staging) }}"
   with_items: "{{ ['staging'] if ('righttoknow_staging' in group_names) else ['production'] }}"
   notify: nginx restart
 
@@ -272,7 +272,7 @@
     dest: "/etc/init.d/{{ item[1] }}-{{ item[0] }}"
     mode: 0755
   vars:
-    - stage: "{{ item[0] }}"
+    stage: "{{ item[0] }}"
   with_nested:
     - "{{ ['staging'] if ('righttoknow_staging' in group_names) else ['production'] }}"
     - ['send-notifications', 'foi-alert-tracks', 'alaveteli']


### PR DESCRIPTION
## Relevant issue(s)
got errors when running ansible:
```
[ERROR]: Vars in a Task must be specified as a dictionary.
Origin: /home/brenda/projects/OpenAustralia/infrastructure/roles/internal/righttoknow/tasks/main.yml:264:5

262     group: deploy
263   vars:
264     - stage: "{{ item }}"
        ^ column 5
```

## What does this do?
fixes the syntax
