### PR TITLE
Update logrotate configuration to use systemctl for rsyslog restart

### DIFF
--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -178,7 +178,7 @@ dependencies:
           - compress
           - delaycompress
           - sharedscripts
-          - postrotate reload rsyslog >/dev/null 2>&1 || true
+          - postrotate systemctl restart rsyslog >/dev/null 2>&1 || true
           - endscript
       - name: production
         path: "/srv/www/production/shared/log/*.log"


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Updates the logrotate configuration to restart rsyslog using systemctl instead of the previous method.

## Why was this needed?
At the moment, the current setup doesn't restart rsyslog correctly which results in files not being written to the correct day.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

