### PR TITLE
Handle both mysql 5 and 8 databases in openaustralia

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   hosts = {
     # Services required by the servers
     "mysql" => { node: 10,
-                 box: "ubuntu/xenial64",
+                 box: "ubuntu/jammy64",
                  groups: ["mysql"] },
     # TODO: Do we want to seperate out the postgres for PA and everything else
     "postgresql" => { node: 11,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,8 +160,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     # More cpus and crank up the memory for a faster build
-    v.memory = 2048
-    v.cpus = 2
+    v.memory = (ENV['VAGRANT_MEMORY'] || 2048).to_i
+    v.cpus   = (ENV['VAGRANT_CPUS']   || 2).to_i
   end
 
   # Use this so that you don't need to give the machine name for all vagrant

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -4,8 +4,7 @@ mysql_host: 192.168.56.10
 postgresql_host: 192.168.56.11
 planningalerts_db_host: 192.168.56.11
 
-mysql_5_host: "{{ mysql_host }}"
-mysql_8_host: "{{ mysql_host }}"
+db_host: "{{ mysql_host }}"
 
 newrelic_license_key: null
 devsite: true

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -10,3 +10,5 @@ newrelic_license_key: null
 devsite: true
 rds_admin_password: "test_password"
 nrinfragent_state: absent
+
+db_host: "{{ postgresql_host if 'requires_postgresql' in group_names else mysql_host }}"

--- a/group_vars/ec2.yml
+++ b/group_vars/ec2.yml
@@ -22,13 +22,13 @@ aws_secret_key: !vault |
           6434643564643137640a333265323036303130353761613465313937653564303237306166643862
           63663031653636636137303266646532616635323635326365663134653539646639636465613766
           3334393761626366336464363162376430613638616235343437
+# TODO: verify if planningalerts actually needs access to both mysal and pg databases!
 
-# Only one of these will be set at a time as servers only belong in one of the `requires_*` groups
-mysql_5_host: "{{ rds_mysql5.instance.endpoint }}"
-mysql_8_host: "{{ rds_mysql8.instance.endpoint }}"
-postgresql_host: "{{ rds_postgresql.instance.endpoint }}"
-
+# db_host is set when in one of requires_* groups
+db_host: "{{ rds_database.instance.endpoint }}"
+# Set when in requires_postgresql group (Unsure why not planningalerts group)
 planningalerts_db_host: "{{ rds_planningalerts.instance.endpoint }}"
+
 newrelic_license_key: !vault |
           $ANSIBLE_VAULT;1.2;AES256;ec2
           63343465396536616465383664646636633632616133343734666464303438613965313037633032

--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -84,6 +84,7 @@ logs:
      log_group_name: /var/log/unattended-upgrades/unattended-upgrades.log
      log_stream_name: "{{ inventory_hostname }}"
      timestamp_format: "%Y-%m-%d %H:%M:%S"
+
 domains_for_certbot:
   - email: contact@oaf.org.au
     domains:
@@ -102,3 +103,7 @@ ruby_versions:
   - ruby-3.4.9
 rbenv_extra_depends:
   - libyaml-dev
+
+environments:
+  - production
+  - staging

--- a/group_vars/requires_mysql.yml
+++ b/group_vars/requires_mysql.yml
@@ -3,3 +3,5 @@
 # Current Mysql 8.x version (NOT 5.7!)
 
 # attributes are discovered dynamically in site.yml
+
+db_name: maindb

--- a/group_vars/requires_mysql_5.yml
+++ b/group_vars/requires_mysql_5.yml
@@ -3,3 +3,5 @@
 # OLD MySql 5.7 version (that we are migrating off to MySql 8.x)
 
 # attributes are discovered dynamically in site.yml
+
+db_name: main-database

--- a/group_vars/requires_postgresql.yml
+++ b/group_vars/requires_postgresql.yml
@@ -5,3 +5,8 @@
 # use `make show-rds-vars host=<postgres-using-host>` to show them
 
 # ec2 group sets the relevant variables
+
+db_name: postgresql
+
+# TODO: discover why this is in this group rather than planningalerts (based on what was in site.yml)
+planningalerts_db_name: planningalerts

--- a/group_vars/theyvoteforyou.yml
+++ b/group_vars/theyvoteforyou.yml
@@ -90,3 +90,7 @@ production_certbot_domains: >-
 staging_certbot_domains:
   - "test.{{ theyvoteforyou_domain }}"
   - "www.test.{{ theyvoteforyou_domain }}"
+
+environments:
+  - production
+  - staging

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -60,19 +60,17 @@ ec2-3-27-189-101.ap-southeast-2.compute.amazonaws.com
 [proxy]
 au.proxy.oaf.org.au
 
-# Group for all sites that need information on the MySQL 8.x RDS instance
+# Group for all sites that use and thus need information on the MySQL 8.x RDS instance
 [requires_mysql:children]
 openaustralia_new
 theyvoteforyou
-metabase
 
-# Group for all sites that need information on the MySQL 5.7 RDS instance
+# Group for all sites that use and need information on the MySQL 5.7 RDS instance
 [requires_mysql_5:children]
 openaustralia_old
 
-# Group for all sites that need information on the PostgreSQL RDS instance
+# Group for all sites that use and need information on the PostgreSQL RDS instance
 [requires_postgresql:children]
-theyvoteforyou
 righttoknow
 metabase
 planningalerts

--- a/roles/internal/mysql/files/apt_pin
+++ b/roles/internal/mysql/files/apt_pin
@@ -1,3 +1,0 @@
-Package: *
-Pin: origin "repo.mysql.com"
-Pin-Priority: 999

--- a/roles/internal/mysql/files/mysqld.cnf
+++ b/roles/internal/mysql/files/mysqld.cnf
@@ -1,10 +1,6 @@
 #
 # The MySQL database server configuration file.
 #
-# You can copy this to one of:
-# - "/etc/mysql/my.cnf" to set global options,
-# - "~/.my.cnf" to set user-specific options.
-#
 # One can use all long options that the program supports.
 # Run program with --help to get a list of available options and with
 # --print-defaults to see which it would actually understand and use.
@@ -12,96 +8,71 @@
 # For explanations see
 # http://dev.mysql.com/doc/mysql/en/server-system-variables.html
 
-# This will be passed to all mysql clients
-# It has been reported that passwords should be enclosed with ticks/quotes
-# escpecially if they contain "#" chars...
-# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
-
 # Here is entries for some specific programs
 # The following values assume you have at least 32M ram
-
-[mysqld_safe]
-socket		= /var/run/mysqld/mysqld.sock
-nice		= 0
 
 [mysqld]
 #
 # * Basic Settings
 #
 user		= mysql
-pid-file	= /var/run/mysqld/mysqld.pid
-socket		= /var/run/mysqld/mysqld.sock
-port		= 3306
-basedir		= /usr
-datadir		= /var/lib/mysql
-tmpdir		= /tmp
-lc-messages-dir	= /usr/share/mysql
-skip-external-locking
+# pid-file	= /var/run/mysqld/mysqld.pid
+# socket	= /var/run/mysqld/mysqld.sock
+# port		= 3306
+# datadir	= /var/lib/mysql
+
+
+# If MySQL is running as a replication slave, this should be
+# changed. Ref https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_tmpdir
+# tmpdir		= /tmp
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
-bind-address		= 0.0.0.0
+bind-address		= 127.0.0.1
+mysqlx-bind-address	= 127.0.0.1
 #
 # * Fine Tuning
 #
 key_buffer_size		= 16M
-max_allowed_packet	= 16M
-thread_stack		= 192K
-thread_cache_size       = 8
+# max_allowed_packet	= 64M
+# thread_stack		= 256K
+
+# thread_cache_size       = -1
+
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
 myisam-recover-options  = BACKUP
-#max_connections        = 100
-#table_cache            = 64
-#thread_concurrency     = 10
-#
-# * Query Cache Configuration
-#
-query_cache_limit	= 1M
-query_cache_size        = 16M
+
+# max_connections        = 151
+
+# table_open_cache       = 4000
+
 #
 # * Logging and Replication
 #
 # Both location gets rotated by the cronjob.
+#
+# Log all queries
 # Be aware that this log type is a performance killer.
-# As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
+# general_log_file        = /var/log/mysql/query.log
+# general_log             = 1
 #
 # Error log - should be very few entries.
 #
 log_error = /var/log/mysql/error.log
 #
 # Here you can see queries with especially long duration
-#log_slow_queries	= /var/log/mysql/mysql-slow.log
-#long_query_time = 2
-#log-queries-not-using-indexes
+# slow_query_log		= 1
+# slow_query_log_file	= /var/log/mysql/mysql-slow.log
+# long_query_time = 2
+# log-queries-not-using-indexes
 #
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
 #       other settings you may need to change.
-#server-id		= 1
-#log_bin			= /var/log/mysql/mysql-bin.log
-expire_logs_days	= 10
+# server-id		= 1
+# log_bin			= /var/log/mysql/mysql-bin.log
+# binlog_expire_logs_seconds	= 2592000
 max_binlog_size   = 100M
-#binlog_do_db		= include_database_name
-#binlog_ignore_db	= include_database_name
-#
-# * InnoDB
-#
-# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
-# Read the manual for more InnoDB related options. There are many!
-innodb_large_prefix = true
-innodb_file_format = barracuda
-innodb_file_per_table = true
-#
-# * Security Features
-#
-# Read the manual, too, if you want chroot!
-# chroot = /var/lib/mysql/
-#
-# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
-#
-# ssl-ca=/etc/mysql/cacert.pem
-# ssl-cert=/etc/mysql/server-cert.pem
-# ssl-key=/etc/mysql/server-key.pem
+# binlog_do_db		= include_database_name
+# binlog_ignore_db	= include_database_name

--- a/roles/internal/mysql/files/mysqld.cnf
+++ b/roles/internal/mysql/files/mysqld.cnf
@@ -28,24 +28,23 @@ user		= mysql
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
-bind-address		= 127.0.0.1
-mysqlx-bind-address	= 127.0.0.1
+bind-address		= 0.0.0.0
+mysqlx = OFF
 #
 # * Fine Tuning
 #
 key_buffer_size		= 16M
-# max_allowed_packet	= 64M
-# thread_stack		= 256K
-
-# thread_cache_size       = -1
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size	= 8
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
 myisam-recover-options  = BACKUP
 
-# max_connections        = 151
+max_connections        = 50
 
-# table_open_cache       = 4000
+table_open_cache       = 256
 
 #
 # * Logging and Replication
@@ -76,3 +75,22 @@ log_error = /var/log/mysql/error.log
 max_binlog_size   = 100M
 # binlog_do_db		= include_database_name
 # binlog_ignore_db	= include_database_name
+
+# Reduce memory usage
+# Add if we need extra memory
+# performance_schema = OFF
+innodb_buffer_pool_instances = 1
+innodb_log_buffer_size = 8M
+sort_buffer_size = 512K
+join_buffer_size = 256K
+table_definition_cache = 400
+innodb_buffer_pool_size = 512M
+innodb_redo_log_capacity = 256M
+tmp_table_size = 32M
+max_heap_table_size = 32M
+temptable_max_ram = 256M
+skip-name-resolve = 1
+
+# Emulate RDS:
+default_authentication_plugin = mysql_native_password
+innodb_file_per_table = 1

--- a/roles/internal/mysql/tasks/main.yml
+++ b/roles/internal/mysql/tasks/main.yml
@@ -23,3 +23,4 @@
     password: "{{ rds_admin_password }}"
     priv: '*.*:ALL,GRANT'
     host: '%'
+    login_unix_socket: /var/run/mysqld/mysqld.sock

--- a/roles/internal/mysql/tasks/main.yml
+++ b/roles/internal/mysql/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # tasks file for roles/internal/mysql
 
-# We're installing mysql 5.7 because that's what we're using on AWS in production
-- name: Install mysql 5.7 server
+# We're installing mysql because that's what we're using on AWS in production
+- name: Install mysql server
   apt:
     pkg: mysql-server
     update_cache: true
 
 - name: Install dependency for following command
-  apt: pkg=python-mysqldb
+  apt: pkg=python3-mysqldb
 
 - name: Update mysql config to bind to public ip
   copy:

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -32,7 +32,7 @@
     group: deploy
     state: directory
   with_nested:
-    - ['production', 'staging']
+    - "{{ environments }}"
     - ['images/mps', 'images/mpsL', 'images/mpsXL', 'pwdata', 'html_cache', 'regmem_scan', 'regmem_scan_old', 'search/searchdb']
 
 - name: Ensure that directories in /srv/www exist
@@ -42,7 +42,7 @@
     group: deploy
     state: directory
   with_nested:
-    - ['production', 'staging']
+    - "{{ environments }}"
     - ['log', 'releases', 'shared/config', 'shared/rss/mp', 'shared/sitemaps']
 
 - name: Link directories in /srv/www to /data
@@ -51,7 +51,7 @@
     src: "/data/{{ item[0] }}/{{ item[1] }}"
     dest: "/srv/www/{{ item[0] }}/shared/{{ item[1] }}"
   with_nested:
-    - ['production', 'staging']
+    - "{{ environments }}"
     - ['images', 'pwdata', 'html_cache', 'regmem_scan', 'regmem_scan_old', 'search']
 
 - name: Link file alerts-lastsent in /srv/www to /data
@@ -61,43 +61,52 @@
     dest: "/srv/www/{{ item }}/shared/alerts-lastsent"
     # Doing this because the src file might not yet exist and that's okay
     force: true
-  with_items:
-    - production
-    - staging
+  with_items: "{{ environments }}"
 
 - name: Install dependency for ansible mysql_db module
   when: "'openaustralia_old' in group_names"
   apt: pkg=python-mysqldb
 
+- name: Install MySQL client dev headers
+  apt:
+    name: libmysqlclient-dev
+    state: present
+
+- name: Install OpenSSL
+  apt:
+    name: libssl-dev
+    state: present
+
+# NOTE - This works for both mysql 5 AND 8
 - name: Create openaustralia databases
   mysql_db:
     login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: "oa-{{ item }}"
-  with_items:
-    - production
-    - staging
+  loop: "{{ environments }}"
 
-- name: Create openaustralia user with access to the database (production)
+- name: Create openaustralia users with access to the databases
   mysql_user:
     login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
-    name: oa-production
-    password: "{{ openaustralia_production_mysql_password }}"
-    priv: 'oa-production.*:ALL'
+    name: oa-{{ item }}
+    password: "{{ (item == 'production') | ternary(openaustralia_production_mysql_password, openaustralia_staging_mysql_password) }}"
+    priv: "oa-{{ item }}.*:ALL"
     host: "%"
+  loop: "{{ environments }}"
 
-- name: Create mysql user with readonly access to the production openaustralia database for metabase
+- name: Create mysql users with readonly access to the openaustralia databases for metabase
   mysql_user:
     login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
-    name: oa-production-readonly
+    name: "oa-{{ item }}-readonly"
     password: "{{ mysql_production_password_readonly }}"
-    priv: 'oa-production.*:SELECT'
+    priv: 'oa-{{ item }}.*:SELECT'
     host: "%"
+  loop: "{{ environments }}"
 
 - name: Create .my.cnf in development with password for both production and staging
   template:

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -70,9 +70,8 @@
   apt: pkg=python-mysqldb
 
 - name: Create openaustralia databases
-  when: "'openaustralia_old' in group_names"
   mysql_db:
-    login_host: "{{ mysql_5_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: "oa-{{ item }}"
@@ -81,9 +80,8 @@
     - staging
 
 - name: Create openaustralia user with access to the database (production)
-  when: "'openaustralia_old' in group_names"
   mysql_user:
-    login_host: "{{ mysql_5_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: oa-production
@@ -92,32 +90,16 @@
     host: "%"
 
 - name: Create mysql user with readonly access to the production openaustralia database for metabase
-  when: "'openaustralia_old' in group_names"
   mysql_user:
-    login_host: "{{ mysql_5_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: oa-production-readonly
     password: "{{ mysql_production_password_readonly }}"
     priv: 'oa-production.*:SELECT'
     host: "%"
-  run_once: true
 
-# Removed from mysql5 host
-# - name: Create openaustralia user with access to the database (staging)
-#   when: "'openaustralia_old' in group_names"
-#   mysql_user:
-#     login_host: "{{ mysql_5_host }}"
-#     login_user: admin
-#     login_password: "{{ rds_admin_password }}"
-#     name: oa-staging
-#     password: "{{ openaustralia_staging_mysql_password }}"
-#     priv: 'oa-staging.*:ALL'
-#     host: "%"
-
-#This file will always point at the production db
-# Which seems like that's what we want, in development
-- name: Create .my.cnf in development
+- name: Create .my.cnf in development with password for both production and staging
   template:
     src: mysql
     dest: /root/.my.cnf
@@ -125,13 +107,6 @@
     group: root
     mode: "0600"
   when: "'development' in group_names"
-  vars:
-    db_password: "{{ (item == 'production') | ternary(openaustralia_production_mysql_password, openaustralia_staging_mysql_password) }}"
-    stage: "{{ item }}"
-  with_items:
-    - production
-
-
 
 # Create fake let's encrypt directories when in development
 - name: Create fake let's encrypt directories when in development

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -86,7 +86,7 @@
     name: "oa-{{ item }}"
   loop: "{{ environments }}"
 
-- name: Create openaustralia users with access to the databases
+- name: Create openaustralia mysql admin user with access to the databases
   mysql_user:
     login_host: "{{ db_host }}"
     login_user: admin
@@ -97,7 +97,7 @@
     host: "%"
   loop: "{{ environments }}"
 
-- name: Create mysql users with readonly access to the openaustralia databases for metabase
+- name: Create mysql user with readonly access to the openaustralia databases for metabase
   mysql_user:
     login_host: "{{ db_host }}"
     login_user: admin

--- a/roles/internal/openaustralia/templates/general
+++ b/roles/internal/openaustralia/templates/general
@@ -4,11 +4,7 @@
 
 // *******************************************************************************
 // MySQL database.
-{% if 'openaustralia_new' in group_names %}
-define ("DB_HOST", "{{ mysql_8_host }}");
-{% else %}
-define ("DB_HOST", "{{ mysql_5_host }}");
-{% endif %}
+define ("DB_HOST", "{{ db_host }}");
 define ("DB_USER", "oa-{{ stage }}");
 define ("DB_PASSWORD", "{{ db_password }}");
 define ("DB_NAME", "oa-{{ stage }}");

--- a/roles/internal/openaustralia/templates/mysql
+++ b/roles/internal/openaustralia/templates/mysql
@@ -1,5 +1,11 @@
 [client]
 port = 3306
-host = {{ mysql_8_host }}
+host = {{ db_host }}
+
+[production]
 database = oa-production
-password = {{ db_password }}
+password = {{ openaustralia_production_mysql_password }}
+
+[staging]
+database = oa-staging
+password = {{ openaustralia_staging_mysql_password }}

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -14,11 +14,12 @@
     state: present
     update_cache: true
 
-- name: Install nginx and passenger
+- name: Install nginx, passenger and libyaml packages
   apt:
     pkg:
       - libnginx-mod-http-passenger
       - nginx
+      - libyaml-dev
     state: present
 
 # We want this directory to exist in development too so that

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: Create theyvoteforyou databases
   mysql_db:
-    login_host: "{{ mysql_8_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: "tvfy-{{ item }}"
@@ -52,7 +52,7 @@
 
 - name: Create theyvoteforyou user with access to the database (production)
   mysql_user:
-    login_host: "{{ mysql_8_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: tvfy-production
@@ -62,7 +62,7 @@
 
 - name: Create mysql 8 user with readonly access to the production theyvoteforyou database for metabase
   mysql_user:
-    login_host: "{{ mysql_8_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: tvfy-production-readonly
@@ -73,7 +73,7 @@
 
 - name: Create theyvoteforyou user with access to the database (staging)
   mysql_user:
-    login_host: "{{ mysql_8_host }}"
+    login_host: "{{ db_host }}"
     login_user: admin
     login_password: "{{ rds_admin_password }}"
     name: tvfy-staging

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -354,7 +354,7 @@
     group: deploy
     state: directory
   with_nested:
-    - ['production', 'staging']
+    - "{{ environments }}"
     - ['public', 'public/cards']
 
 - name: Link directories in /srv/www to /data
@@ -363,5 +363,5 @@
     src: "/data/{{ item[0] }}/{{ item[1] }}"
     dest: "/srv/www/{{ item[0] }}/shared/{{ item[1] }}"
   with_nested:
-    - ['production', 'staging']
+    - "{{ environments }}"
     - ['public/cards']

--- a/roles/internal/theyvoteforyou/templates/database-production.yml
+++ b/roles/internal/theyvoteforyou/templates/database-production.yml
@@ -1,6 +1,6 @@
 production:
   adapter: mysql2
-  host: {{ mysql_8_host }}
+  host: {{ db_host }}
   database: tvfy-production
   username: tvfy-production
   password: "{{ theyvoteforyou_production_mysql_password }}"

--- a/roles/internal/theyvoteforyou/templates/database-staging.yml
+++ b/roles/internal/theyvoteforyou/templates/database-staging.yml
@@ -1,6 +1,6 @@
 production:
   adapter: mysql2
-  host: {{ mysql_8_host }}
+  host: {{ db_host }}
   database: tvfy-staging
   username: tvfy-staging
   password: "{{ theyvoteforyou_staging_mysql_password }}"

--- a/site.yml
+++ b/site.yml
@@ -28,6 +28,17 @@
 
 # Use terraform (see terraform directory) to actually provision ec2 infrastructure
 
+- name: Validate not in multiple requires_ groups
+  hosts: all
+  gather_facts: false
+  tags: facts
+  tasks:
+    - name: Ensure host is not in multiple requires_* groups
+      assert:
+        that:
+          - "(['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list | length) <= 1"
+        fail_msg: "{{ inventory_hostname }} is in multiple exclusive groups: {{ ['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list }}"
+
 # Ensure python3 is available for Ansible (required before gather_facts), with fallback to python2
 # If it does fall back, set ansible_python_interpreter to /usr/bin/python in that old group
 - hosts: all
@@ -61,7 +72,7 @@
     - python2
   become: true
   tasks:
-    - name: Install python packages
+    - name: Install python2 packages
       tags: python
       apt:
         pkg: "{{ item }}"
@@ -100,24 +111,12 @@
       pip: name=boto3
       when: ansible_python_version is version('3', '>=')
 
-- hosts: all
-  name: "Check inventory group membership"
-  tags:
-    - rds
-    - facts
-  become: true
-  tasks:
-    - name: Ensure host is not in multiple requires_* groups
-      assert:
-        that:
-          - "(['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list | length) <= 1"
-        fail_msg: "{{ inventory_hostname }} is in multiple exclusive groups: {{ ['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list }}"
-
 - hosts: ec2
   name: "Gather RDS facts"
   tags:
     - rds
     - facts
+  become: true
   tasks:
     - name: Get information about the RDS instance
       rds:

--- a/site.yml
+++ b/site.yml
@@ -54,17 +54,6 @@
         apt install -y python-minimal
       changed_when: false
 
-- name: Validate not in multiple requires_ groups
-  hosts: all
-  gather_facts: false
-  tags: facts
-  tasks:
-    - name: Ensure host is not in multiple requires_* groups
-      assert:
-        that:
-          - "(['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list | length) <= 1"
-        fail_msg: "{{ inventory_hostname }} is in multiple exclusive groups: {{ ['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list }}"
-
 - hosts: all
   name: "Install python2 requirements"
   tags:

--- a/site.yml
+++ b/site.yml
@@ -43,7 +43,7 @@
         apt install -y python-minimal
       changed_when: false
 
-- hosts: ec2
+- hosts: all
   name: "Install python2 requirements"
   tags:
     - python
@@ -64,7 +64,7 @@
       pip: name=boto
       when: ansible_python_version is version('3', '<')
 
-- hosts: ec2
+- hosts: all
   name: "Install python3 requirements"
   tags:
     - python
@@ -85,79 +85,60 @@
       pip: name=boto3
       when: ansible_python_version is version('3', '>=')
 
+- hosts: all
+  name: "Check inventory group membership"
+  tags:
+    - rds
+    - facts
+  become: true
+  tasks:
+    - name: Ensure host is not in multiple requires_* groups
+      assert:
+        that:
+          - "(['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list | length) <= 1"
+        fail_msg: "{{ inventory_hostname }} is in multiple exclusive groups: {{ ['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list }}"
+
 - hosts: ec2
   name: "Gather RDS facts"
   tags:
     - rds
     - facts
   tasks:
-    - name: Get information about the DEPRECATED Mysql 5 instance
+    - name: Get information about the RDS instance
       rds:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         command: facts
-        instance_name: main-database
+        instance_name: "{{ db_name }}"
         region: "{{ ec2_region }}"
-      register: rds_mysql5
+      register: rds_database
       # Run this task even when running ansible-playbook with "--check"
       check_mode: false
-      when: "'requires_mysql_5' in group_names"
+      when: "db_name is defined"
 
-    - name: Display information about the DEPRECATED Mysql 5 instance
+    - name: Display information about the RDS database
       debug:
-        var: "rds_mysql5"
-      when: "(show_rds_debug | default(false) | bool) and ('requires_mysql_5' in group_names)"
-
-    - name: Get information about the Mysql 8 instance
-      rds:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        command: facts
-        instance_name: maindb
-        region: "{{ ec2_region }}"
-      register: rds_mysql8
-      # Run this task even when running ansible-playbook with "--check"
-      check_mode: false
-      when: "'requires_mysql' in group_names"
-
-    - name: Display information about the Mysql 8 instance
-      debug:
-        var: "rds_mysql8"
-      when: "(show_rds_debug | default(false) | bool) and ('requires_mysql' in group_names)"
-
-    - name: Get information about the postgresql RDS instance
-      rds:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        command: facts
-        instance_name: postgresql
-        region: "{{ ec2_region }}"
-      register: rds_postgresql
-      # Run this task even when running ansible-playbook with "--check"
-      check_mode: false
-      when: "'requires_postgresql' in group_names"
-
-    - name: Display information about the postgresql RDS instance
-      debug:
-        var: "rds_postgresql"
-      when: "(show_rds_debug | default(false) | bool) and ('requires_postgresql' in group_names)"
+        var: "rds_database"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and (db_name is defined)"
 
     - name: Get information about the planningalerts RDS instance
       rds:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
         command: facts
-        instance_name: planningalerts
+        instance_name: "{{ planningalerts_db_name }}"
         region: "{{ ec2_region }}"
       register: rds_planningalerts
       # Run this task even when running ansible-playbook with "--check"
       check_mode: false
-      when: "'requires_postgresql' in group_names"
+      when: "planningalerts_db_name is defined"
 
     - name: Displays information about the planningalerts RDS instance
       debug:
         var: "rds_planningalerts"
-      when: "(show_rds_debug | default(false) | bool) and ('requires_postgresql' in group_names)"
+      tags: facts
+      when: "(show_rds_debug | default(false) | bool) and (planningalerts_db_name is defined)"
 
 - hosts: all
   become: true

--- a/site.yml
+++ b/site.yml
@@ -43,6 +43,17 @@
         apt install -y python-minimal
       changed_when: false
 
+- name: Validate not in multiple requires_ groups
+  hosts: all
+  gather_facts: false
+  tags: facts
+  tasks:
+    - name: Ensure host is not in multiple requires_* groups
+      assert:
+        that:
+          - "(['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list | length) <= 1"
+        fail_msg: "{{ inventory_hostname }} is in multiple exclusive groups: {{ ['requires_mysql', 'requires_mysql_5', 'requires_postgresql'] | select('in', group_names) | list }}"
+
 - hosts: all
   name: "Install python2 requirements"
   tags:
@@ -51,6 +62,7 @@
   become: true
   tasks:
     - name: Install python packages
+      tags: python
       apt:
         pkg: "{{ item }}"
         cache_valid_time: 300
@@ -61,6 +73,7 @@
       when: ansible_python_version is version('3', '<')
 
     - name: Install boto which is required for EC2 stuff (Python 2)
+      tags: python
       pip: name=boto
       when: ansible_python_version is version('3', '<')
 
@@ -72,6 +85,7 @@
   become: true
   tasks:
     - name: Install python packages
+      tags: python
       apt:
         pkg: "{{ item }}"
         cache_valid_time: 300
@@ -82,6 +96,7 @@
       when: ansible_python_version is version('3', '>=')
 
     - name: Install boto3 which is required for EC2 stuff (Python 3)
+      tags: python
       pip: name=boto3
       when: ansible_python_version is version('3', '>=')
 
@@ -112,6 +127,9 @@
         instance_name: "{{ db_name }}"
         region: "{{ ec2_region }}"
       register: rds_database
+      tags:
+      - facts
+      - rds
       # Run this task even when running ansible-playbook with "--check"
       check_mode: false
       when: "db_name is defined"
@@ -119,7 +137,9 @@
     - name: Display information about the RDS database
       debug:
         var: "rds_database"
-      tags: facts
+      tags:
+        - facts
+        - rds
       when: "(show_rds_debug | default(false) | bool) and (db_name is defined)"
 
     - name: Get information about the planningalerts RDS instance
@@ -130,6 +150,9 @@
         instance_name: "{{ planningalerts_db_name }}"
         region: "{{ ec2_region }}"
       register: rds_planningalerts
+      tags:
+        - facts
+        - rds
       # Run this task even when running ansible-playbook with "--check"
       check_mode: false
       when: "planningalerts_db_name is defined"
@@ -137,10 +160,13 @@
     - name: Displays information about the planningalerts RDS instance
       debug:
         var: "rds_planningalerts"
-      tags: facts
+      tags:
+        - facts
+        - rds
       when: "(show_rds_debug | default(false) | bool) and (planningalerts_db_name is defined)"
 
 - hosts: all
+  tags: base-server
   become: true
   tags: base-server
   name: "Install base server packages"


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/414

Based on PRs (do not review this PR till the following are merged and this branch has been rebased):

* https://github.com/openaustralia/infrastructure/pull/447
* https://github.com/openaustralia/infrastructure/pull/448
* https://github.com/openaustralia/infrastructure/pull/449
* https://github.com/openaustralia/infrastructure/pull/450
* https://github.com/openaustralia/infrastructure/pull/451

## What does this do?

* Refactor down to just db_name used to discover db_host getting rid of engine and version dependent code
* Add environments list to iterate over elsewhere
* Update openaustralia role to handle either mysql 5 or 8 databases and use environments list

Stacked on:
* https://github.com/openaustralia/infrastructure/pull/412

## Why was this needed?

Ansible wasn't handling mysql8 and the code was overly repetitive (not DRY)

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
