### PR TITLE
Update DNS records to point test. at wp.com hosted blog

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -73,6 +73,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/google" {
   version = "7.12.0"
   hashes = [
+    "h1:axUhrDS/FeAEKHRKS57WfT0AkrNDC3d5DkWMMnk+fT4=",
     "h1:kBKvDUp6GLwHAsoM6CIj9ZTxVBzSnQjyxaVSP8SfqHQ=",
     "zh:38722ec7777543c23e22e02695e53dd5c94644022647c3c79e11e587063d4d2b",
     "zh:417b12b69c91c12e3fcefee38744b7a37bae73b706e3071c714151a623a6b0e9",

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -132,11 +132,25 @@ resource "cloudflare_record" "alt_www" {
   value   = "openaustraliafoundation.org.au"
 }
 
-resource "cloudflare_record" "alt_test" {
+resource "cloudflare_record" "test_1" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "test.openaustraliafoundation.org.au"
+  type    = "A"
+  value   = "192.0.78.151"
+}
+
+resource "cloudflare_record" "test_2" {
+  zone_id = var.openaustraliafoundation_org_au_zone_id
+  name    = "test.openaustraliafoundation.org.au"
+  type    = "A"
+  value   = "192.0.78.202"
+}
+
+resource "cloudflare_record" "www_test_cname" {
+  zone_id = var.openaustraliafoundation_org_au_zone_id
+  name    = "www.test"
   type    = "CNAME"
-  value   = "openaustraliafoundation.org.au"
+  value   = "test.oaf.org.au"
 }
 
 # MX records


### PR DESCRIPTION
Change DNS records to use the new wp.com hosted site for test.

Once we start using th is site, we'll change things so the test. name goes to a new staging site we set up there, and the main www records will redirect to the wp.com hosting