### PR TITLE
Update MySQL engine version to full version string

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "main" {
   # Using general purpose SSD
   storage_type   = "gp2"
   engine         = "mysql"
-  engine_version = "5.7.44"
+  engine_version = "5.7.44-rds.20250508"
 
   # We can't currently upgrade to the graviton instance type because we're on an
   # older version of mysql


### PR DESCRIPTION
## Relevant issue(s)
- N/A 

## What does this do?
- Updates the MySQL engine version to include the full version string.

## Why was this needed?
- Required to ensure that Terraform continues to run without error messages

## Implementation/Deploy Steps (Optional)
- None required - this change is pulling from the current configuraiton in the cloud.

## Notes to reviewer (Optional)
@Br3nda this will fix the issues we were discussing on Slack