### PR TITLE
Increase PlanningAlerts DB instance to 90GB

### DIFF
--- a/terraform/planningalerts/databases.tf
+++ b/terraform/planningalerts/databases.tf
@@ -30,7 +30,7 @@ resource "aws_db_instance" "main" {
   # TODO: Less space should be needed in production
   # TODO: Enable storage autoscaling
   # TODO: Set maximum storage threshold to 200GB? 
-  allocated_storage = 50
+  allocated_storage = 90
 
   # Using general purpose SSD
   storage_type   = "gp3"


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/planningalerts/issues/2018

## What does this do?
- Updates Terraform to reflect that we have increased the allocated storage for the planningalerts database from 50GB to 90GB.

## Why was this needed?
- This change reflects a manual adjustment to ensure adequate storage capacity for production needs.
- If we don't make this change, we risk it being undone when we next apply terraform.

## Implementation/Deploy Steps (Optional)
- None Required

## Notes to reviewer (Optional)
- This PR is required to ensure the change is not reversed when `tf-apply` is run.
