### PR TITLE
Update RTK Role to use "storage" folder exclusively

### DIFF
--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -55,7 +55,7 @@
     state: directory
   with_nested:
     - "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
-    - ['files', 'cache', 'bundle', 'storage', 'xapiandbs']
+    - ['cache', 'bundle', 'storage', 'xapiandbs']
 
 - name: Ensure that deploy owns application directories
   file:
@@ -74,7 +74,7 @@
     dest: "/srv/www/{{ item[0] }}/shared/{{ item[1] }}"
   with_nested:
     - "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
-    - ['files', 'cache', 'bundle', 'storage', 'xapiandbs']
+    - ['cache', 'bundle', 'storage', 'xapiandbs']
 
 - name: Set the ruby version for the alaveteli deploy (production)
   copy:


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Removes the "files" folder from the RTK Role configuration.

## Why was this needed?
We no longer use "files" but "storage" instead. Removing "files" folder ensures that it isn't created by accident.

It also resolves an error when running `make check-righttoknow-all` which was failing.

## Implementation/Deploy Steps (Optional)
- Nil

## Notes to reviewer (Optional)
- This change is already in production and the change exists to prevent the folder from being recreated.