### PR TITLE
change "name" to "site_name"

### DIFF
--- a/group_vars/electionleaflets.yml
+++ b/group_vars/electionleaflets.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: electionleaflets.org.au
+site_name: electionleaflets.org.au
 backup_gpg_pw: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           38613838343137663461623731353661373533396530636665656437363538663031333433343536

--- a/group_vars/metabase.yml
+++ b/group_vars/metabase.yml
@@ -1,4 +1,4 @@
-name: metabase.oaf.org.au
+site_name: metabase.oaf.org.au
 db_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           64636137653232633237393332643835653231386139383431393136376638326664393034393539

--- a/group_vars/oaf.yml
+++ b/group_vars/oaf.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: oaf.org.au
+site_name: oaf.org.au
 cron_enabled: true
 admin_user: admin
 admin_password: !vault |

--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: openaustralia.org.au
+site_name: openaustralia.org.au
 openaustralia_production_mysql_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           33613134623466616233383862366434366264323562313439366566343461663337313037376364

--- a/group_vars/opengovernment.yml
+++ b/group_vars/opengovernment.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: opengovernment.org.au
+site_name: opengovernment.org.au
 opengovernment_production_mysql_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           61303430656638616337626363386435343063373337323335313433356335373131393666316339

--- a/group_vars/plausible.yml
+++ b/group_vars/plausible.yml
@@ -1,4 +1,4 @@
-name: plausible.oaf.org.au
+site_name: plausible.oaf.org.au
 secret_key_base: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           63663637316331323333393266623234343565316435376539353031383035343737393738633137

--- a/group_vars/proxy.yml
+++ b/group_vars/proxy.yml
@@ -1,4 +1,4 @@
-name: au.proxy.oaf.org.au
+site_name: au.proxy.oaf.org.au
 password: !vault |
           $ANSIBLE_VAULT;1.1;AES256
           63623366396435326635316537663863386665633566316532636135326161333331303362646631

--- a/group_vars/righttoknow.yml
+++ b/group_vars/righttoknow.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: righttoknow.org.au
+site_name: righttoknow.org.au
 github_users:
   [
     "benrfairless",

--- a/group_vars/righttoknow_production.yml
+++ b/group_vars/righttoknow_production.yml
@@ -3,7 +3,7 @@
 
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: prod.righttoknow.org.au
+site_name: prod.righttoknow.org.au
 
 # Domain configuration for standalone production server
 righttoknow_domain: righttoknow.org.au # Used in certbot and SSL

--- a/group_vars/theyvoteforyou.yml
+++ b/group_vars/theyvoteforyou.yml
@@ -1,6 +1,6 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
-name: theyvoteforyou.org.au
+site_name: theyvoteforyou.org.au
 # Not using any non-alphanumeric characters in the password so that we can use
 # ansible-vault encrypt_string without having to use stdin input (which appears to
 # introduce an extra carriage return at the end)

--- a/host_vars/righttoknow.org.au.test.yml
+++ b/host_vars/righttoknow.org.au.test.yml
@@ -1,4 +1,4 @@
-name: righttoknow.org.au.test
+site_name: righttoknow.org.au.test
 db_password_production: db_password_production
 db_password_staging: db_password_staging
 alavateli_incoming_email_secret: alavateli_incoming_email_secret

--- a/roles/internal/base-server/meta/main.yml
+++ b/roles/internal/base-server/meta/main.yml
@@ -14,4 +14,4 @@ dependencies:
   - role: newrelic.newrelic-infra
     nrinfragent_config:
       license_key: "{{ newrelic_license_key }}"
-      display_name: "{{ name }}"
+      display_name: "{{ site_name }}"


### PR DESCRIPTION
name is a reserved variable in ansible


## Relevant issue(s)
each ansible run we get this warning:
`[WARNING]: Found variable using reserved name 'name'.`

## What does this do?
rename from `name` to `site_name`
the variable is only used to identify the system in newrelic.
