### PR TITLE
Feature/document msmtp and how to setup mail catcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
       - [Deploying OpenAustralia to your local development server](#deploying-openaustralia-to-your-local-development-server)
       - [Deploying OpenAustralia to production](#deploying-openaustralia-to-production)
   - [Backups](#backups)
+  - [Mailcatcher](#Mailcatcher)
 
 <!-- vscode-markdown-toc-config
 	numbering=false
@@ -481,3 +482,37 @@ Data directories of servers are backed up to S3 using Duply.
 Using the `data_directory` profile as an example, to run a backup manually you'd log in as root and run `duply data_directory backup`.
 
 To restore the latest backup to `/mnt/restore` you'd run `duply data_directory restore /mnt/restore`.
+
+## <a name='Mailcatcher'></a>Mailcatcher
+
+To send email to a mail catcher on openaustralia, update the `/etc/msmstprc` file, keeping a copy as the ansible `internal/openaustralia` role will overwite it!
+
+Note: This will affect BOTH the production and staging environments on that server! 
+If you ONLY want to change staging, then add the following to the `/etc/apache2/sites-enabled` config file for staging:
+```
+    php_admin_value sendmail_path "msmtp --read-envelope-from -t -a mailpit"
+```
+
+You will want to add a mailpit entry:
+```
+account mailpit
+tls off
+host <mailpit.server>
+port 2525
+auth plain
+user openaustralia
+password <your-password>
+host plannies-mate.thesite.info
+```
+
+Change the default if you want both production and staging to be changed:
+```
+account default : mailpit
+#account default : cuttlefish
+```
+
+To undo this, change the default back, optionally remove the mailpit entry, and update the apache vhost config if you have changed it.
+
+REMEMBER: Keep a copy of the files you change and copy them back after running a diff to confirm if you run ansible.
+(TODO: Make it a default for setting up qa/test servers)
+


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/392

## What does this do?

* Documents setup in README.md
* Builds on
  * https://github.com/openaustralia/infrastructure/pull/391

## Why was this needed?

I needed to set up a mail catcher, and it wasn't documented, so I did.

## Implementation/Deploy Steps (Optional)

Manual setup as documented in README.md, with a comment to consider rolling it back into default for staging.

## Notes to reviewer (Optional)
