### PR TITLE
Upgrade Metabase image to version 0.58.x

### DIFF
--- a/roles/internal/metabase/templates/docker-compose.yml
+++ b/roles/internal/metabase/templates/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   metabase:
-    image: metabase/metabase:v0.57.5.x
+    image: metabase/metabase:v0.58.x
     # Using 8000 as the port on the host to be consistent with planningalerts
     ports:
       - 8000:3000


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
Upgrades the Metabase Docker image to version 0.58.x in the docker-compose configuration.

## Why was this needed?
This update ensures the use of the latest features and improvements available in Metabase.

## Implementation/Deploy Steps (Optional)
Run `make apply-metabase`

## Notes to reviewer (Optional)
This is a routine upgrade to Metabase.