### PR TITLE
Increase apt lock timeout from 60 second default to 300 (upgrade of ansible required)

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -40,3 +40,6 @@ github_users:
 
 # User python3
 ansible_python_interpreter: /usr/bin/python3
+
+# Fix "Failed to update apt cache" errors by increasing timeout from default 60 seconds
+apt_lock_timeout: 300

--- a/roles/internal/base-server/tasks/main.yml
+++ b/roles/internal/base-server/tasks/main.yml
@@ -3,14 +3,15 @@
 - name: Ensure git is installed
   apt:
     pkg: git
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # Setup timezone stuff
 
 - name: Install tzdata package
-  apt: pkg=tzdata state=present
+  apt: pkg=tzdata state=present lock_timeout="{{ apt_lock_timeout }}"
 
 - name: Install ACL (required for Ansible to work)
-  apt: pkg=acl state=present
+  apt: pkg=acl state=present lock_timeout="{{ apt_lock_timeout }}"
 
 # We have to do it like this for Ubuntu 16.04
 # See https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806

--- a/roles/internal/metabase/.travis.yml
+++ b/roles/internal/metabase/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
     - python-pip
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 install:
   # Install ansible

--- a/roles/internal/metabase/tasks/main.yml
+++ b/roles/internal/metabase/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install dependency for postgresql_db
   apt:
     pkg: python3-psycopg2
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Ensure that we have the Docker repository key
   apt_key:
@@ -13,6 +14,7 @@
 
 - name: Install docker
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     name:
       - docker-ce 
       - docker-ce-cli
@@ -20,10 +22,12 @@
 
 - name: Install dependency for ansible mysql_db module
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     pkg: python3-mysqldb
 
 - name: Install pip
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     pkg: python3-pip
 
 - name: Install docker-compose python library

--- a/roles/internal/mysql/tasks/main.yml
+++ b/roles/internal/mysql/tasks/main.yml
@@ -6,9 +6,10 @@
   apt:
     pkg: mysql-server
     update_cache: yes
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install dependency for following command
-  apt: pkg=python-mysqldb
+  apt: pkg=python-mysqldb lock_timeout="{{ apt_lock_timeout }}"
 
 - name: Update mysql config to bind to public ip
   copy:

--- a/roles/internal/oaf.backup/tasks/install.deb.yml
+++ b/roles/internal/oaf.backup/tasks/install.deb.yml
@@ -3,7 +3,7 @@
 - include_vars: "{{ansible_distribution}}.yml"
 
 - name: Install dependencies (Ubuntu 18.04 and earlier)
-  apt: name={{item}}
+  apt: name={{item}} lock_timeout="{{ apt_lock_timeout }}"
   with_items:
   - cron
   - gzip
@@ -12,7 +12,7 @@
   when: ansible_distribution_release not in ['focal', 'jammy']
 
 - name: Install dependencies (Ubuntu 20.04 and 22.04)
-  apt: name={{item}}
+  apt: name={{item}} lock_timeout="{{ apt_lock_timeout }}"
   with_items:
   - cron
   - gzip
@@ -24,4 +24,4 @@
   when: backup_duplicity_version
 
 - name: Install duplicity
-  apt: pkg={{backup_duplicity_pkg}}
+  apt: pkg={{backup_duplicity_pkg}} lock_timeout="{{ apt_lock_timeout }}"

--- a/roles/internal/oaf.certbot/tasks/main.yml
+++ b/roles/internal/oaf.certbot/tasks/main.yml
@@ -10,15 +10,18 @@
 
 - name: Install certbot
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     pkg: certbot
 
 - name: Install certbot plugin (python != 3)
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     pkg: "python-certbot-{{ certbot_webserver }}"
   when: ansible_python['version']['major'] != 3
 
 - name: Install certbot plugin (python == 3)
   apt:
+    lock_timeout: "{{ apt_lock_timeout }}"
     pkg: "python3-certbot-{{ certbot_webserver }}"
   when: ansible_python['version']['major'] == 3
 

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: Install dependency for ansible mysql_db module
   when: "'openaustralia_old' in group_names"
-  apt: pkg=python-mysqldb
+  apt: pkg=python-mysqldb lock_timeout="{{ apt_lock_timeout }}"
 
 - name: Create openaustralia databases
   when: "'openaustralia_old' in group_names"
@@ -171,7 +171,7 @@
   notify: reload apache
 
 - name: Install apache now (for the benefit of certbot)
-  apt: pkg=apache2
+  apt: pkg=apache2 lock_timeout="{{ apt_lock_timeout }}"
   when: "'ec2' in group_names"
 
 # Install php5 on xenial requires a few more jumps than usual
@@ -184,6 +184,7 @@
   apt:
     name: "{{ item }}"
     update_cache: yes
+    lock_timeout: "{{ apt_lock_timeout }}"
   with_items:
     - php5.6
     - php5.6-curl
@@ -213,6 +214,7 @@
   apt:
     name: "{{ item }}"
     update_cache: yes
+    lock_timeout: "{{ apt_lock_timeout }}"
   with_items:
     - apache2
     - ghostscript
@@ -481,6 +483,7 @@
 - name: Install postfix so we can mail out from cron jobs
   apt:
     pkg: postfix
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # For local development (under vagrant we don't want the cron jobs generating email)
 - cronvar:
@@ -495,6 +498,7 @@
   apt:
     pkg: newrelic-php5
     state: absent
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Configure newrelic php monitor
   file:
@@ -522,6 +526,7 @@
 - name: Autoremove unneeded packages
   apt:
     autoremove: yes
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # We allow the capistrano deploys to restart apache
 - name: Allow deploy user to restart apache

--- a/roles/internal/openvpn/tasks/main.yml
+++ b/roles/internal/openvpn/tasks/main.yml
@@ -11,6 +11,7 @@
     state: present
     update_cache: yes
     cache_valid_time: 3600
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install AWS CLI and boto3 via pip
   pip:
@@ -133,6 +134,7 @@
   apt:
     name: iptables-persistent
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Save iptables rules
   shell: iptables-save > /etc/iptables/rules.v4

--- a/roles/internal/planningalerts/tasks/database.yml
+++ b/roles/internal/planningalerts/tasks/database.yml
@@ -3,6 +3,7 @@
 - name: Install dependency for postgresql_db
   apt:
     pkg: python3-psycopg2
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: "Create planningalerts database on postgres"
   postgresql_db:

--- a/roles/internal/planningalerts/tasks/main.yml
+++ b/roles/internal/planningalerts/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install memcached
   apt:
     pkg: memcached
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Make memcached listen to the outside world
   lineinfile:
@@ -37,6 +38,7 @@
       # Needed for rgeo geos support. See https://github.com/rgeo/rgeo/issues/227#issuecomment-1145169888
       - libgeos++-dev
       - libgeos-dev
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Copy rails master key for production
   template:
@@ -54,6 +56,7 @@
 - name: Install postfix to handle incoming email
   apt:
     pkg: postfix
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Update postfix configuration
   template:

--- a/roles/internal/postgresql/tasks/main.yml
+++ b/roles/internal/postgresql/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Install postgresql 15 server
   apt:
     name: postgresql-15
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Update postgresql config to bind to public ip
   lineinfile:
@@ -32,6 +33,7 @@
 - name: Install dependency for postgresql_user
   apt:
     pkg: python3-psycopg2
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Create root user
   postgresql_user:

--- a/roles/internal/proxy/tasks/main.yml
+++ b/roles/internal/proxy/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install compiler
   apt:
     pkg: build-essential
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Download tinyproxy source code
   get_url:

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -32,6 +32,7 @@
 - name: Install varnish and nginx now (for the benefit of certbot)
   apt:
     pkg: "{{ item }}"
+    lock_timeout: "{{ apt_lock_timeout }}"
   with_items:
     - varnish
     - nginx

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: apache2
     state: absent
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Add key for passenger
   ansible.builtin.get_url:
@@ -20,6 +21,7 @@
       - libnginx-mod-http-passenger
       - nginx
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # We want this directory to exist in development too so that
 # things are as consistent as possible
@@ -173,6 +175,7 @@
       - wv
       - xapian-tools
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install sidekiq systemd unit (staging)
   template:
@@ -228,6 +231,7 @@
 - name: Install dependency for postgresql_db
   apt:
     pkg: python3-psycopg2
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Create database
   postgresql_db:
@@ -424,6 +428,7 @@
 - name: Install varnish
   apt:
     pkg: varnish
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Update varnish config
   copy:
@@ -448,6 +453,7 @@
       # Only needed to run opendkim-genkey
       # TODO: Probably don't need opendkim-tools in production
       - opendkim-tools
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Create directory for DKIM keypair
   file:
@@ -518,3 +524,4 @@
 - name: Install memcached
   apt:
     pkg: memcached
+    lock_timeout: "{{ apt_lock_timeout }}"

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: apache2
     state: absent
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Add key for passenger
   apt_key:
@@ -13,6 +14,7 @@
   apt:
     name: apt-transport-https
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Apt add passenger to list
   apt_repository:
@@ -26,15 +28,18 @@
       - libnginx-mod-http-passenger
       - nginx
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install memcached
   apt:
     pkg: memcached
     state: present
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install pip
   apt:
     pkg: python3-pip
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Install dependency for following command
   pip:
@@ -158,6 +163,7 @@
 - name: Ensure package to build gem native extensions are installed
   apt:
     pkg: libmysqlclient-dev
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # Create fake let's encrypt directories when in development
 - name: Create fake let's encrypt directories when in development
@@ -284,6 +290,7 @@
 - name: Install postfix so we can mail out from cron jobs
   apt:
     pkg: postfix
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 # TODO: Make this mail to different addresses for development/production
 - name: Mail output of cron
@@ -315,6 +322,7 @@
     pkg: google-chrome-stable
     # We want to make sure we're always running the latest version
     state: latest
+    lock_timeout: "{{ apt_lock_timeout }}"
 
 - name: Get latest version number for chromedriver
   uri:

--- a/site.yml
+++ b/site.yml
@@ -43,6 +43,7 @@
       apt:
         pkg:  "{{ item }}"
         cache_valid_time: 300
+        lock_timeout: "{{ apt_lock_timeout }}"
       loop:
         - python-pip
         - python-pymysql
@@ -57,6 +58,7 @@
       apt:
         pkg: "{{ item }}"
         cache_valid_time: 300
+        lock_timeout: "{{ apt_lock_timeout }}"
       loop:
         - python3-pip
         - python3-pymysql
@@ -202,6 +204,7 @@
     - name: Install redis
       apt:
         name: redis
+        lock_timeout: "{{ apt_lock_timeout }}"
     - name: Make redis listen on 0.0.0.0
       lineinfile:
         path: /etc/redis/redis.conf


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/438

NOTE: We will have to upgrade from ansible 2.10 (EOL May 2022) to 2.18 (released in late 2024 and matches the python v3.11.13 we are using)

## What does this do?

Fixes lock conflict if unattended-updates is running in background for internal roles

Increase apt lock timeout from 60 second default to 300

Note - external roles may still fail

## Why was this needed?

Ben said:
> When running make apply-righttoknow STAGE=all it fails to run intermittently with the error failed: [staging.righttoknow.org.au] (item=python3-pip) => {"ansible_loop_var": "item", "changed": false, "item": "python3-pip", "msg": "Failed to update apt cache: unknown reason"}

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

I have encountered this issue on other projects.

We can up the timeout further if needed - the first time it runs on a new VM it will take time.