### PR TITLE
Update Nginx Deny list to block SQL Injection attempts

### DIFF
--- a/roles/internal/righttoknow/templates/nginx/stage
+++ b/roles/internal/righttoknow/templates/nginx/stage
@@ -98,6 +98,9 @@ server {
 
   location / {
 
+    # Deny IP Address that is attempting to perform SQL Injection
+    deny 144.31.1.0/24
+    
     # Block overly aggressive bot that isn't giving a sensible user agent
     deny 47.76.0.0/16;
     deny 47.242.0.0/16;

--- a/roles/internal/righttoknow/templates/nginx/stage
+++ b/roles/internal/righttoknow/templates/nginx/stage
@@ -99,7 +99,7 @@ server {
   location / {
 
     # Deny IP Address that is attempting to perform SQL Injection
-    deny 144.31.1.0/24
+    deny 144.31.1.0/24;
     
     # Block overly aggressive bot that isn't giving a sensible user agent
     deny 47.76.0.0/16;


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
Updates the Nginx configuration to deny access from an IP address associated with SQL injection attempts.

## Why was this needed?
We received numerous alerts that this IP address was attempting to perform SQL injection using the search function in Right to Know.

## Implementation/Deploy Steps (Optional)
This has already been deployed as an emergency change

## Notes to reviewer (Optional)
This was affecting production hence the change was deployed urgently.