### PR TITLE
Block bot putting load on services

### DIFF
--- a/roles/internal/theyvoteforyou/templates/production
+++ b/roles/internal/theyvoteforyou/templates/production
@@ -24,7 +24,9 @@ server {
     deny 47.82.0.0/19;
     deny 47.82.12.0/23;
     deny 47.82.14.0/23;
-
+    # Alibaba Cloud
+    deny 47.79.192.0/19;
+    
     # Desperate measures - blocking whole ASN 136907
     # This list from https://www.enjen.net/asn-blocklist/index.php?asn=136907&type=nginx
     deny 101.46.136.0/21;


### PR DESCRIPTION
## Relevant issue(s)
Bot hitting TVFY today, creating high load and using all resources

## What does this do?
Block that range

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
Same range is already blocked on RTK