### PR TITLE
Update Ruby version logic and add Sidekiq configuration for staging

### DIFF
--- a/roles/internal/righttoknow/handlers/main.yml
+++ b/roles/internal/righttoknow/handlers/main.yml
@@ -26,3 +26,9 @@
   service:
     name: opendkim
     state: restarted
+
+- name: restart sidekiq
+  systemd:
+    name: sidekiq
+    daemon_reload: yes
+    state: restarted

--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -125,7 +125,7 @@ dependencies:
     rbenv:
       env: user
       version: v1.1.2
-      default_ruby: "{{ ruby_version_production }}"
+      default_ruby: "{{ ruby_version_staging if 'righttoknow_staging' in group_names else ruby_version_production }}"
       rubies:
         - version: "{{ ruby_version_staging }}"
         - version: "{{ ruby_version_production }}"

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -182,6 +182,28 @@
   when: "'righttoknow_staging' in group_names"
   tags: redis
 
+- name: Install sidekiq systemd unit (staging)
+  template:
+    src: sidekiq.service
+    dest: /etc/systemd/system/sidekiq.service
+    mode: "0644"
+  vars:
+    sidekiq_daemon_name: "sidekiq (staging)"
+    sidekiq_user: deploy
+    sidekiq_vhost_dir: /srv/www
+    sidekiq_vcspath: staging/current
+    sidekiq_rails_env: production
+  when: "'righttoknow_staging' in group_names"
+  notify: restart sidekiq
+
+- name: Enable and start sidekiq (staging)
+  systemd:
+    name: sidekiq
+    enabled: yes
+    state: started
+    daemon_reload: yes
+  when: "'righttoknow_staging' in group_names"
+
 # The changes of there being differences between the production and staging version
 # of this script are extremely small. So, just using the production version.
 # This is used in cron jobs

--- a/roles/internal/righttoknow/templates/sidekiq.service
+++ b/roles/internal/righttoknow/templates/sidekiq.service
@@ -1,0 +1,21 @@
+[Unit]
+Description={{ sidekiq_daemon_name }}
+After=syslog.target network.target
+
+[Service]
+Type=notify
+WatchdogSec=10
+
+User={{ sidekiq_user }}
+Group={{ sidekiq_user }}
+UMask=0002
+
+WorkingDirectory={{ sidekiq_vhost_dir }}/{{ sidekiq_vcspath }}
+
+ExecStart=/bin/bash -lc 'bundle exec sidekiq -e {{ sidekiq_rails_env }}'
+
+RestartSec=1
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/righttoknow/issues/974
- https://github.com/openaustralia/infrastructure/issues/310

## What does this do?
- Ensures the correct ruby is configured on staging servers
- Creates the Sidekiq service

## Why was this needed?
- Sidekiq is required for Alaveteli 0.43.2.1
- We can use different versions of Ruby in production vs staging, so we need to make sure the right version is set as default. 

## Implementation/Deploy Steps (Optional)
- `make apply-righttoknow-staging`

## Notes to reviewer (Optional)
- Changes have already been implemented