### PR TITLE
Update user authentication flow

### DIFF
--- a/roles/internal/righttoknow/files/default.vcl
+++ b/roles/internal/righttoknow/files/default.vcl
@@ -68,6 +68,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Pass /sidekiq/ admin requests directly to backend - session cookies must be
+    # preserved for AdminConstraint to work, and these responses must not be cached.
+    if (req.url ~ "^/sidekiq(/|$)") {
+        return (pass);
+    }
+
     # Ignore Cookies on images...
     if (req.url ~ "\.(png|gif|jpg|jpeg|swf|css|js|rdf|ico)(\?.*|)$") {
         unset req.http.Cookie;


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
Fix an issue preventing access to the Sidekiq console on Right to Know

## Why was this needed?
We neeed to pass requests directly to the back-end, as sesssion cookies must be preserved and responses should not be cached (even by Varnish).

## Implementation/Deploy Steps (Optional)
- Deploy by running `make apply-righttoknow-all`

## Notes to reviewer (Optional)
- Manual fix has already been deployed in production