### PR TITLE
Fix OpenVPN client config and IAM auth script

### DIFF
--- a/roles/internal/openvpn/tasks/main.yml
+++ b/roles/internal/openvpn/tasks/main.yml
@@ -8,14 +8,15 @@
       - easy-rsa
       - python3-pip
       - jq
-      - awscli
     state: present
     update_cache: yes
     cache_valid_time: 3600
 
-- name: Install boto3 for IAM authentication
+- name: Install AWS CLI and boto3 via pip
   pip:
-    name: boto3
+    name:
+      - boto3
+      - awscli
     executable: pip3
     state: present
 
@@ -143,8 +144,21 @@
     enabled: yes
     state: started
 
+- name: Read CA certificate for client config
+  slurp:
+    src: /etc/openvpn/ca.crt
+  register: ca_cert
+
+- name: Read TLS auth key for client config
+  slurp:
+    src: /etc/openvpn/ta.key
+  register: ta_key
+
 - name: Create client configuration template
   template:
     src: client-template.ovpn.j2
     dest: /root/client-template.ovpn
     mode: '0600'
+  vars:
+    ca_cert_content: "{{ ca_cert.content | b64decode }}"
+    ta_key_content: "{{ ta_key.content | b64decode }}"

--- a/roles/internal/openvpn/templates/client-template.ovpn.j2
+++ b/roles/internal/openvpn/templates/client-template.ovpn.j2
@@ -11,3 +11,12 @@ cipher AES-256-GCM
 auth SHA256
 verb 3
 auth-user-pass
+key-direction 1
+
+<ca>
+{{ ca_cert_content }}
+</ca>
+
+<tls-auth>
+{{ ta_key_content }}
+</tls-auth>

--- a/roles/internal/openvpn/templates/openvpn-iam-auth.sh.j2
+++ b/roles/internal/openvpn/templates/openvpn-iam-auth.sh.j2
@@ -18,7 +18,7 @@ export AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY"
 export AWS_DEFAULT_REGION={{ openvpn_aws_region }}
 
 # Try to get caller identity
-if ! IDENTITY=$(aws sts get-caller-identity 2>&1); then
+if ! IDENTITY=$(/usr/local/bin/aws sts get-caller-identity 2>&1); then
     logger -t openvpn-iam "Authentication failed: Invalid credentials - $IDENTITY"
     exit 1
 fi
@@ -34,7 +34,7 @@ fi
 # Check if user is in {{ openvpn_iam_group }} group (use instance role for this check)
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
-IAM_GROUPS=$(aws iam list-groups-for-user --user-name "$IAM_USERNAME" 2>/dev/null | jq -r '.Groups[].GroupName')
+IAM_GROUPS=$(/usr/local/bin/aws iam list-groups-for-user --user-name "$IAM_USERNAME" 2>/dev/null | jq -r '.Groups[].GroupName')
 
 if ! echo "$IAM_GROUPS" | grep -q "^{{ openvpn_iam_group }}$"; then
     logger -t openvpn-iam "Authentication failed: User $IAM_USERNAME not in {{ openvpn_iam_group }} group. Groups: $IAM_GROUPS"

--- a/terraform/vpn-iam.tf
+++ b/terraform/vpn-iam.tf
@@ -60,6 +60,20 @@ resource "aws_iam_group" "vpn_users" {
   path = "/"
 }
 
+# VPN users group membership
+# These are manually created IAM users who need VPN access
+resource "aws_iam_group_membership" "vpn_users" {
+  name  = "vpn-users-membership"
+  group = aws_iam_group.vpn_users.name
+
+  users = [
+    "jon",
+    "ben",
+    "brenda",
+    "ian+oaf",
+  ]
+}
+
 output "vpn_users_group_name" {
   description = "IAM group name for VPN access"
   value       = aws_iam_group.vpn_users.name


### PR DESCRIPTION
  What does this do?

  - Fixes OpenVPN client config template to embed CA certificate and TLS auth key inline
  - Updates IAM auth script to use /usr/local/bin/aws (pip-installed) instead of system aws
  - Installs awscli via pip instead of apt to avoid Python package version conflicts
  - Adds existing vpn-users IAM group membership to Terraform state (jon, ben, brenda, ian+oaf)

  Why was this needed?

  - Client config was missing embedded certificates, causing "You must define CA file" error on connection
  - System awscli (apt) had botocore version conflicts causing auth script to fail with Python tracebacks
  - VPN users group membership was manually configured but not tracked in Terraform

  Implementation/Deploy Steps (Optional)

  1. Terraform: terraform apply to create the group membership resource (users already in group, just adding to state)
  2. Ansible: Re-run playbook to regenerate client config with embedded certs: ansible-playbook site.yml -l openvpn
  3. Distribute new client-template.ovpn to users

  Note: Server already has these fixes applied manually during troubleshooting.

  Notes to reviewer (Optional)

  VPN is currently working with these changes applied directly to the server. This PR captures those fixes in code.
