### PR TITLE
Lock OpenVPN server to specific Ubuntu 22.04 LTS AMI

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -74,6 +74,15 @@ variable "ubuntu_24_ami" {
   default = "ami-001f2488b35ca8aad"
 }
 
+# AMI for Ubuntu 22.04 LTS (used by OpenVPN server), locked to a specific version 
+# so that we don't keep re-provisioning the servers when the AMI gets updated
+variable "ubuntu_22_openvpn_ami" {
+  # Created by: Canonical
+  # Virtualization type: hvm
+  # 64-bit x86
+  default = "ami-0c73bd9145b5546f5"
+}
+
 variable "cloudflare_account_id" {
   default = "668e6ebb9952c26ec3c17a85fb3a25a1"
 }

--- a/terraform/vpn-server.tf
+++ b/terraform/vpn-server.tf
@@ -2,7 +2,7 @@
 # Users must be in the 'vpn-users' IAM group to connect
 
 resource "aws_instance" "openvpn" {
-  ami                    = data.aws_ami.ubuntu_jammy.id
+  ami                    = var.ubuntu_22_openvpn_ami
   instance_type          = "t3.small"
   key_name               = "terraform"
   vpc_security_group_ids = [aws_security_group.openvpn.id]
@@ -22,22 +22,6 @@ resource "aws_instance" "openvpn" {
     volume_type = "gp3"
     volume_size = 20
     encrypted   = true
-  }
-}
-
-# Use latest Ubuntu 22.04 LTS
-data "aws_ami" "ubuntu_jammy" {
-  most_recent = true
-  owners      = ["099720109477"] # Canonical
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Locks the OpenVPN server to a specific Ubuntu 22.04 LTS AMI to prevent re-provisioning when the AMI updates.

## Why was this needed?
When running `make tf-plan` the ec2 instance was going to be destroyed and recreated.

This change ensures stability and consistency in the OpenVPN server environment by using a fixed AMI version.

## Implementation/Deploy Steps (Optional)
None required. This is a change to prevent servers from being rebuilt.


## Notes to reviewer (Optional)

