### PR TITLE
Update Terraform configuration for new OpenAustralia server

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -94,6 +94,7 @@ module "openaustralia" {
   security_group_service   = aws_security_group.openaustralia
   instance_profile         = aws_iam_instance_profile.logging
   ami                      = var.ubuntu_16_ami
+  ubuntu_22_ami            = var.ubuntu_22_ami
   ubuntu_24_ami            = var.ubuntu_24_ami
   cloudflare_account_id    = var.cloudflare_account_id
 }

--- a/terraform/openaustralia/production.tf
+++ b/terraform/openaustralia/production.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "production" {
 
   instance_type = "t3.small"
   ebs_optimized = true
-  key_name      = "test"
+  key_name      = "terraform"
   tags = {
     Name = "openaustralia-prod"
   }

--- a/terraform/openaustralia/production.tf
+++ b/terraform/openaustralia/production.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "production" {
   ebs_optimized = true
   key_name      = "test"
   tags = {
-    Name = "openaustralia"
+    Name = "openaustralia-prod"
   }
 
   # Increase root volume size to 20GB to allow for more packages and data
@@ -44,7 +44,7 @@ resource "aws_ebs_volume" "production_data" {
   size = 20
   type = "gp3"
   tags = {
-    Name = "openaustralia_data"
+    Name = "openaustralia-prod-data"
   }
 }
 

--- a/terraform/openaustralia/production.tf
+++ b/terraform/openaustralia/production.tf
@@ -1,10 +1,11 @@
-# New OpenAustralia Production Server on Ubuntu 24.04
+# New OpenAustralia Production Server on Ubuntu 22.04
 # This creates a parallel production environment for OpenAustralia
 
 # After discussion with Brenda, this new server will house both staging and production.
+# Note: Using Ubuntu 22.04 due to Ansible 2.10 compatibility issues with Ubuntu 24.04
 
 resource "aws_instance" "production" {
-  ami = var.ubuntu_24_ami
+  ami = var.ubuntu_22_ami
 
   instance_type = "t3.small"
   ebs_optimized = true

--- a/terraform/openaustralia/variables.tf
+++ b/terraform/openaustralia/variables.tf
@@ -3,4 +3,5 @@ variable "security_group_service" {}
 variable "instance_profile" {}
 variable "ami" {}
 variable "cloudflare_account_id" {}
+variable "ubuntu_22_ami" {}
 variable "ubuntu_24_ami" {}


### PR DESCRIPTION
## Relevant issue(s)
- #339
- #346

## What does this do?
Updates Terraform to deploy a new OpenAustralia production server using Ubuntu 22.04 AMI

## Why was this needed?
We are upgrading Openaustralia.org.au and need a shiny new server to go along with it.

## Implementation/Deploy Steps (Optional)
- `make tf-plan` to review the changes
- `make-tf-apply` to apply the changes

## Notes to reviewer (Optional)
- These changes have already been applied in production.
- Changes were split from #339 as Terraform and Ansible changes shoould be on seperate PRs 
