### PR TITLE
Rtk backup exclude cache

### DIFF
--- a/roles/internal/oaf.backup/tasks/configure.yml
+++ b/roles/internal/oaf.backup/tasks/configure.yml
@@ -38,8 +38,18 @@
   with_items: "{{backup_profiles}}"
 
 - name: backup-configure | Create work directories
-  file: state=directory path={{backup_work}}/{{item.name}} owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}}  
+  file: state=directory path={{backup_work}}/{{item.name}} owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}}
   with_items: "{{backup_profiles}}"
+
+- name: backup-configure | Create temp directories
+  file: state=directory path={{item.temp_dir}} mode=0700 owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}}
+  with_items: "{{backup_profiles}}"
+  when: item.temp_dir is defined
+
+- name: backup-configure | Create archive directories
+  file: state=directory path={{item.arch_dir}} mode=0700 owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}}
+  with_items: "{{backup_profiles}}"
+  when: item.arch_dir is defined
 
 - name: backup-configure | Setup cron
   template: src=cron.j2 dest=/etc/cron.d/backup owner=root group=root mode=0644

--- a/roles/internal/oaf.backup/templates/conf.j2
+++ b/roles/internal/oaf.backup/templates/conf.j2
@@ -71,7 +71,15 @@ DUPL_PARAMS="$DUPL_PARAMS --volsize $VOLSIZE "
 
 # temporary file space. at least the size of the biggest file in backup
 # for a successful restoration process. (default is '/tmp', if not set)
-#TEMP_DIR=/tmp
+{% if item.temp_dir|default(backup_temp_dir)|default(None) %}
+TEMP_DIR={{ item.temp_dir|default(backup_temp_dir) }}
+{% endif %}
+
+# Archive directory for duplicity cache (signatures, manifests)
+# Use this to move cache off root filesystem for large backups
+{% if item.arch_dir|default(backup_arch_dir)|default(None) %}
+ARCH_DIR={{ item.arch_dir|default(backup_arch_dir) }}
+{% endif %}
 
 # more duplicity command line options can be added in the following way
 # don't forget to leave a separating space char at the end

--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -140,6 +140,9 @@ dependencies:
         target: "s3://s3.amazonaws.com/oaf-backups/righttoknow/{{ inventory_hostname }}/data"
         exclude:
           - "**/bundle"
+        # Use /data volume for temp/cache to avoid filling root filesystem during full backups
+        temp_dir: /data/backup_tmp
+        arch_dir: /data/backup_cache
     when: ansible_distribution_release in ['bionic', 'jammy'] and 'righttoknow_production' in group_names
     
   - role: nickhammond.logrotate

--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -140,6 +140,7 @@ dependencies:
         target: "s3://s3.amazonaws.com/oaf-backups/righttoknow/{{ inventory_hostname }}/data"
         exclude:
           - "**/bundle"
+          - "**/cache"
         # Use /data volume for temp/cache to avoid filling root filesystem during full backups
         temp_dir: /data/backup_tmp
         arch_dir: /data/backup_cache


### PR DESCRIPTION
  What does this do?                                                                                                                                 
                                                                                                                                                     
  Adds **/cache to the backup exclusion list for Right to Know, alongside the existing **/bundle exclusion.                                          
                                                                                                                                                     
  Why was this needed?                                                                                                                               
                                                                                                                                                     
  The cache directory doesn't need to be backed up - it contains regeneratable data. Excluding it reduces backup size and duration.                  
                                                                                                                                                     
  Implementation/Deploy Steps (Optional)                                                                                                             
                                                                                                                                                     
  Already deployed and verified working. Today's backup (Dec 18) completed successfully with the exclusion in place.                                 
                                                                                                                                                     
  Notes to reviewer (Optional)                                                                                                                       
                                                                                                                                                     
  The temp_dir and arch_dir changes to use /data were already committed in the rtk-backup-temp-dir branch - this PR just adds the cache exclusion    
  that was deployed but not yet in version control. 