### PR TITLE
adding a new server for running soon-to-be-upgraded openaustralia.org.au

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,6 +100,7 @@ module "openaustralia" {
   security_group_service   = aws_security_group.openaustralia
   instance_profile         = aws_iam_instance_profile.logging
   ami                      = var.ubuntu_16_ami
+  ubuntu_24_ami            = var.ubuntu_24_ami
   cloudflare_account_id    = var.cloudflare_account_id
 }
 

--- a/terraform/openaustralia/main.tf
+++ b/terraform/openaustralia/main.tf
@@ -10,8 +10,21 @@ terraform {
 resource "aws_instance" "main" {
   ami = var.ami
 
-  # Running sitemap generation (a ruby process, suprise, surprise) pegged the
-  # memory usage on a t2.small. So, upping to a t2.medium.
+  instance_type = "t3.small"
+  ebs_optimized = true
+  key_name      = "test"
+  tags = {
+    Name = "openaustralia"
+  }
+  vpc_security_group_ids  = [var.security_group_webserver.id, var.security_group_service.id]
+  availability_zone       = aws_ebs_volume.data.availability_zone
+  disable_api_termination = true
+  iam_instance_profile    = var.instance_profile.name
+}
+
+resource "aws_instance" "main2026" {
+  ami = var.ami
+
   instance_type = "t3.small"
   ebs_optimized = true
   key_name      = "test"

--- a/terraform/openaustralia/main.tf
+++ b/terraform/openaustralia/main.tf
@@ -22,21 +22,6 @@ resource "aws_instance" "main" {
   iam_instance_profile    = var.instance_profile.name
 }
 
-resource "aws_instance" "main2026" {
-  ami = var.ami
-
-  instance_type = "t3.small"
-  ebs_optimized = true
-  key_name      = "test"
-  tags = {
-    Name = "openaustralia"
-  }
-  vpc_security_group_ids  = [var.security_group_webserver.id, var.security_group_service.id]
-  availability_zone       = aws_ebs_volume.data.availability_zone
-  disable_api_termination = true
-  iam_instance_profile    = var.instance_profile.name
-}
-
 resource "aws_eip" "main" {
   instance = aws_instance.main.id
   tags = {

--- a/terraform/openaustralia/production.tf
+++ b/terraform/openaustralia/production.tf
@@ -1,0 +1,53 @@
+# New OpenAustralia Production Server on Ubuntu 24.04
+# This creates a parallel production environment for OpenAustralia
+
+resource "aws_instance" "production" {
+  ami = var.ubuntu_24_ami
+
+  instance_type = "t3.small"
+  ebs_optimized = true
+  key_name      = "test"
+  tags = {
+    Name = "openaustralia"
+  }
+
+  # Increase root volume size to 20GB to allow for more packages and data
+  root_block_device {
+    volume_size = 20
+  }
+
+  vpc_security_group_ids  = [var.security_group_webserver.id, var.security_group_service.id]
+  availability_zone       = aws_ebs_volume.data.availability_zone
+  disable_api_termination = true
+  iam_instance_profile    = var.instance_profile.name
+}
+
+resource "aws_eip" "production" {
+  instance = aws_instance.production.id
+  tags = {
+    Name = "openaustralia-prod"
+  }
+}
+
+# We'll create a seperate EBS volume for all the application
+# data that can not be regenerated. e.g. parliamentary XML,
+# register of members interests scans, etc..
+
+resource "aws_ebs_volume" "production_data" {
+  availability_zone = "ap-southeast-2c"
+
+  # 10 Gb is an educated guess based on seeing how much space is taken up
+  # on kedumba.
+  # After loading real data in we upped it to 20GB
+  size = 20
+  type = "gp3"
+  tags = {
+    Name = "openaustralia_data"
+  }
+}
+
+resource "aws_volume_attachment" "production_data" {
+  device_name = "/dev/sdh"
+  volume_id   = aws_ebs_volume.production_data.id
+  instance_id = aws_instance.production.id
+}

--- a/terraform/openaustralia/variables.tf
+++ b/terraform/openaustralia/variables.tf
@@ -3,3 +3,4 @@ variable "security_group_service" {}
 variable "instance_profile" {}
 variable "ami" {}
 variable "cloudflare_account_id" {}
+variable "ubuntu_24_ami" {}


### PR DESCRIPTION
## Relevant issue(s)
to get openaustralia.org.au to connect to mysql8, it needs upgrading to php7 or php8
The PHP 7 on the current 16.04 server doesn't support modern password auth that MySQL 8 in AWS RDS demands. 
## What does this do?
This shaves one yak. Specifically it gives us a new server to put staging on, and php8, and connect to MySQL8

The PHP upgrade is underway here:
https://github.com/openaustralia/twfy/pull/44

## Why was this needed?
The code is 19 years old. It's time.
