### PR TITLE
Update Right to Know Production to use Cloudflare

### DIFF
--- a/roles/internal/cloudflare_realip/tasks/main.yml
+++ b/roles/internal/cloudflare_realip/tasks/main.yml
@@ -13,6 +13,7 @@
   delegate_to: localhost
   become: false
   run_once: true
+  check_mode: false
 
 - name: Fetch Cloudflare IPv6 ranges
   uri:
@@ -22,6 +23,7 @@
   delegate_to: localhost
   become: false
   run_once: true
+  check_mode: false
   when: cloudflare_include_ipv6
 
 - name: Parse Cloudflare IP ranges

--- a/roles/internal/righttoknow/meta/main.yml
+++ b/roles/internal/righttoknow/meta/main.yml
@@ -163,6 +163,9 @@ dependencies:
     tags:
       - backup
     
+  - role: cloudflare_realip
+    cloudflare_webserver: nginx
+
   - role: nickhammond.logrotate
     logrotate_scripts:
       # This is the log rotation scheme required by Alaveteli

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -10,7 +10,7 @@ resource "cloudflare_record" "root" {
   name    = "righttoknow.org.au"
   type    = "A"
   value   = aws_eip.production.public_ip
-  proxied = false
+  proxied = true
 }
 
 resource "cloudflare_record" "production" {
@@ -28,7 +28,7 @@ resource "cloudflare_record" "www" {
   name    = "www.righttoknow.org.au"
   type    = "CNAME"
   value   = "righttoknow.org.au"
-  proxied = false
+  proxied = true
 }
 
 resource "cloudflare_record" "www_production" {


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/infrastructure/issues/312

## What does this do?
1. Updates Terraform for the root and www domains on Right to Know to enable the proxy (orange cloud).
2. Adds the cloudflare_realip role as a dependency of the righttoknow role so that the real IP address is passesd through to Right to Know.

## Why was this needed?
This change ensures that the Nginx webserver can correctly handle real IP addresses from Cloudflare and improves the DNS configuration by enabling proxying for better performance and security.

## Implementation/Deploy Steps (Optional)
- Run `make tf-plan` to verify changes to be applied via Terraform
- Run `make check-righttoknow-all` to verify changes to be applied via Ansible
- When satisifed with both, run `make tf-apply` and `make apply-righttoknow-all`

## Notes to reviewer (Optional)
- I will be implementing this change once it is approved.