### PR TITLE
Update instructions in site.yml regarding key files

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,8 @@
-## FIRST: edit the `vault_identity_list` in ``ansible.cfg``
-# and make sure  you have all the password files you need.
+# FIRST: check the `vault_identity_list` in `ansible.cfg` using
+# `ls -ld .*pass*`
+# and make sure you have all the password files you need.
+# If you are missing some, then you can override the list using a `.envrc` entry, eg:
+# export ANSIBLE_VAULT_IDENTITY_LIST=".vault_pass.txt,ec2@.ec2-vault-pass,all@.all-vault-pass"
 
 ## THEN
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/205

## What does this do?

Fixes instructions at top of site.yml 

Stacked on top of:
* https://github.com/openaustralia/infrastructure/pull/412

## Why was this needed?

I noticed it was a bad approach and dangerous (we don't want keys to be dropped and committed back to the repo by accident)

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
