### PR TITLE
Add storage.yml to SHARED_FILES

### DIFF
--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -808,6 +808,7 @@ SHARED_FILES_PATH: '/srv/www/{{ stage }}/shared'
 SHARED_FILES:
   - config/database.yml
   - config/general.yml
+  - config/storage.yml
   - config/user_spam_scorer.yml
   - config/rails_env.rb
   - config/newrelic.yml


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Adds `storage.yml` to the `SHARED_FILES` list for proper symlink creation.

## Why was this needed?
Ensures that `storage.yml` is correctly symlinked in the shared configuration, which is essential for application functionality.

## Implementation/Deploy Steps
Run `make apply-righttoknow` to push the change across staging and production

## Notes to reviewer (Optional)
This change should have no impact until capistrano is run a second time.