### PR TITLE
stop replicating the OAF blog

### DIFF
--- a/terraform/dms-migration.tf
+++ b/terraform/dms-migration.tf
@@ -57,18 +57,18 @@ locals {
         rule-action = "include"
       }
     ] : [],
-    var.dms_replicate_oaf ? [
-      {
-        rule-type = "selection"
-        rule-id   = "5"
-        rule-name = "replicate-oaf-production"
-        object-locator = {
-          schema-name = "oaf-production"
-          table-name  = "%"
-        }
-        rule-action = "include"
-      }
-    ] : []
+    # var.dms_replicate_oaf ? [
+    #   {
+    #     rule-type = "selection"
+    #     rule-id   = "5"
+    #     rule-name = "replicate-oaf-production"
+    #     object-locator = {
+    #       schema-name = "oaf-production"
+    #       table-name  = "%"
+    #     }
+    #     rule-action = "include"
+    #   }
+    # ] : []
   )
 }
 

--- a/terraform/dms-migration.tf
+++ b/terraform/dms-migration.tf
@@ -56,7 +56,7 @@ locals {
         }
         rule-action = "include"
       }
-    ] : [],
+    ] : []
     # var.dms_replicate_oaf ? [
     #   {
     #     rule-type = "selection"


### PR DESCRIPTION
We're not migrating this to MySQL 8. Instead we're moving to wordpress.com