### PR TITLE
Update code owners from code-reviewers to team-infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is used to define code owners for this repository.
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @openaustralia/code-reviewers
+* @openaustralia/team-infrastructure


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
This pull request updates the repository's code ownership to assign responsibility to the `@openaustralia/team-infrastructure` team instead of the previous group.
- Changed the default code owner for the repository from `@openaustralia/code-reviewers` to `@openaustralia/team-infrastructure` in `.github/CODEOWNERS`.

## Why was this needed?
The "Code Reviewers" group is supposed to be a catchall group. This allows people to have access to approve Infrastructure changes while restricting access to other projects.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
