### PR TITLE
Enable Cloudflare proxying (Orange Cloud) on TheyVoteForYou

### DIFF
--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -24,7 +24,7 @@ resource "cloudflare_record" "root" {
   name    = "theyvoteforyou.org.au"
   type    = "A"
   value   = aws_eip.main.public_ip
-  proxied = false
+  proxied = true
 }
 
 # CNAME records
@@ -34,7 +34,7 @@ resource "cloudflare_record" "www" {
   name    = "www.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
-  proxied = false
+  proxied = true
 }
 
 resource "cloudflare_record" "test" {
@@ -42,7 +42,7 @@ resource "cloudflare_record" "test" {
   name    = "test.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
-  proxied = false
+  proxied = true
 }
 
 resource "cloudflare_record" "www_test" {
@@ -50,7 +50,7 @@ resource "cloudflare_record" "www_test" {
   name    = "www.test.theyvoteforyou.org.au"
   type    = "CNAME"
   value   = "theyvoteforyou.org.au"
-  proxied = false
+  proxied = true
 }
 
 resource "cloudflare_record" "email" {


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/infrastructure/issues/312

## What does this do?
- Enables Cloudflare proxying for the TheyVoteForYou domain and its subdomains.

## Why was this needed?
- Proxying through Cloudflare enhances security and performance for the website.
- This change was already implemented manually so this change ensures that the manual changes are not reversed.

## Implementation/Deploy Steps (Optional)
- N/A (already deployed manually)

## Notes to reviewer (Optional)

