### PR TITLE
Update DMARC and SPF records for multiple services

### DIFF
--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -79,7 +79,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.main.id
   name    = "morph.io"
   type    = "TXT"
-  value   = "v=spf1 include:_spf.google.com -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com -all"
 }
 
 resource "cloudflare_record" "google_site_verification" {

--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -120,7 +120,7 @@ resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.morph.io"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+yuyhziqptlw@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+yuyhziqptlw@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 # CAA records

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -110,7 +110,7 @@ resource "cloudflare_record" "dmarc" {
   zone_id = var.oaf_org_au_zone_id
   name    = "_dmarc.oaf.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 # SPF include record containing all A records for OAF services

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -242,5 +242,5 @@ resource "cloudflare_record" "alt_dmarc" {
   zone_id = cloudflare_zone.org_au.id
   name    = "_dmarc.openaustralia.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+no6xy3wrymr@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+no6xy3wrymr@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -81,7 +81,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.main.id
   name    = "planningalerts.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf.google.com a:cuttlefish.oaf.org.au  -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com a:cuttlefish.oaf.org.au -all"
 }
 
 resource "cloudflare_record" "google_site_verification" {

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -129,5 +129,5 @@ resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.planningalerts.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+b1g0fn6boqu@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+b1g0fn6boqu@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -122,7 +122,7 @@ resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.righttoknow.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=quarantine; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; ruf=; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  value   = "v=DMARC1; p=quarantine; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 # Staging environment DNS records

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -141,7 +141,7 @@ resource "cloudflare_record" "tvfy_dmarc" {
   zone_id = cloudflare_zone.org_au.id
   name    = "_dmarc.theyvoteforyou.org.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+ldnqce6nisu@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ldnqce6nisu@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 ## theyvoteforyou.org
@@ -172,7 +172,7 @@ resource "cloudflare_record" "tvfy_alt1_dmarc" {
   zone_id = cloudflare_zone.org.id
   name    = "_dmarc.theyvoteforyou.org"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+qbce7gaoklg@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+qbce7gaoklg@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }
 
 ## theyvoteforyou.com.au
@@ -203,5 +203,5 @@ resource "cloudflare_record" "tvfy_alt2_dmarc" {
   zone_id = cloudflare_zone.com_au.id
   name    = "_dmarc.theyvoteforyou.com.au"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+ffljniarmuh@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ffljniarmuh@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
 }

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -92,7 +92,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.org_au.id
   name    = "theyvoteforyou.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf.google.com -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com -all"
 }
 
 # TODO: Remove this once the one below is up and running


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
- Update DMARC records to remove redundant parameters and include necessary configurations for TheyVoteForYou, Morph, and Planning Alerts.
- Update SPF records to ensure proper email handling across these services.

## Why was this needed?
- Redundant ruf records needed removing
- SPF include records need to be added to include cuttlefish
- Adding TheyVoteForYou to Suped

## Implementation/Deploy Steps (Optional)
- Run `make tf-plan` to verify changes
- Run `make tf-apply` to apply changes

## Notes to reviewer (Optional)
- N/A