### PR TITLE
Add staging DNS records for OpenAustralia

### DIFF
--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -20,6 +20,14 @@ resource "cloudflare_record" "root" {
   proxied = false
 }
 
+resource "cloudflare_record" "root_staging" {
+  zone_id = cloudflare_zone.org.id
+  name    = "staging.openaustralia.org"
+  type    = "A"
+  value   = aws_eip.production.public_ip
+  proxied = false
+}
+
 # CNAME records
 resource "cloudflare_record" "www" {
   zone_id = cloudflare_zone.org.id
@@ -133,6 +141,15 @@ resource "cloudflare_record" "alt_root" {
   value   = aws_eip.main.public_ip
   proxied = false
 }
+
+resource "cloudflare_record" "alt_root_staging" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "staging.openaustralia.org.au"
+  type    = "A"
+  value   = aws_eip.production.public_ip
+  proxied = false
+}
+
 
 # CNAME records
 

--- a/terraform/openaustralia/production.tf
+++ b/terraform/openaustralia/production.tf
@@ -1,6 +1,8 @@
 # New OpenAustralia Production Server on Ubuntu 24.04
 # This creates a parallel production environment for OpenAustralia
 
+# After discussion with Brenda, this new server will house both staging and production.
+
 resource "aws_instance" "production" {
   ami = var.ubuntu_24_ami
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Adds DNS records for a staging environment for OpenAustralia:
- staging.openaustralia.org
- staging.openaustralia.org.au

## Why was this needed?
Brenda needs the DNS configured for her new server

## Implementation/Deploy Steps (Optional)
- Run `make tf-apply` and approve the changes

## Notes to reviewer (Optional)
There is a reference to the DMS Replication rule that will also be changed - I don't think this is an issue as the deletion/addition is the same.
