### PR TITLE
Feature/show ansible inventory vars and facts for main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ show-vars: check-host
 	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m debug -a "var=hostvars[inventory_hostname]"
 
 show-facts: check-host
-	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m setup;
+	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m setup
+
+show-rds-facts: check-host
+	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml --limit $(host) --tags facts -e "show_rds_debug=true"
 
 clean:
 	rm -rf .venv roles/external site.retry collections .keybase

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,22 @@ letsencrypt: $(KEYSANDROLES)
 retry: $(KEYSANDROLES) site.retry
 	.venv/bin/ansible-playbook site.yml -l @site.retry
 
+check-host:
+ifndef host
+	@echo "ERROR: host is not set! Add host=<value> using a host from inventory:\n"
+	@$(MAKE) show-inventory
+	@exit 1
+endif
+
+show-inventory:
+	.venv/bin/ansible-inventory -i ./inventory/ec2-hosts --graph
+
+show-vars: check-host
+	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m debug -a "var=hostvars[inventory_hostname]"
+
+show-facts: check-host
+	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m setup;
+
 clean:
 	rm -rf .venv roles/external site.retry collections .keybase
 	

--- a/site.yml
+++ b/site.yml
@@ -66,9 +66,16 @@
         instance_name: main-database
         region: "{{ ec2_region }}"
       register: rds_mysql5
+      tags: facts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
       when: "'requires_mysql' in group_names"
+
+    - name: Display information about the DEPRECATED Mysql 5 instance
+      debug:
+        var: "rds_mysql5"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and ('requires_mysql' in group_names)"
     
     - name: Get information about the Mysql 8 instance
       rds:
@@ -78,10 +85,16 @@
         instance_name: maindb
         region: "{{ ec2_region }}"
       register: rds_mysql8
+      tags: facts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
       when: "'requires_mysql' in group_names"
 
+    - name: Display information about the Mysql 8 instance
+      debug:
+        var: "rds_mysql8"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and ('requires_mysql' in group_names)"
 
     - name: Get information about the postgresql RDS instance
       rds:
@@ -91,9 +104,16 @@
         instance_name: postgresql
         region: "{{ ec2_region }}"
       register: rds_postgresql
+      tags: facts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
       when: "'requires_postgresql' in group_names"
+
+    - name: Display information about the postgresql RDS instance
+      debug:
+        var: "rds_postgresql"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and ('requires_postgresql' in group_names)"
 
     - name: Get information about the planningalerts RDS instance
       rds:
@@ -103,9 +123,16 @@
         instance_name: planningalerts
         region: "{{ ec2_region }}"
       register: rds_planningalerts
+      tags: facts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: no
       when: "'requires_postgresql' in group_names"
+
+    - name: Displays information about the planningalerts RDS instance
+      debug:
+        var: "rds_planningalerts"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and ('requires_postgresql' in group_names)"
 
 - hosts: all
   become: true


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/205

## What does this do?

Adds make targets:
* show-inventory - shows graph of hosts in their groups, useful to select a host as well as confirm group_vars active
* show-vars - shows the variables for a host, decrypting variables from vault as appropriate, also reveals when dependencies are not defined
* show-facts - shows the facts discovered by gather_facts in when `gather_facts: false` is not explicitly set  (lots of them)

## Why was this needed?

I needed to find some passwords that where encrypted, and decided a general utility would be useful

## Implementation/Deploy Steps (Optional)

run on local dev host with keybase enabled to decode variables as needed.

```
$ make show-inventory

$->(130) make show-inventory
.venv/bin/ansible-inventory -i ./inventory/ec2-hosts --graph
@all:
  |--@ec2:
  |  |--au.proxy.oaf.org.au
  |  |--newprod.openaustralia.org.au
  |  |--openaustralia.org.au
  |  |--prod.righttoknow.org.au
  |  |--staging.righttoknow.org.au
  |  |--theyvoteforyou.org.au
  |  |--vpn.oaf.org.au
  |  |--web.metabase.oaf.org.au
  |--@openaustralia:
  |  |--newprod.openaustralia.org.au
  |  |--openaustralia.org.au
   ...
  |--@ungrouped:

$ make show-vars host=prod.righttoknow.org.au # When you don't have the required keybase perms

prod.righttoknow.org.au | FAILED! => {
    "msg": "Decryption failed (no vault secrets were found that could decrypt)"
}

$ make show-vars host=ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com
.venv/bin/ansible -i ./inventory/ec2-hosts ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com -m debug -a "var=hostvars[inventory_hostname]"
ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com | SUCCESS => {
    "hostvars[inventory_hostname]": {
        "ansible_check_mode": false,
 ...

$ make show-facts host=au.proxy.oaf.org.au

au.proxy.oaf.org.au | SUCCESS => {
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
            "172.31.14.229"
        ],
        "ansible_all_ipv6_addresses": [
            "fe80::b8:f9ff:fe3e:fe70"
        ],
...


Eg:


Prompts when host=<value> is not passed

## Notes to reviewer (Optional)
