### PR TITLE
Fix/cleanup vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,16 +62,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.verbose = "vv"
 
     ansible.groups = {
-      "righttoknow" => ["righttoknow.org.au.test"],
-      "planningalerts" => ["web.planningalerts.org.au.test"],
-      "theyvoteforyou" => ["theyvoteforyou.org.au.test"],
-      "oaf" => ["oaf.org.au.test"],
-      "openaustralia" => ["openaustralia.org.au.test"],
-      "proxy" => ["au.proxy.oaf.org.au.test"],
-      "metabase" => ["web.metabase.oaf.org.au.test"],
-      "mysql" => ["mysql.test"],
-      "postgresql" => ["postgresql.test"],
-      "redis" => ["redis.test"],
       "development" => [
         "righttoknow.org.au.test",
         "web.planningalerts.org.au.test",
@@ -83,7 +73,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "mysql.test",
         "postgresql.test",
         "redis.test"
-      ]
+      ],
+      "metabase" => ["web.metabase.oaf.org.au.test"],
+      "mysql" => ["mysql.test"],
+      "oaf" => ["oaf.org.au.test"],
+      "openaustralia" => ["openaustralia.org.au.test"],
+      "planningalerts" => ["web.planningalerts.org.au.test"],
+      "postgresql" => ["postgresql.test"],
+      "proxy" => ["au.proxy.oaf.org.au.test"],
+      "redis" => ["redis.test"],
+      "righttoknow" => ["righttoknow.org.au.test"],
+      "theyvoteforyou" => ["theyvoteforyou.org.au.test"],
+
+      # Server groups that are not used
+      "ec2" => [],
+      "openaustralia_new" => [],
+      "openaustralia_old" => [],
+      "openvpn" => [],
+      "plausible" => [],
+      "requires_mysql" => [],
+      "requires_mysql_5" => [],
+      "requires_postgresql" => [],
+      "righttoknow_production" => [],
+      "righttoknow_staging" => [],
     }
     tags = ENV["TAGS"].to_s.gsub(/[^A-Z0-9_]+/i, ",").split(",").reject { |s| s.to_s == "" }
     if tags.any?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,8 +101,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "requires_mysql_5" => ["openaustralia.org.au.test"],
       "requires_postgresql" => ["theyvoteforyou.org.au.test", "righttoknow.org.au.test", "web.metabase.oaf.org.au.test", "web.planningalerts.org.au.test"],
 
-      # Server groups that are not used / tested
+      # Empty list just so ansible doesn't complain it doesn't know about these cloud servers
       "ec2" => [],
+
+      # TODO: Consider adding hosts for these Server groups (that are used)
       "openvpn" => [],
       "plausible" => [],
     }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,39 +63,48 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     ansible.groups = {
       "development" => [
-        "righttoknow.org.au.test",
-        "web.planningalerts.org.au.test",
-        "theyvoteforyou.org.au.test",
+        "web.metabase.oaf.org.au.test",
+        "newprod.openaustralia.org.au.test",
         "oaf.org.au.test",
         "openaustralia.org.au.test",
-        "au.proxy.oaf.org.au.test",
-        "web.metabase.oaf.org.au.test",
+        "web.planningalerts.org.au.test",
+
         "mysql.test",
         "postgresql.test",
-        "redis.test"
+        "au.proxy.oaf.org.au.test",
+        "redis.test",
+
+        "righttoknow.org.au.test",
+        "theyvoteforyou.org.au.test",
+
       ],
-      "metabase" => ["web.metabase.oaf.org.au.test"],
+      # Services required by the servers 192.168.56.1x
       "mysql" => ["mysql.test"],
-      "oaf" => ["oaf.org.au.test"],
-      "openaustralia" => ["openaustralia.org.au.test"],
-      "planningalerts" => ["web.planningalerts.org.au.test"],
       "postgresql" => ["postgresql.test"],
       "proxy" => ["au.proxy.oaf.org.au.test"],
       "redis" => ["redis.test"],
+
+      # Servers 192.168.56.2x
+      "metabase" => ["web.metabase.oaf.org.au.test"],
+      "oaf" => ["oaf.org.au.test"],
+      "openaustralia" => ["openaustralia.org.au.test", "newprod.openaustralia.org.au.test"],
+      "openaustralia_old" => ["openaustralia.org.au.test"],
+      "openaustralia_new" => ["newprod.openaustralia.org.au.test"],
+      "planningalerts" => ["web.planningalerts.org.au.test"],
       "righttoknow" => ["righttoknow.org.au.test"],
+      "righttoknow_production" => [],
+      "righttoknow_staging" => ["righttoknow.org.au.test"],
       "theyvoteforyou" => ["theyvoteforyou.org.au.test"],
 
-      # Server groups that are not used
+      # Requirements
+      "requires_mysql" => ["newprod.openaustralia.org.au.test", "theyvoteforyou.org.au.test", "web.metabase.oaf.org.au.test"],
+      "requires_mysql_5" => ["openaustralia.org.au.test"],
+      "requires_postgresql" => ["theyvoteforyou.org.au.test", "righttoknow.org.au.test", "web.metabase.oaf.org.au.test", "web.planningalerts.org.au.test"],
+
+      # Server groups that are not used / tested
       "ec2" => [],
-      "openaustralia_new" => [],
-      "openaustralia_old" => [],
       "openvpn" => [],
       "plausible" => [],
-      "requires_mysql" => [],
-      "requires_mysql_5" => [],
-      "requires_postgresql" => [],
-      "righttoknow_production" => [],
-      "righttoknow_staging" => [],
     }
     tags = ENV["TAGS"].to_s.gsub(/[^A-Z0-9_]+/i, ",").split(",").reject { |s| s.to_s == "" }
     if tags.any?
@@ -116,18 +125,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   hosts = {
-    "righttoknow.org.au.test" => "192.168.56.10",
-    "web.planningalerts.org.au.test" => "192.168.56.11",
-    "theyvoteforyou.org.au.test" => "192.168.56.14",
-    "oaf.org.au.test" => "192.168.56.15",
-    "openaustralia.org.au.test" => "192.168.56.16",
-    "mysql.test" => "192.168.56.17",
-    # TODO: Do we want to seperate out the postgres for PA and everything else
+    # Services required by the servers
+    "mysql.test" => "192.168.56.10",
+    "postgresql.test" => "192.168.56.11",
+    "au.proxy.oaf.org.au.test" => "192.168.56.12",
+    "redis.test" => "192.168.56.13",
+
+    # Servers
+    "web.metabase.oaf.org.au.test" => "192.168.56.20",
+    "oaf.org.au.test" => "192.168.56.21",
+    "openaustralia.org.au.test" => "192.168.56.22",
+    "newprod.openaustralia.org.au.test" => "192.168.56.23",
+    "web.planningalerts.org.au.test" => "192.168.56.24",
+    "righttoknow.org.au.test" => "192.168.56.25",
     # so they can track production versions more accurately?
-    "postgresql.test" => "192.168.56.18",
-    "au.proxy.oaf.org.au.test" => "192.168.56.20",
-    "web.metabase.oaf.org.au.test" => "192.168.56.21",
-    "redis.test" => "192.168.56.22"
+    "theyvoteforyou.org.au.test" => "192.168.56.26",
+    # TODO: Do we want to seperate out the postgres for PA and everything else
   }
 
   # Use this so that you don't need to give the machine name for all vagrant
@@ -138,7 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define hostname, primary: (hostname == primary_host) do |host|
       host.vm.box = case hostname
                     # Only a few services so far are using a more recent version of Ubuntu
-                    when "web.metabase.oaf.org.au.test", "redis.test", "web.planningalerts.org.au.test", "postgresql.test"
+                    when "web.metabase.oaf.org.au.test", "redis.test", "web.planningalerts.org.au.test", "postgresql.test", "newprod.openaustralia.org.au.test"
                       # jammy (22.04 LTS) "standard" support ends in April 2027
                       "ubuntu/jammy64"
                     when "theyvoteforyou.org.au.test"
@@ -152,7 +165,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                       # xenial (16.04 LTS) "standard" support ended in April 2021!
                       "ubuntu/xenial64"
                     else
-                      raise "Couldn't figure out version of ubuntu"
+                      raise "Couldn't figure out version of ubuntu for #{hostname}"
                     end
       host.vm.network :private_network, ip: ip
       host.vm.hostname = hostname

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -1,7 +1,7 @@
 righttoknow_domain: righttoknow.org.au.test
-mysql_host: 192.168.56.17
-postgresql_host: 192.168.56.18
-planningalerts_db_host: 192.168.56.18
+mysql_host: 192.168.56.10
+postgresql_host: 192.168.56.11
+planningalerts_db_host: 192.168.56.11
 openaustralia_domain: openaustralia.org.au.test
 theyvoteforyou_domain: theyvoteforyou.org.au.test
 newrelic_license_key: null


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/407

## What does this do?

List ansible groups used in Vagrantfile in order, and explicitly list the normal groups as empty groups to help diagnose differences between vagrant and ec2

## Why was this needed?

Clear understanding of vagrant environment

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
