### PR TITLE
Refactor OpenVPN infrastructure to separate Terraform and Ansible

### DIFF
--- a/group_vars/openvpn.yml
+++ b/group_vars/openvpn.yml
@@ -1,0 +1,15 @@
+site_name: openvpn-server
+
+# Disable NewRelic for VPN server
+newrelic_license_key: "disabled"
+
+# OpenVPN specific configuration
+# Update this IP after Terraform creates the Elastic IP
+openvpn_server_public_ip: "52.64.33.12"
+openvpn_iam_group: "vpn-users"
+openvpn_aws_region: "ap-southeast-2"
+
+# VPC configuration for ap-southeast-2
+openvpn_vpc_network: "172.31.0.0"
+openvpn_vpc_netmask: "255.255.0.0"
+openvpn_vpc_dns: "172.31.0.2"

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -8,6 +8,7 @@ opengovernment.org.au
 electionleaflets.org.au
 au.proxy.oaf.org.au
 web.metabase.oaf.org.au
+vpn.oaf.org.au
 ; We've decided to use the hosted version at plausible.io for the time
 ; being because it was just a little too much work to get a decent
 ; production worthy setup going. That could of course change and we always
@@ -45,6 +46,9 @@ au.proxy.oaf.org.au
 [metabase]
 web.metabase.oaf.org.au
 
+[openvpn]
+52.64.33.12 ansible_user=ubuntu ansible_ssh_private_key_file=terraform.pem
+
 [planningalerts]
 ec2-3-27-58-54.ap-southeast-2.compute.amazonaws.com
 ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com
@@ -52,3 +56,19 @@ ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com
 [plausible]
 ; See comment above
 ; web.plausible.oaf.org.au
+
+; Group for all sites that need information on the MySQL RDS instance
+[requires_mysql:children]
+electionleaflets
+oaf
+openaustralia
+opengovernment
+theyvoteforyou
+metabase
+
+; Group for all sites that need information on the PostgreSQL RDS instance
+[requires_postgresql:children]
+theyvoteforyou
+righttoknow
+metabase
+planningalerts

--- a/roles/internal/openvpn/defaults/main.yml
+++ b/roles/internal/openvpn/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# OpenVPN Server Configuration Defaults
+
+# Easy-RSA Certificate Configuration
+openvpn_country: "AU"
+openvpn_province: "NSW"
+openvpn_city: "Sydney"
+openvpn_org: "OAF"
+openvpn_email: "admin@openaustraliafoundation.org.au"
+openvpn_ou: "IT"
+openvpn_key_size: 2048
+openvpn_ca_expire: 3650
+openvpn_cert_expire: 3650
+
+# OpenVPN Network Configuration
+openvpn_server_network: "10.8.0.0"
+openvpn_server_netmask: "255.255.255.0"
+openvpn_client_network: "10.8.0.0/24"
+
+# VPC Network Configuration (AWS)
+openvpn_vpc_network: "172.31.0.0"
+openvpn_vpc_netmask: "255.255.0.0"
+openvpn_vpc_dns: "172.31.0.2"
+
+# IAM Authentication
+openvpn_iam_group: "vpn-users"
+openvpn_aws_region: "ap-southeast-2"
+
+# Server Public IP (should be set via inventory or group_vars)
+# openvpn_server_public_ip: "{{ ansible_default_ipv4.address }}"

--- a/roles/internal/openvpn/handlers/main.yml
+++ b/roles/internal/openvpn/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# OpenVPN Handlers
+
+- name: restart openvpn
+  systemd:
+    name: openvpn@server
+    state: restarted

--- a/roles/internal/openvpn/meta/main.yml
+++ b/roles/internal/openvpn/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: internal/base-server

--- a/roles/internal/openvpn/tasks/main.yml
+++ b/roles/internal/openvpn/tasks/main.yml
@@ -1,0 +1,150 @@
+---
+# OpenVPN Server Configuration with IAM Authentication
+
+- name: Install required packages
+  apt:
+    name:
+      - openvpn
+      - easy-rsa
+      - python3-pip
+      - jq
+      - awscli
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install boto3 for IAM authentication
+  pip:
+    name: boto3
+    executable: pip3
+    state: present
+
+- name: Create Easy-RSA directory
+  command: make-cadir /etc/openvpn/easy-rsa
+  args:
+    creates: /etc/openvpn/easy-rsa
+
+- name: Configure Easy-RSA variables
+  copy:
+    dest: /etc/openvpn/easy-rsa/vars
+    content: |
+      set_var EASYRSA_REQ_COUNTRY    "{{ openvpn_country }}"
+      set_var EASYRSA_REQ_PROVINCE   "{{ openvpn_province }}"
+      set_var EASYRSA_REQ_CITY       "{{ openvpn_city }}"
+      set_var EASYRSA_REQ_ORG        "{{ openvpn_org }}"
+      set_var EASYRSA_REQ_EMAIL      "{{ openvpn_email }}"
+      set_var EASYRSA_REQ_OU         "{{ openvpn_ou }}"
+      set_var EASYRSA_KEY_SIZE       {{ openvpn_key_size }}
+      set_var EASYRSA_CA_EXPIRE      {{ openvpn_ca_expire }}
+      set_var EASYRSA_CERT_EXPIRE    {{ openvpn_cert_expire }}
+    mode: '0644'
+
+- name: Initialize PKI
+  command: ./easyrsa init-pki
+  args:
+    chdir: /etc/openvpn/easy-rsa
+    creates: /etc/openvpn/easy-rsa/pki
+
+- name: Build CA
+  command: ./easyrsa --batch build-ca nopass
+  args:
+    chdir: /etc/openvpn/easy-rsa
+    creates: /etc/openvpn/easy-rsa/pki/ca.crt
+
+- name: Generate DH parameters
+  command: ./easyrsa gen-dh
+  args:
+    chdir: /etc/openvpn/easy-rsa
+    creates: /etc/openvpn/easy-rsa/pki/dh.pem
+
+- name: Build server certificate
+  command: ./easyrsa build-server-full server nopass
+  args:
+    chdir: /etc/openvpn/easy-rsa
+    creates: /etc/openvpn/easy-rsa/pki/issued/server.crt
+
+- name: Generate TLS auth key
+  command: openvpn --genkey secret /etc/openvpn/ta.key
+  args:
+    creates: /etc/openvpn/ta.key
+
+- name: Copy certificates to OpenVPN directory
+  copy:
+    src: "/etc/openvpn/easy-rsa/pki/{{ item.src }}"
+    dest: "/etc/openvpn/{{ item.dest }}"
+    remote_src: yes
+    mode: "{{ item.mode }}"
+  loop:
+    - { src: 'ca.crt', dest: 'ca.crt', mode: '0644' }
+    - { src: 'issued/server.crt', dest: 'server.crt', mode: '0644' }
+    - { src: 'private/server.key', dest: 'server.key', mode: '0600' }
+    - { src: 'dh.pem', dest: 'dh.pem', mode: '0644' }
+
+- name: Get EC2 instance metadata (private IP)
+  uri:
+    url: http://169.254.169.254/latest/meta-data/local-ipv4
+    return_content: yes
+  register: ec2_private_ip
+
+- name: Create OpenVPN server configuration
+  template:
+    src: server.conf.j2
+    dest: /etc/openvpn/server.conf
+    mode: '0644'
+  notify: restart openvpn
+
+- name: Create PAM configuration for OpenVPN
+  copy:
+    dest: /etc/pam.d/openvpn
+    content: |
+      # Pass the username/password (signed SigV4 blob) to the helper via $PAM_AUTHTOK
+      auth   required pam_exec.so expose_authtok seteuid /usr/local/bin/openvpn-iam-auth.sh
+      account required pam_permit.so
+    mode: '0644'
+
+- name: Create IAM authentication script
+  template:
+    src: openvpn-iam-auth.sh.j2
+    dest: /usr/local/bin/openvpn-iam-auth.sh
+    mode: '0755'
+
+- name: Enable IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    reload: yes
+
+- name: Get default network interface
+  shell: ip route | grep default | awk '{print $5}'
+  register: default_interface
+  changed_when: false
+
+- name: Configure NAT for VPN clients
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    source: "{{ openvpn_client_network }}"
+    out_interface: "{{ default_interface.stdout }}"
+    jump: MASQUERADE
+
+- name: Install iptables-persistent
+  apt:
+    name: iptables-persistent
+    state: present
+
+- name: Save iptables rules
+  shell: iptables-save > /etc/iptables/rules.v4
+  changed_when: false
+
+- name: Enable and start OpenVPN service
+  systemd:
+    name: openvpn@server
+    enabled: yes
+    state: started
+
+- name: Create client configuration template
+  template:
+    src: client-template.ovpn.j2
+    dest: /root/client-template.ovpn
+    mode: '0600'

--- a/roles/internal/openvpn/templates/client-template.ovpn.j2
+++ b/roles/internal/openvpn/templates/client-template.ovpn.j2
@@ -1,0 +1,13 @@
+client
+dev tun
+proto udp
+remote {{ openvpn_server_public_ip }} 1194
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+remote-cert-tls server
+cipher AES-256-GCM
+auth SHA256
+verb 3
+auth-user-pass

--- a/roles/internal/openvpn/templates/openvpn-iam-auth.sh.j2
+++ b/roles/internal/openvpn/templates/openvpn-iam-auth.sh.j2
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# OpenVPN IAM Authentication Script
+# Validates IAM credentials and checks {{ openvpn_iam_group }} group membership
+
+# Get access key from PAM username
+ACCESS_KEY_ID="$PAM_USER"
+
+# Read secret key from stdin (provided by PAM expose_authtok)
+read -r SECRET_ACCESS_KEY
+
+# Log authentication attempt (without credentials)
+logger -t openvpn-iam "Authentication attempt for access key: $ACCESS_KEY_ID"
+
+# Validate credentials using STS GetCallerIdentity
+export AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION={{ openvpn_aws_region }}
+
+# Try to get caller identity
+if ! IDENTITY=$(aws sts get-caller-identity 2>&1); then
+    logger -t openvpn-iam "Authentication failed: Invalid credentials - $IDENTITY"
+    exit 1
+fi
+
+# Extract username from ARN
+IAM_USERNAME=$(echo "$IDENTITY" | jq -r '.Arn' | grep -oP '(?<=user/).*')
+
+if [ -z "$IAM_USERNAME" ]; then
+    logger -t openvpn-iam "Authentication failed: Could not extract username from ARN: $IDENTITY"
+    exit 1
+fi
+
+# Check if user is in {{ openvpn_iam_group }} group (use instance role for this check)
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+IAM_GROUPS=$(aws iam list-groups-for-user --user-name "$IAM_USERNAME" 2>/dev/null | jq -r '.Groups[].GroupName')
+
+if ! echo "$IAM_GROUPS" | grep -q "^{{ openvpn_iam_group }}$"; then
+    logger -t openvpn-iam "Authentication failed: User $IAM_USERNAME not in {{ openvpn_iam_group }} group. Groups: $IAM_GROUPS"
+    exit 1
+fi
+
+logger -t openvpn-iam "Authentication successful: User $IAM_USERNAME"
+exit 0

--- a/roles/internal/openvpn/templates/server.conf.j2
+++ b/roles/internal/openvpn/templates/server.conf.j2
@@ -1,0 +1,41 @@
+port 1194
+proto udp
+dev tun
+
+ca ca.crt
+cert server.crt
+key server.key
+dh dh.pem
+tls-auth ta.key 0
+
+server {{ openvpn_server_network }} {{ openvpn_server_netmask }}
+
+# Push routes to clients for VPC access
+push "route {{ openvpn_vpc_network }} {{ openvpn_vpc_netmask }}"
+
+# DNS - use VPC DNS
+push "dhcp-option DNS {{ openvpn_vpc_dns }}"
+
+# Client networking
+client-to-client
+keepalive 10 120
+cipher AES-256-GCM
+auth SHA256
+user nobody
+group nogroup
+persist-key
+persist-tun
+
+status /var/log/openvpn-status.log
+log-append /var/log/openvpn.log
+verb 4
+
+# IAM Authentication
+plugin /usr/lib/openvpn/openvpn-plugin-auth-pam.so openvpn
+username-as-common-name
+
+# Allow auth without client TLS certs (we're using PAM/IAM)
+verify-client-cert none
+
+# Make sure scripts/PAM helpers can run with env
+script-security 2

--- a/site.yml
+++ b/site.yml
@@ -58,16 +58,30 @@
       pip: name=boto3
       when: ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy'
 
-    - name: Get information about the RDS instance
+    - name: Get information about the Mysql 5 instance
       rds:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         command: facts
         instance_name: main-database
         region: "{{ ec2_region }}"
-      register: rds_mysql
+      register: rds_mysql5
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
+      when: "'requires_mysql' in group_names"
+    
+    - name: Get information about the Mysql 8 instance
+      rds:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        command: facts
+        instance_name: maindb
+        region: "{{ ec2_region }}"
+      register: rds_mysql8
+      # Run this task even when running ansible-playbook with "--check"
+      check_mode: no
+      when: "'requires_mysql' in group_names"
+
 
     - name: Get information about the postgresql RDS instance
       rds:
@@ -79,6 +93,7 @@
       register: rds_postgresql
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
+      when: "'requires_postgresql' in group_names"
 
     - name: Get information about the planningalerts RDS instance
       rds:
@@ -90,6 +105,7 @@
       register: rds_planningalerts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
+      when: "'requires_postgresql' in group_names"
 
 - hosts: all
   become: true
@@ -150,6 +166,11 @@
   become: true
   roles:
     - metabase
+
+- hosts: openvpn
+  become: true
+  roles:
+    - internal/openvpn
 
 - hosts: redis
   become: true

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -71,21 +71,20 @@ provider "registry.terraform.io/hashicorp/external" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "7.2.0"
+  version = "7.12.0"
   hashes = [
-    "h1:CxA714vkxOLC7EEKF3rQNfHteGIAIVNqygDDRn8iyY8=",
-    "h1:rx4REBgSS0Bs5OQ9wEjR85a/cjKqQXYtgke6l4ORfEs=",
-    "zh:0f036e400c90ae45289b948afb49ca938d169fb4a31d7560b345fd0ae5121407",
-    "zh:28a7c683656178456dc7942f051df46052150cee74da7535e7ca8748a83baf30",
-    "zh:2994083c634cff44de626b4bfca3e5e8ed5b2a08baa6f4c4fa4b217d5f49559a",
-    "zh:3c0d98921944c39f2e9d7f42122f44bcf07418ee9ee5faf81e6357cecbac4870",
-    "zh:4f869f574ab7e5970e9ec543fccd4c773e41a111f9bedc7075b725217f3c6fd2",
-    "zh:65479468ab9f6735d267bb593af8d139561790467ba6f8f99c3ba3be25b3a8e9",
-    "zh:827cb00f8dc4bba03afce2ff5d11bcd2d0528fc4624ea05b70354a1fa18b59fb",
-    "zh:a087e5155bd73d59f9dc6df65c1b38944de06cb2a5ead2439b31ad10a18da5a7",
-    "zh:db714b0e7a4365b3d93c17df2abc2bc883c89b15524111433af05aea176680c1",
-    "zh:e5444fde901cfefe7f66c8e9a1d9915d403fc2a6ebe87eaa2a262d2a50ee0a10",
-    "zh:f360342aa2bad7f6123c959b2129abaed99e26891dcd0b0719fec55252bb44b9",
+    "h1:kBKvDUp6GLwHAsoM6CIj9ZTxVBzSnQjyxaVSP8SfqHQ=",
+    "zh:38722ec7777543c23e22e02695e53dd5c94644022647c3c79e11e587063d4d2b",
+    "zh:417b12b69c91c12e3fcefee38744b7a37bae73b706e3071c714151a623a6b0e9",
+    "zh:4902cea92c78b462beaf053de03d0d55fb2241d41ca3379b4568ba247f667fa9",
+    "zh:50ccce39d403ba477943e6652ccb6913092d9dcce1d55533b00b66062888db3d",
+    "zh:56dccfe5df28cfe368d93c37ad6c46a16e76da61482fd0bfc83676b1423cecf5",
+    "zh:7265fca2921e5e300da5d8de7e28b658c0863fdda9da696c5b97dbd3122c17c2",
+    "zh:8317467e828178a6db9ddabe431bb13935c00bfb5e4b4d9760bd56f7ae596eca",
+    "zh:84cc9d9277422a0d6c80d2bd204642d8776ddbba23feb94cf2760bb5f15410bc",
+    "zh:8f79d72e7ed4e36d01560ce5fc944dc7e0387fa0f8272a4345fc6ae896e8f575",
+    "zh:98c3d756beca036f84e7840e2099ff7359e9a246cd9a35386e03ce65032b3f5f",
+    "zh:a07e3ca19673d28da9289ca28dfb83204fa6636f642b8cf46de8caaf526b7dde",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/vpn-server.tf
+++ b/terraform/vpn-server.tf
@@ -1,0 +1,61 @@
+# OpenVPN Server for IAM-authenticated VPN access
+# Users must be in the 'vpn-users' IAM group to connect
+
+resource "aws_instance" "openvpn" {
+  ami                    = data.aws_ami.ubuntu_jammy.id
+  instance_type          = "t3.small"
+  key_name               = "terraform"
+  vpc_security_group_ids = [aws_security_group.openvpn.id]
+  iam_instance_profile   = aws_iam_instance_profile.openvpn.name
+
+  # Enable source/dest check disable for NAT functionality
+  source_dest_check = false
+
+  user_data = file("${path.module}/vpn-user-data.sh")
+
+  tags = {
+    Name = "openvpn-server"
+    Role = "vpn"
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = true
+  }
+}
+
+# Use latest Ubuntu 22.04 LTS
+data "aws_ami" "ubuntu_jammy" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Elastic IP for consistent VPN endpoint
+resource "aws_eip" "openvpn" {
+  instance = aws_instance.openvpn.id
+
+  tags = {
+    Name = "openvpn-server"
+  }
+}
+
+output "vpn_server_ip" {
+  description = "OpenVPN server public IP"
+  value       = aws_eip.openvpn.public_ip
+}
+
+output "vpn_server_private_ip" {
+  description = "OpenVPN server private IP"
+  value       = aws_instance.openvpn.private_ip
+}

--- a/terraform/vpn-user-data.sh
+++ b/terraform/vpn-user-data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Minimal bootstrap script for OpenVPN server
+# Actual configuration is handled by Ansible
+
+# Update system packages
+apt-get update
+apt-get upgrade -y
+
+# Install Python for Ansible (if not present)
+apt-get install -y python3 python3-pip
+
+# Log instance initialization
+logger -t user-data "OpenVPN server instance initialized - ready for Ansible configuration"


### PR DESCRIPTION
Separate concerns between infrastructure provisioning (Terraform) and configuration management (Ansible) for the OpenVPN VPN server.

Terraform changes:
- Minimize vpn-user-data.sh to bootstrap only (Python installation)
- Update vpn-server.tf to use file() instead of templatefile()
- Infrastructure creates: EC2, IAM roles/policies, security groups, EIP

Ansible changes:
- Create internal/openvpn role for server configuration
- Implement IAM-based authentication via AWS STS
- Configure Easy-RSA PKI, OpenVPN service, and NAT routing
- Add openvpn group to inventory and site.yml playbook

Configuration:
- VPN network: 10.8.0.0/24
- VPC access: 172.31.0.0/16
- IAM group: vpn-users
- Region: ap-southeast-2


## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
