### PR TITLE
Add per-database control for DMS replication

### DIFF
--- a/terraform/dms-migration.tf
+++ b/terraform/dms-migration.tf
@@ -1,5 +1,76 @@
 # DMS Migration Setup for MySQL 5.7 -> MySQL 8.0
 # Continuous replication during application migration period
+#
+# To disable replication for a specific database after migration:
+#   Set the corresponding dms_replicate_* variable to false in terraform.tfvars
+#   Then stop and restart the DMS task to apply the new table mappings
+#
+# Databases:
+#   - oa-production, oa-staging (OpenAustralia) - var.dms_replicate_openaustralia
+#   - tvfy-production, tvfy-staging (TheyVoteForYou) - var.dms_replicate_theyvoteforyou
+#   - oaf-production (OAF WordPress) - var.dms_replicate_oaf
+
+# Build the list of databases to replicate based on variables
+locals {
+  dms_replication_rules = concat(
+    var.dms_replicate_openaustralia ? [
+      {
+        rule-type = "selection"
+        rule-id   = "1"
+        rule-name = "replicate-openaustralia-production"
+        object-locator = {
+          schema-name = "oa-production"
+          table-name  = "%"
+        }
+        rule-action = "include"
+      },
+      {
+        rule-type = "selection"
+        rule-id   = "2"
+        rule-name = "replicate-openaustralia-staging"
+        object-locator = {
+          schema-name = "oa-staging"
+          table-name  = "%"
+        }
+        rule-action = "include"
+      }
+    ] : [],
+    var.dms_replicate_theyvoteforyou ? [
+      {
+        rule-type = "selection"
+        rule-id   = "3"
+        rule-name = "replicate-theyvoteforyou-production"
+        object-locator = {
+          schema-name = "tvfy-production"
+          table-name  = "%"
+        }
+        rule-action = "include"
+      },
+      {
+        rule-type = "selection"
+        rule-id   = "4"
+        rule-name = "replicate-theyvoteforyou-staging"
+        object-locator = {
+          schema-name = "tvfy-staging"
+          table-name  = "%"
+        }
+        rule-action = "include"
+      }
+    ] : [],
+    var.dms_replicate_oaf ? [
+      {
+        rule-type = "selection"
+        rule-id   = "5"
+        rule-name = "replicate-oaf-production"
+        object-locator = {
+          schema-name = "oaf-production"
+          table-name  = "%"
+        }
+        rule-action = "include"
+      }
+    ] : []
+  )
+}
 
 # DMS Subnet Group
 resource "aws_dms_replication_subnet_group" "main" {
@@ -129,18 +200,7 @@ resource "aws_dms_replication_task" "mysql_migration" {
   cdc_start_time = "2025-11-18T16:07:39"
 
   table_mappings = jsonencode({
-    rules = [
-      {
-        rule-type = "selection"
-        rule-id   = "1"
-        rule-name = "replicate-all-tables"
-        object-locator = {
-          schema-name = "%"
-          table-name  = "%"
-        }
-        rule-action = "include"
-      }
-    ]
+    rules = local.dms_replication_rules
   })
 
   replication_task_settings = jsonencode({

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -77,3 +77,23 @@ variable "ubuntu_24_ami" {
 variable "cloudflare_account_id" {
   default = "668e6ebb9952c26ec3c17a85fb3a25a1"
 }
+
+# DMS Migration settings - set to false to stop replicating a database
+# once an application has been migrated to MySQL 8
+variable "dms_replicate_openaustralia" {
+  description = "Enable DMS replication for oa-production and oa-staging databases"
+  type        = bool
+  default     = true
+}
+
+variable "dms_replicate_theyvoteforyou" {
+  description = "Enable DMS replication for tvfy-production and tvfy-staging databases"
+  type        = bool
+  default     = true
+}
+
+variable "dms_replicate_oaf" {
+  description = "Enable DMS replication for oaf-production database"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## What does this do?

  Switch DMS table mappings from wildcard (%) to explicit database names, allowing individual databases to be disabled as they migrate to MySQL 8.

  Variables added:
  - `dms_replicate_openaustralia` (oa-production, oa-staging)
  - `dms_replicate_theyvoteforyou` (tvfy-production, tvfy-staging)
  - `dms_replicate_oaf` (oaf-production)

  ## Why was this needed?

  We're migrating applications one-by-one to MySQL 8. Once an app is flipped to MySQL 8, we need to stop DMS from overwriting changes made directly to that database. This allows
  per-database control without affecting the other databases still being replicated.

  ## Implementation/Deploy Steps

  To disable replication for a migrated database:

  1. Set `dms_replicate_X = false` in terraform.tfvars
  2. Stop the task:
     ```bash
     aws dms stop-replication-task --replication-task-arn arn:aws:dms:ap-southeast-2:924104513718:task:SD2D5PRTQFGUNBTLIAA4YTDJUE --region ap-southeast-2
  3. Apply terraform:
  terraform apply -target=aws_dms_replication_task.mysql_migration
  4. Start the task:
  aws dms start-replication-task --replication-task-arn arn:aws:dms:ap-southeast-2:924104513718:task:SD2D5PRTQFGUNBTLIAA4YTDJUE --start-replication-task-type resume-processing
  --region ap-southeast-2

  Notes to reviewer

  - The terraform change has already been applied - DMS is now running with the explicit database list
  - CDC will resume from the binlog position when stopped/started, so no data loss
  - DDL changes (drops, truncates, alters) still replicate through, which is useful for cleanup