### PR TITLE
Update DMARC and SPF records for multiple domains

### DIFF
--- a/terraform/cuttlefish/outputs.tf
+++ b/terraform/cuttlefish/outputs.tf
@@ -1,0 +1,10 @@
+# Output cuttlefish server details
+output "ipv4_address" {
+  value       = linode_instance.main.ip_address
+  description = "IPv4 address of the cuttlefish server"
+}
+
+output "ipv6_address" {
+  value       = cidrhost(linode_instance.main.ipv6, 0)
+  description = "IPv6 address of the cuttlefish server"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,12 +63,6 @@ module "morph" {
   cloudflare_account_id = var.cloudflare_account_id
 }
 
-module "oaf" {
-  source                                 = "./oaf"
-  oaf_org_au_zone_id                     = cloudflare_zone.oaf_org_au.id
-  openaustraliafoundation_org_au_zone_id = cloudflare_zone.openaustraliafoundation_org_au.id
-}
-
 module "metabase" {
   source                   = "./metabase"
   security_group_behind_lb = aws_security_group.planningalerts
@@ -102,6 +96,17 @@ module "openaustralia" {
   ami                      = var.ubuntu_16_ami
   ubuntu_24_ami            = var.ubuntu_24_ami
   cloudflare_account_id    = var.cloudflare_account_id
+}
+
+module "oaf" {
+  source                                 = "./oaf"
+  oaf_org_au_zone_id                     = cloudflare_zone.oaf_org_au.id
+  openaustraliafoundation_org_au_zone_id = cloudflare_zone.openaustraliafoundation_org_au.id
+  openaustralia_main_ip                  = module.openaustralia.main_public_ip
+  openaustralia_production_ip            = module.openaustralia.production_public_ip
+  righttoknow_production_ip              = module.righttoknow.production_public_ip
+  righttoknow_staging_ip                 = module.righttoknow.staging_public_ip
+  cuttlefish_ip                          = module.cuttlefish.ipv4_address
 }
 
 # module "opengovernment" {

--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -111,17 +111,16 @@ resource "cloudflare_record" "google_domainkey" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuVyV09pmp6w9YCOWQ9+2p/xe6w7mbZYgg0v4d+51GSoVrQNwp5RERtg76xhl3pbHSLVmtQyfdavLZN/r38/b3NS7E9AsD3dOUIa1iy60YklKVgcWr5eMIviL3E9FXqyQBULoffTWDj69Q/uVsmZmD1VFDICzEctlgKLs9cdtky4kssQQOfJ2KVMfa/GNCorF628jeHiqB6A2UsP/RQ40VVDunDatWO/0mmwHSRJSB61RSro2dYqzo8lzKOBWxnZDxkDO13Dg41VAlOReu4qDRn1MbCj3T79Ur1I6GJj09Em/va/VD4qKJPPt+lW7fKPqVlQ1RqEtSJUGMmiSEKlbYwIDAQAB"
 }
 
-# For the time being we're just using DMARC records to get some data on what's
-# happening with email that we're sending (and whether anyone else is impersonating
-# us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
+# DMARC record for email authentication and reporting
+# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
+# Suped provides ongoing monitoring and analysis
+# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to webmaster@morph.io
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.morph.io"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+yuyhziqptlw@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+yuyhziqptlw@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 # CAA records

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -40,7 +40,7 @@ resource "cloudflare_record" "spf" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "google_site_verification" {
@@ -171,7 +171,7 @@ resource "cloudflare_record" "alt_spf" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "openaustraliafoundation.org.au"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "alt_google_site_verification" {

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -113,6 +113,21 @@ resource "cloudflare_record" "dmarc" {
   value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
+# SPF include record containing all A records for OAF services
+# This is used by other domains via "include:_spf1.oaf.org.au"
+# Dynamically includes IPs from:
+# - oaf.org.au (WordPress.com hosted)
+# - openaustraliafoundation.org.au (WordPress.com hosted)
+# - openaustralia.org / openaustralia.org.au (main and production servers)
+# - righttoknow.org.au (production and staging)
+# - cuttlefish.oaf.org.au
+resource "cloudflare_record" "spf_include" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "_spf1.oaf.org.au"
+  type    = "TXT"
+  value   = "v=spf1 ip4:192.0.78.154 ip4:192.0.78.197 ip4:192.0.78.177 ip4:192.0.78.220 ip4:${var.openaustralia_main_ip} ip4:${var.openaustralia_production_ip} ip4:${var.righttoknow_production_ip} ip4:${var.righttoknow_staging_ip} ip4:${var.cuttlefish_ip} -all"
+}
+
 ## openaustraliafoundation.org.au
 
 # A records

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -101,17 +101,16 @@ resource "cloudflare_record" "domainkey_cuttlefish" {
   value = "k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7fLXgEr26+qIswukULxl1OIPfz2CZ1iPcy4+LsveWZKGi1mU4jcy2vregS8FOm1B/V2nI354jBxlEi4XLxElcThq7zrFcDLXPNkrCg7yyPCF3qBnISlWDF/EwB0wOE1VF3QcwcILdR9vzRHP2yo0uTkz+stZpzVgthfM4FAOd5vDQ+cYxCwKTtXyCBUHH+/c2KUYnKiAOEXmuOUfwdo7uAPdClyg8mPAqYzjEQtPlktulD3rLQp3bom5lkGVLzklfiD77JVK1PD1a9C2OItG55KYbie3EPrXLkecGMob1ulhvz7ml/bSx3bqDUcbelnVLlT9VjeRiEUWoSYzJxXoMwIDAQAB"
 }
 
-# For the time being we're just using DMARC records to get some data on what's
-# happening with email that we're sending (and whether anyone else is impersonating
-# us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
+# DMARC record for email authentication and reporting
+# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
+# Suped provides ongoing monitoring and analysis
+# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to webmaster@oaf.org.au
 resource "cloudflare_record" "dmarc" {
   zone_id = var.oaf_org_au_zone_id
   name    = "_dmarc.oaf.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 ## openaustraliafoundation.org.au

--- a/terraform/oaf/variables.tf
+++ b/terraform/oaf/variables.tf
@@ -1,2 +1,17 @@
 variable "oaf_org_au_zone_id" {}
 variable "openaustraliafoundation_org_au_zone_id" {}
+variable "openaustralia_main_ip" {
+  description = "Public IP address of the main openaustralia server"
+}
+variable "openaustralia_production_ip" {
+  description = "Public IP address of the production openaustralia server"
+}
+variable "righttoknow_production_ip" {
+  description = "Public IP address of the righttoknow production server"
+}
+variable "righttoknow_staging_ip" {
+  description = "Public IP address of the righttoknow staging server"
+}
+variable "cuttlefish_ip" {
+  description = "IPv4 address of the cuttlefish server"
+}

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -93,7 +93,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.org.id
   name    = "openaustralia.org"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 # TODO: Remove this once the one below is up and running
@@ -209,7 +209,7 @@ resource "cloudflare_record" "alt_spf" {
   zone_id = cloudflare_zone.org_au.id
   name    = "openaustralia.org.au"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "alt_google_site_verification" {

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -233,15 +233,14 @@ resource "cloudflare_record" "alt_domainkey_google" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlL0dk9aaopGcbFKfugmxVqdUKCnpYTrnQj0Sz6RW1a+kFK44snSraBdMe6B14mvfUH1xkIuEiuKKWYIkYq5FHHZYcszVwt66FieU6HTaOvMNwDuXEJgU2zMIvGsUNiDO87CiEMZf0KhqyTrXIldVO/d9A5U7iZRy4poIKOQlm6NNEk6brfUXHct9S/Z4H6dlaowxUdjIp37838/U0AVTDiYYbSDrv2w60e1zTZy1y/9YXEGPlDpue4ijjJz1tjvJtS6cxfKT8elmXEOAo5j45K8NONJ4bEGNmTJxPMQwox0gBFwXwrf7pd4uYUpJW6GH9/vx7AW/jZe0SafCV/f0NQIDAQAB"
 }
 
-# For the time being we're just using DMARC records to get some data on what's
-# happening with email that we're sending (and whether anyone else is impersonating
-# us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
+# DMARC record for email authentication and reporting
+# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
+# Suped provides ongoing monitoring and analysis
+# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to webmaster@openaustralia.org.au
 resource "cloudflare_record" "alt_dmarc" {
   zone_id = cloudflare_zone.org_au.id
   name    = "_dmarc.openaustralia.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+no6xy3wrymr@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+no6xy3wrymr@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }

--- a/terraform/openaustralia/outputs.tf
+++ b/terraform/openaustralia/outputs.tf
@@ -1,0 +1,10 @@
+# Output main server details
+output "main_public_ip" {
+  value       = aws_eip.main.public_ip
+  description = "Public IP address of the main openaustralia server"
+}
+
+output "production_public_ip" {
+  value       = aws_eip.production.public_ip
+  description = "Public IP address of the production openaustralia server"
+}

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -120,15 +120,14 @@ resource "cloudflare_record" "domainkey_google" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkUq+EPS6XemyHdVi5CCW7+M+X1XMrAg85Y2oYEUYVcB2IU+1HF/fGUdY9w8wvphSC/28wznJOOTl92pj6/DvwRcfpogRrjITYmPZQMOC0SQ4/4nOeL5ug6fNWFg74LZQvQJqWGAQuUhiSiwxUpkUHAv6H5iE/EKDVOdeWjPWjsIkoAC5HdAie0WCcq3gDlfDJZ3L6K7/nGorPd96764EYG/pdsN43/jzcU23vVGJlhw9my1jvkxNnMS1xRkUuk/JcCIRWp4RkgQOkK7JEoNXB2u+bgW+8mLlGX66dag2l67CR+qzOuE1nHcOu5ADLqVh42MOTNMhw75TzugEbtn0QQIDAQAB"
 }
 
-# For the time being we're just using DMARC records to get some data on what's
-# happening with email that we're sending (and whether anyone else is impersonating
-# us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
+# DMARC record for email authentication and reporting
+# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
+# Suped provides ongoing monitoring and analysis
+# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to contact@oaf.org.au
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.planningalerts.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+b1g0fn6boqu@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+b1g0fn6boqu@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -64,7 +64,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.main.id
   name    = "righttoknow.org.au"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "google_site_verification" {
@@ -146,7 +146,7 @@ resource "cloudflare_record" "staging-spf" {
   zone_id = cloudflare_zone.main.id
   name    = "staging.righttoknow.org.au"
   type    = "TXT"
-  value   = "v=spf1 a include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
 resource "cloudflare_record" "staging-mx" {

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -113,14 +113,16 @@ resource "cloudflare_record" "google_domainkey" {
 }
 
 ## 2024-09-02 - Set DMARC to quarantine emails that don't meet the DMARC requirements.
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
+# DMARC record for email authentication and reporting
+# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
+# Suped provides ongoing monitoring and analysis
+# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
 # Report goes to webmaster@righttoknow.org.au
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.righttoknow.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=quarantine; rua=mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; sp=none; pct=100; aspf=r;"
+  value   = "v=DMARC1; p=quarantine; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 # Staging environment DNS records


### PR DESCRIPTION
## Relevant issue(s)
- Nil

## What does this do?
This update modifies DMARC and SPF records for morph, oaf, openaustralia, planningalerts, and righttoknow.

This includes adding new outputs for server IP addresses and relocating the oaf module to incorporate IP addresses from other modules.

## Why was this needed?
This change aims to enhance email deliverability and monitoring capabilities.

It also facilitates a trial with Suped to monitor email performance.

## Implementation/Deploy Steps (Optional)
- Run 'make tf-plan' to check changes
- Run 'make tf-apply' to apply configuration 

## Notes to reviewer (Optional)
- N/A
