### PR TITLE
Add explicit proxied = false to Cloudflare DNS records

### DIFF
--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -6,6 +6,7 @@ resource "cloudflare_record" "root" {
   name    = "oaf.org.au"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 # CNAME records
@@ -14,6 +15,7 @@ resource "cloudflare_record" "test" {
   name    = "test.oaf.org.au"
   type    = "CNAME"
   value   = "oaf.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "www" {
@@ -21,6 +23,7 @@ resource "cloudflare_record" "www" {
   name    = "www.oaf.org.au"
   type    = "CNAME"
   value   = "oaf.org.au"
+  proxied = false
 }
 
 # MX records
@@ -122,6 +125,7 @@ resource "cloudflare_record" "alt_root" {
   name    = "openaustraliafoundation.org.au"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 # CNAME records
@@ -130,6 +134,7 @@ resource "cloudflare_record" "alt_www" {
   name    = "www.openaustraliafoundation.org.au"
   type    = "CNAME"
   value   = "openaustraliafoundation.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "test_1" {

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -17,6 +17,7 @@ resource "cloudflare_record" "root" {
   name    = "openaustralia.org"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 # CNAME records
@@ -25,6 +26,7 @@ resource "cloudflare_record" "www" {
   name    = "www.openaustralia.org"
   type    = "CNAME"
   value   = "openaustralia.org"
+  proxied = false
 }
 
 resource "cloudflare_record" "test" {
@@ -32,6 +34,7 @@ resource "cloudflare_record" "test" {
   name    = "test.openaustralia.org"
   type    = "CNAME"
   value   = "openaustralia.org"
+  proxied = false
 }
 
 # TODO: This should point at oaf.org.au
@@ -40,6 +43,7 @@ resource "cloudflare_record" "blog" {
   name    = "blog.openaustralia.org"
   type    = "CNAME"
   value   = "openaustralia.org"
+  proxied = false
 }
 
 resource "cloudflare_record" "data" {
@@ -47,6 +51,7 @@ resource "cloudflare_record" "data" {
   name    = "data.openaustralia.org"
   type    = "CNAME"
   value   = "openaustralia.org"
+  proxied = false
 }
 
 resource "cloudflare_record" "software" {
@@ -54,6 +59,7 @@ resource "cloudflare_record" "software" {
   name    = "software.openaustralia.org"
   type    = "CNAME"
   value   = "openaustralia.org"
+  proxied = false
 }
 
 resource "cloudflare_record" "hackfest" {
@@ -125,6 +131,7 @@ resource "cloudflare_record" "alt_root" {
   name    = "openaustralia.org.au"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 # CNAME records
@@ -134,6 +141,7 @@ resource "cloudflare_record" "alt_www" {
   name    = "www.openaustralia.org.au"
   type    = "CNAME"
   value   = "openaustralia.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "alt_test" {
@@ -141,6 +149,7 @@ resource "cloudflare_record" "alt_test" {
   name    = "test.openaustralia.org.au"
   type    = "CNAME"
   value   = "openaustralia.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "alt_www_test" {
@@ -148,6 +157,7 @@ resource "cloudflare_record" "alt_www_test" {
   name    = "www.test.openaustralia.org.au"
   type    = "CNAME"
   value   = "openaustralia.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "alt_data" {
@@ -155,6 +165,7 @@ resource "cloudflare_record" "alt_data" {
   name    = "data.openaustralia.org.au"
   type    = "CNAME"
   value   = "openaustralia.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "alt_software" {
@@ -162,6 +173,7 @@ resource "cloudflare_record" "alt_software" {
   name    = "software.openaustralia.org.au"
   type    = "CNAME"
   value   = "openaustralia.org.au"
+  proxied = false
 }
 
 # MX records

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -31,6 +31,7 @@ resource "cloudflare_record" "root" {
   name    = "planningalerts.org.au"
   type    = "CNAME"
   value   = var.load_balancer.dns_name
+  proxied = false
 }
 
 resource "cloudflare_record" "www" {
@@ -38,6 +39,7 @@ resource "cloudflare_record" "www" {
   name    = "www.planningalerts.org.au"
   type    = "CNAME"
   value   = var.load_balancer.dns_name
+  proxied = false
 }
 
 resource "cloudflare_record" "api" {
@@ -45,6 +47,7 @@ resource "cloudflare_record" "api" {
   name    = "api.planningalerts.org.au"
   type    = "CNAME"
   value   = var.load_balancer.dns_name
+  proxied = false
 }
 
 resource "cloudflare_record" "email2" {

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -10,6 +10,7 @@ resource "cloudflare_record" "root" {
   name    = "righttoknow.org.au"
   type    = "A"
   value   = aws_eip.production.public_ip
+  proxied = false
 }
 
 resource "cloudflare_record" "production" {
@@ -17,6 +18,7 @@ resource "cloudflare_record" "production" {
   name    = "prod.righttoknow.org.au"
   type    = "A"
   value   = aws_eip.production.public_ip
+  proxied = false
 }
 
 
@@ -26,6 +28,7 @@ resource "cloudflare_record" "www" {
   name    = "www.righttoknow.org.au"
   type    = "CNAME"
   value   = "righttoknow.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "www_production" {
@@ -33,6 +36,7 @@ resource "cloudflare_record" "www_production" {
   name    = "www.prod.righttoknow.org.au"
   type    = "CNAME"
   value   = "prod.righttoknow.org.au"
+  proxied = false
 }
 
 # MX records
@@ -125,6 +129,7 @@ resource "cloudflare_record" "staging" {
   name    = "staging.righttoknow.org.au"
   type    = "A"
   value   = aws_eip.staging.public_ip
+  proxied = false
 }
 
 resource "cloudflare_record" "www_staging" {
@@ -132,6 +137,7 @@ resource "cloudflare_record" "www_staging" {
   name    = "www.staging.righttoknow.org.au"
   type    = "CNAME"
   value   = "staging.righttoknow.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "staging-spf" {

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -24,6 +24,7 @@ resource "cloudflare_record" "root" {
   name    = "theyvoteforyou.org.au"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 # CNAME records
@@ -33,6 +34,7 @@ resource "cloudflare_record" "www" {
   name    = "www.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "test" {
@@ -40,6 +42,7 @@ resource "cloudflare_record" "test" {
   name    = "test.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "www_test" {
@@ -47,6 +50,7 @@ resource "cloudflare_record" "www_test" {
   name    = "www.test.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
+  proxied = false
 }
 
 resource "cloudflare_record" "email" {
@@ -147,6 +151,7 @@ resource "cloudflare_record" "alt1_root" {
   name    = "theyvoteforyou.org"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 resource "cloudflare_record" "alt1_www" {
@@ -154,6 +159,7 @@ resource "cloudflare_record" "alt1_www" {
   name    = "www.theyvoteforyou.org"
   type    = "CNAME"
   value   = "theyvoteforyou.org"
+  proxied = false
 }
 
 # For the time being we're just using DMARC records to get some data on what's
@@ -176,6 +182,7 @@ resource "cloudflare_record" "alt2_root" {
   name    = "theyvoteforyou.com.au"
   type    = "A"
   value   = aws_eip.main.public_ip
+  proxied = false
 }
 
 resource "cloudflare_record" "alt2_www" {
@@ -183,6 +190,7 @@ resource "cloudflare_record" "alt2_www" {
   name    = "www.theyvoteforyou.com.au"
   type    = "CNAME"
   value   = "theyvoteforyou.com.au"
+  proxied = false
 }
 
 # For the time being we're just using DMARC records to get some data on what's


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/infrastructure/pull/316

## What does this do?

Adds explicit proxied = false to all web-facing A and CNAME records across 6 Cloudflare DNS terraform modules (36 records total).
This makes the proxy status explicit in code rather than relying on the implicit default.

## Why was this needed?
  Preparation for enabling Cloudflare proxy protection on AWS-hosted applications. By making the proxy setting explicit:

  1. The current DNS-only behavior is preserved (no infrastructure changes on apply)
  2. Enabling proxy for any app becomes a simple one-line change (false → true)
  3. Proxy status is now visible and auditable in code


## Implementation/Deploy Steps (Optional)

  1. terraform plan - Should show no changes (since proxied = false is already the default)
  2. terraform apply - Locks in the explicit state
  3. To enable proxy for a specific app later, change proxied = false to proxied = true for that app's records

## Notes to reviewer (Optional)

  - Records that should never be proxied were intentionally left unchanged (MX, TXT, email CNAMEs, external service CNAMEs)
  - electionleaflets/dns.tf was skipped as it already has proxied = true (using Cloudflare redirect rules)
  - When enabling proxy in the future, ensure SSL mode is set appropriately (Full Strict recommended) and origin servers have valid certs