### PR TITLE
Update DNS Records for oaf.org.au and openaustraliafoundation.org.au

### DIFF
--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -1,23 +1,23 @@
 
 ## oaf.org.au
 # A records
-resource "cloudflare_record" "root" {
+resource "cloudflare_record" "root_primary" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"
   type    = "A"
-  value   = aws_eip.main.public_ip
+  value   = "192.0.78.154"
+  proxied = false
+}
+
+resource "cloudflare_record" "root_secondary" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "oaf.org.au"
+  type    = "A"
+  value   = "192.0.78.197"
   proxied = false
 }
 
 # CNAME records
-resource "cloudflare_record" "test" {
-  zone_id = var.oaf_org_au_zone_id
-  name    = "test.oaf.org.au"
-  type    = "CNAME"
-  value   = "oaf.org.au"
-  proxied = false
-}
-
 resource "cloudflare_record" "www" {
   zone_id = var.oaf_org_au_zone_id
   name    = "www.oaf.org.au"
@@ -27,8 +27,6 @@ resource "cloudflare_record" "www" {
 }
 
 # MX records
-
-# We can now use a single MX record for Google workspace
 resource "cloudflare_record" "mx" {
   zone_id  = var.oaf_org_au_zone_id
   name     = "oaf.org.au"
@@ -120,11 +118,19 @@ resource "cloudflare_record" "dmarc" {
 
 # A records
 
-resource "cloudflare_record" "alt_root" {
+resource "cloudflare_record" "alt_root_primary" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "openaustraliafoundation.org.au"
   type    = "A"
-  value   = aws_eip.main.public_ip
+  value   = "192.0.78.177"
+  proxied = false
+}
+
+resource "cloudflare_record" "alt_root_secondary" {
+  zone_id = var.openaustraliafoundation_org_au_zone_id
+  name    = "openaustraliafoundation.org.au"
+  type    = "A"
+  value   = "192.0.78.220"
   proxied = false
 }
 
@@ -137,30 +143,7 @@ resource "cloudflare_record" "alt_www" {
   proxied = false
 }
 
-resource "cloudflare_record" "test_1" {
-  zone_id = var.openaustraliafoundation_org_au_zone_id
-  name    = "test.openaustraliafoundation.org.au"
-  type    = "A"
-  value   = "192.0.78.151"
-}
-
-resource "cloudflare_record" "test_2" {
-  zone_id = var.openaustraliafoundation_org_au_zone_id
-  name    = "test.openaustraliafoundation.org.au"
-  type    = "A"
-  value   = "192.0.78.202"
-}
-
-resource "cloudflare_record" "www_test_cname" {
-  zone_id = var.openaustraliafoundation_org_au_zone_id
-  name    = "www.test"
-  type    = "CNAME"
-  value   = "test.oaf.org.au"
-}
-
 # MX records
-
-# We can now use a single MX record for Google workspace
 resource "cloudflare_record" "alt_mx" {
   zone_id  = var.openaustraliafoundation_org_au_zone_id
   name     = "openaustraliafoundation.org.au"

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -5,7 +5,7 @@ resource "cloudflare_record" "root_primary" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"
   type    = "A"
-  value   = "192.0.78.154"
+  value   = "192.0.78.154" # hosted on wordpress.com
   proxied = false
 }
 
@@ -13,7 +13,7 @@ resource "cloudflare_record" "root_secondary" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"
   type    = "A"
-  value   = "192.0.78.197"
+  value   = "192.0.78.197" # hosted on wordpress.com
   proxied = false
 }
 
@@ -122,7 +122,7 @@ resource "cloudflare_record" "alt_root_primary" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "openaustraliafoundation.org.au"
   type    = "A"
-  value   = "192.0.78.177"
+  value   = "192.0.78.177" # hosted on wordpress.com
   proxied = false
 }
 
@@ -130,7 +130,7 @@ resource "cloudflare_record" "alt_root_secondary" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "openaustraliafoundation.org.au"
   type    = "A"
-  value   = "192.0.78.220"
+  value   = "192.0.78.220" # hosted on wordpress.com
   proxied = false
 }
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Updates DNS records for oaf.org.au and openaustraliafoundation.org.au to point to specific IP addresses.

## Why was this needed?
To ensure that the domains correctly resolve to the new WordPress.com instance.

## Implementation/Deploy Steps (Optional)
These have already been applied into production. No implementation required.

## Notes to reviewer (Optional)
N/A