### PR TITLE
Configure RTK Production server to support 0.43.2.1

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for righttoknow
 ruby_version_staging: 3.2.9
-ruby_version_production: 2.7.8
+ruby_version_production: 3.2.9

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -196,9 +196,28 @@
     daemon_reload: yes
   when: "'righttoknow_staging' in group_names"
 
-# The changes of there being differences between the production and staging version
-# of this script are extremely small. So, just using the production version.
-# This is used in cron jobs
+- name: Install sidekiq systemd unit (Production)
+  template:
+    src: sidekiq.service
+    dest: /etc/systemd/system/sidekiq.service
+    mode: "0644"
+  vars:
+    sidekiq_daemon_name: "sidekiq (production)"
+    sidekiq_user: deploy
+    sidekiq_vhost_dir: /srv/www
+    sidekiq_vcspath: production/current
+    sidekiq_rails_env: production
+  when: "'righttoknow_production' in group_names"
+  notify: restart sidekiq
+
+- name: Enable and start sidekiq (production)
+  systemd:
+    name: sidekiq
+    enabled: yes
+    state: started
+    daemon_reload: yes
+  when: "'righttoknow_production' in group_names"
+
 - name: Link run-with-lockfile.sh so it's available system-wide
   file:
     src: "/srv/www/{{ 'staging' if ('righttoknow_staging' in group_names) else 'production' }}/current/commonlib/bin/run-with-lockfile.sh"

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -162,6 +162,7 @@
       - rake
       - ruby
       - ruby-dev
+      - redis-server
       - sqlite3
       - tnef
       - fonts-liberation  # Replaces ttf-bitstream-vera
@@ -172,15 +173,6 @@
       - wv
       - xapian-tools
     state: present
-
-## Redis is only being deployed on staging for now while we test the upgrade
-- name: Install Redis (Staging Server)
-  apt:
-    name:
-      - redis-server
-    state: present
-  when: "'righttoknow_staging' in group_names"
-  tags: redis
 
 - name: Install sidekiq systemd unit (staging)
   template:

--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -1284,7 +1284,6 @@ SURVEY_URL: ''
 # ---
 USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 30
 
-{% if 'righttoknow_staging' in group_names %}
 # Background jobs are processed by Rails' ActiveJob using Sidekiq. There are
 # various ways to run Sidekiq depending to server resources and technical
 # knowledge in order to run and maintain a Redis server.
@@ -1300,4 +1299,3 @@ USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 30
 #
 # ---
 BACKGROUND_JOBS: 'server'
-{% endif %}


### PR DESCRIPTION
## Relevant issue(s)
-  https://github.com/openaustralia/righttoknow/issues/974
- https://github.com/openaustralia/infrastructure/issues/310

Staging PRs
- https://github.com/openaustralia/infrastructure/pull/340
- https://github.com/openaustralia/infrastructure/pull/348

## What does this do?
- Updates production ruby to 3.2.9
- Installs redis-server across production and staging
- Configures the Sidekiq service for production.

## Why was this needed?
We are upgrading Right to Know to 0.43.2.1 (see above relevant issue). These changes must be deployed to the production server before we can commence upgrading the code.

## Implementation/Deploy Steps (Optional)
- Check using `make check-righttoknow`
- Deploy using `make apply-righttoknow`

## Notes to reviewer (Optional)
- DO NOT deploy/implement these changes. They will be deployed in the correct order when we upgrade the application.