### PR TITLE
Infrastructure Upgrades to support RTK 0.44.0.3

### DIFF
--- a/roles/internal/righttoknow/files/sidekiq.yml
+++ b/roles/internal/righttoknow/files/sidekiq.yml
@@ -1,0 +1,12 @@
+development:
+  :concurrency: 1
+
+production:
+  :concurrency: 2
+
+:queues:
+  - default
+  - xapian
+
+:limits:
+  xapian: 1

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -406,6 +406,14 @@
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
   notify: nginx restart
 
+- name: Apply sidekiq config
+  copy:
+    src: sidekiq.yml
+    dest: "/srv/www/{{ item }}/shared/sidekiq.yml"
+    owner: deploy
+    group: deploy
+  with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
+  notify: restart sidekiq
 
 - name: Add deploy user to adm group so it can read mail logs
   user:

--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -808,6 +808,7 @@ SHARED_FILES_PATH: '/srv/www/{{ stage }}/shared'
 SHARED_FILES:
   - config/database.yml
   - config/general.yml
+  - config/sidekiq.yml
   - config/storage.yml
   - config/user_spam_scorer.yml
   - config/rails_env.rb


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/righttoknow/issues/989

## What does this do?
Updates infrastructure to support an upgrade to Alaveteli version 0.44.0.3.

Adds initial configuration for Sidekiq queues and sets concurrency levels for development and production environments.

## Why was this needed?
Required for migration to 0.44.0.3

## Implementation/Deploy Steps (Optional)
- Run `make check-righttoknow-staging`
- Run `make apply-righttoknow-staging` to make change
- Re-run `make check-righttoknow-staging` to make sure that all changes have been applied.

## Notes to reviewer (Optional)
I will be coordinating the deployment to production and staging.