### PR TITLE
Add Yahoo domain verification records for oaf.org.au, planningalerts.org.au and righttoknow.org.au

### DIFF
--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -56,6 +56,14 @@ resource "cloudflare_record" "facebook_domain_verification" {
   value   = "facebook-domain-verification=hfy8rxjyjsmjynz68xr373fy86lg4o"
 }
 
+resource "cloudflare_record" "yahoo_domain_verification" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "oaf.org.au"
+  type    = "TXT"
+  value   = "yahoo-verification-key=b22Y3XMni7mCqo0n03D0IOvczsLEdMQZ4i+Pt1WMJ0Y="
+}
+
+
 resource "cloudflare_record" "bluesky_domain_verification" {
   zone_id = var.oaf_org_au_zone_id
   name    = "_atproto.oaf.org.au"

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -95,6 +95,14 @@ resource "cloudflare_record" "facebook_domain_verification" {
   value   = "facebook-domain-verification=djdz2wywxnas3cxhrch14pfk145g93"
 }
 
+resource "cloudflare_record" "yahoo_domain_verification" {
+  zone_id = cloudflare_zone.main.id
+  name    = "planningalerts.org.au"
+  type    = "TXT"
+  value   = "yahoo-verification-key=j/JGsx5QsyhsESucFAGKelmOmW80kCYKW5lxhkxvzr4="
+}
+
+
 resource "cloudflare_record" "domainkey" {
   zone_id = cloudflare_zone.main.id
   name    = "planningalerts_3.cuttlefish._domainkey.planningalerts.org.au"

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -77,6 +77,14 @@ resource "cloudflare_record" "facebook_domain_verification" {
   value   = "facebook-domain-verification=vtlcbmfm4mihp4wql58lwz3nbhc8bt"
 }
 
+resource "cloudflare_record" "yahoo_domain_verification" {
+  zone_id = cloudflare_zone.main.id
+  name    = "righttoknow.org.au"
+  type    = "TXT"
+  value   = "yahoo-verification-key=J/Bl98qV16dX75A0CTg77/jNdSKtp+ULdHN7fwQ6SHw="
+}
+
+
 # Note that this record comes from roles/internal/righttoknow/files/dkimkeys/default.txt which in turn is generated
 # by hand (as part of a keypair) using opendkim
 resource "cloudflare_record" "default_domainkey" {


### PR DESCRIPTION
## What does this do?
Adds verification keys to the below domains:
- oaf.org.au
- planningalerts.org.au
- righttoknow.org.au

## Why was this needed?
To allow access to the Yahoo Sender Hub so we can track the cause of email delivery issues

## Implementation/Deploy Steps (Optional)
I have attempted to deploy this using `make tf-plan` and `make tf-apply` however there are a large number of changes showing when I run `tf plan` that need to be reconciled before I would feel comfortable applying these changes in terraform.

## Notes to reviewer (Optional)
These changes have been manually made in Cloudflare.