### PR TITLE
New openaustralia ansible

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -84,3 +84,15 @@ logs:
      log_group_name: /var/log/unattended-upgrades/unattended-upgrades.log
      log_stream_name: "{{ inventory_hostname }}"
      timestamp_format: "%Y-%m-%d %H:%M:%S"
+domains_for_certbot:
+  - email: contact@oaf.org.au
+    domains:
+      - "{{ openaustralia_domain }}"
+      - www."{{ openaustralia_domain }}"
+      - openaustralia.org
+      - www.openaustralia.org
+  - email: contact@oaf.org.au
+    domains:
+      - test.{{ openaustralia_domain }}
+      - staging.{{ openaustralia_domain }}
+      - www.test.{{ openaustralia_domain }}

--- a/group_vars/openaustralia_staging.yml
+++ b/group_vars/openaustralia_staging.yml
@@ -8,3 +8,7 @@ cron_enabled: false
 
 # Disable backups for staging
 backup_profiles: []
+domains_for_certbot:
+  - email: contact@oaf.org.au
+    domains:
+      - "{{ openaustralia_domain }}"

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -23,6 +23,9 @@ newprod.openaustralia.org.au
 [openaustralia_old]
 openaustralia.org.au
 
+[openaustralia_staging]
+newprod.openaustralia.org.au
+
 [openaustralia_new]
 newprod.openaustralia.org.au
 

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -447,7 +447,6 @@
     newrelic_appname: "{{ (item == 'production') | ternary('OpenAustralia.org', 'OpenAustralia.org Staging') }}"
     password_protect: "{{ item == 'staging' }}"
   with_items:
-    - production
     - staging
   notify: reload apache
 

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -466,18 +466,7 @@
   include_role:
     name: oaf.certbot
   vars:
-    certbot_certs:
-      - email: contact@oaf.org.au
-        domains:
-          - "{{ openaustralia_domain }}"
-          - www."{{ openaustralia_domain }}"
-          - openaustralia.org
-          - www.openaustralia.org
-      - email: contact@oaf.org.au
-        domains:
-          - test.{{ openaustralia_domain }}
-          - staging.{{ openaustralia_domain }}
-          - www.test.{{ openaustralia_domain }}
+    certbot_certs: "{{ domains_for_certbot }}"
   when: "'ec2' in group_names"
 
 
@@ -650,5 +639,3 @@
     src: deploy_can_restart_apache
     dest: /etc/sudoers.d/
     validate: visudo -cf %s
-
-

--- a/roles/internal/openaustralia/templates/apache/stage.conf
+++ b/roles/internal/openaustralia/templates/apache/stage.conf
@@ -1,11 +1,11 @@
-# <VirtualHost *:80>
-#    ServerName {{ domain }}
-#    ServerAlias www.{{ domain }}
-#    ServerAlias www.openaustralia.org
-#    ServerAlias openaustralia.org
+<VirtualHost *:80>
+   ServerName {{ domain }}
+   # ServerAlias www.{{ domain }}
+   # ServerAlias www.openaustralia.org
+   # ServerAlias openaustralia.org
 
-#    RedirectMatch permanent ^/(.*) https://www.{{ domain }}/$1
-# </VirtualHost>
+   RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
+</VirtualHost>
 
 # <VirtualHost *:443>
 #    ServerName {{ domain }}
@@ -20,8 +20,8 @@
 #    # SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
 # </VirtualHost>
 
-# <VirtualHost *:443>
-<VirtualHost *:80>
+<VirtualHost *:443>
+#<VirtualHost *:80>
    # temp hack, we are disabling ssl until i get certbot working
    ServerName {{ domain }}
    ErrorLog "/srv/www/{{ stage }}/log/error_log"
@@ -221,7 +221,7 @@
    #RewriteRule /down.html / [R]
 
    # BRW: disable ssl until i get certbot working
-   # SSLEngine on
-   # SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-   # SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+   SSLEngine on
+   SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
+   SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
 </VirtualHost>


### PR DESCRIPTION
## Relevant issue(s)
unknown
## What does this do?
Makes progress towards getting certbot happy. In fact, certbot is completely happy at this point, but apache is sad

## Why was this needed?
Ansible configs assume that for any stage, there will be four active hostnames:
(www.)?stage.openaustralia..org(.au)?

In this case, we just have one - newprod.openaustralia.org.au. 

One fix for this would have been to update terraform configs to have all four - in fact that's probably what should be done at this point. However, to minimise the problems I was trying to solve, I've reduced the apache configs to having just the one hostname. that works fine. 

The problem now is that the rest of the configs are still assuming that production and staging are on the same machine. I'd suggest unpicking that assumption: either by abstracting the "[production, staging]" list that's used in several places into a variable so that we can control which stages are on a particular machine; or with the "if _staging in group_names" method that's been used elsewhere in the configs.

## Implementation/Deploy Steps (Optional)

- When I first ran this with correct configs, there was an old `/etc/apache2/sites-enabled/production.conf` file lying around. Because that exists, the initial "get apache running for certbot" step was trying to load it. I had to manually remove it.
- Because I've got past the certbot step, I've made it as far as the step which re-creates that file. Which still doesn't work. So that breaks apache again. And it'll mean that trying to re-run this config again won't work either, until the production.conf is manually removed. See notes above about abstracting the list of stages so we don't make a production.conf on a non-production machine.

## Notes to reviewer (Optional)
