### PR TITLE
Update Metabase image version and add Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ check-theyvoteforyou: $(KEYSANDROLES)
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l theyvoteforyou --check --diff
 check-oaf: $(KEYSANDROLES)
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l oaf --check --diff
+check-metabase: $(KEYSANDROLES)
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l metabase --check --diff
 
 # These make changes 
 apply-righttoknow-all: $(KEYSANDROLES)
@@ -79,6 +81,8 @@ apply-theyvoteforyou: $(KEYSANDROLES)
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l theyvoteforyou
 apply-oaf: $(KEYSANDROLES)
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l oaf --diff
+apply-metabase: $(KEYSANDROLES)
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l metabase --diff
 
 # Update ssh keys on all servers
 update-github-ssh-keys: $(KEYSANDROLES)

--- a/roles/internal/metabase/templates/docker-compose.yml
+++ b/roles/internal/metabase/templates/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase:v0.56.x
+    image: metabase/metabase:v0.57.5.x
     # Using 8000 as the port on the host to be consistent with planningalerts
     ports:
       - 8000:3000


### PR DESCRIPTION
## Relevant issue(s)
Nil

## What does this do?
Updates the Metabase image version in the Docker Compose configuration.

## Why was this needed?
To ensure the application uses the latest features and fixes available in Metabase version v0.57.5.x.

## Implementation/Deploy Steps (Optional)
Need to run `make metabase-apply` once merged in order for the changes to apply.

## Notes to reviewer (Optional)
There may be issues with the size of the disk (this has happened previously). If this happens again, we will increase the disk size so that the upgrade can happen without issue.