### PR TITLE
Remove unnecessary shared files from configuration

### DIFF
--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -813,10 +813,8 @@ SHARED_FILES:
   - config/user_spam_scorer.yml
   - config/rails_env.rb
   - config/newrelic.yml
-  - config/httpd.conf
   - public/foi-live-creation.png
   - public/foi-user-use.png
-  - config/aliases
 
 # If you have SHARED_FILES_PATH set, then these options list the directories
 # that are shared; i.e. those that the deploy scripts should create symlinks to


### PR DESCRIPTION
## Relevant issue(s)
- Nil

## What does this do?
Removes unnecessary shared files from the configuration in `general.yml`.

## Why was this needed?
Required to ensure that capistrano deployments continue to work into the future. Also streamlines the configuration by removing files that aren't required to be linked because they don't exist.

## Implementation/Deploy Steps (Optional)
`make apply-righttoknow-all` to implement these changes

## Notes to reviewer (Optional)
This is a minor change which prevents 
