### PR TITLE
Add VPN users group membership and ignore security group ingress changes

### DIFF
--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -73,6 +73,11 @@ resource "aws_security_group" "webserver" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
+  # Ignore ingress changes while testing VPN
+  lifecycle {
+    ignore_changes = [ingress]
+  }
 }
 
 data "aws_security_group" "default" {
@@ -177,5 +182,10 @@ resource "aws_security_group" "planningalerts" {
     protocol         = "-1"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # Ignore ingress changes while testing VPN
+  lifecycle {
+    ignore_changes = [ingress]
   }
 }

--- a/terraform/vpn-iam.tf
+++ b/terraform/vpn-iam.tf
@@ -67,10 +67,11 @@ resource "aws_iam_group_membership" "vpn_users" {
   group = aws_iam_group.vpn_users.name
 
   users = [
-    "jon",
-    "ben",
-    "brenda",
-    "ian+oaf",
+    "jon.vpn",
+    "ben.vpn",
+    "brenda.vpn",
+    "ian.vpn",
+    "james.vpn",
   ]
 }
 


### PR DESCRIPTION
  ## Relevant issue(s)

  N/A - VPN testing in progress

  ## What does this do?

  - Updates `aws_iam_group_membership` for vpn-users group with correct IAM usernames: jon.vpn, ben.vpn, brenda.vpn, ian.vpn, james.vpn
  - Adds `lifecycle { ignore_changes = [ingress] }` to webserver and planningalerts security groups

  ## Why was this needed?

  - The VPN user names in terraform didn't match the actual IAM users (e.g., `jon` vs `jon.vpn`)
  - The lifecycle ignore prevents terraform from removing the manually-added VPN-only SSH rules while we're still testing the VPN setup

  ## Implementation/Deploy Steps (Optional)

  1. Run `terraform plan` to verify changes
  2. Run `terraform apply`

  ## Notes to reviewer (Optional)

  The lifecycle ignore_changes should be removed once VPN testing is complete and we're ready to lock down SSH access to VPN-only.