### PR TITLE
Feature/base domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
-.PHONY: all ansible-lint apply-metabase apply-oaf apply-openaustralia \
+.PHONY: all ansible-lint apply-metabase apply-oaf requirements apply-openaustralia \
         apply-planningalerts apply-righttoknow apply-rtk-prod apply-rtk-staging apply-theyvoteforyou \
         check-host check-metabase check-oaf check-openaustralia check-planningalerts check-righttoknow \
         check-rtk-prod check-rtk-staging check-theyvoteforyou \
         clean clobber help install-linters keybase letsencrypt lint production retry roles \
         show-facts show-inventory show-rds-facts show-vars stage_required tf-apply tf-init tf-plan \
         update-github-ssh-keys vagrant venv yaml-lint
-
-ANSIBLE_DEPENDENCIES := .keybase .make/roles venv
 
 _STAGE := $(if $(filter-out all,$(STAGE)),_$(STAGE),)
 
@@ -36,9 +34,11 @@ endif
 help:
 	@echo "Available targets"
 	@echo "  help                                Output this help text"
-	@echo "  venv                                Create Python virtualenv and install requirements"
-	@echo "  roles                               Install Ansible Galaxy external roles and collections"
 	@echo "  all                                 Run full site.yml playbook against all hosts"
+	@echo "  requirements                        Install requirements: venv, roles, collections and keybase symlink"
+	@echo "  keybase                             Set up Keybase symlink for MacOS or Linux and check perms"
+	@echo "  roles                               Install Ansible Galaxy external roles and collections"
+	@echo "  venv                                Create Python virtualenv and install requirements"
 	@echo "Independent targets (not required by all):"
 	@echo "  letsencrypt                         Renew/update SSL certificates"
 	@echo "  retry                               Re-run site.yml limited to hosts from last failed run"
@@ -52,7 +52,6 @@ help:
 	@echo "  tf-apply                            Run terraform apply in the terraform directory"
 	@echo "  update-github-ssh-keys              Update SSH keys on all servers from GitHub"
 	@echo "  vagrant                             Install vagrant plugins"
-	@echo "  keybase                             Set up Keybase symlink for MacOS or Linux and check perms"
 	@echo "  clean                               Remove virtualenv, external roles, retry file, collections, keybase symlink"
 	@echo "  clobber                             clobber everything make all created (clean + removes .vagrant and log)"
 	@echo ""
@@ -77,6 +76,8 @@ help:
 	@echo "  ANSIBLE_VERBOSE  Ansible verbosity flag, e.g. ANSIBLE_VERBOSE=vvv"
 	@echo "  START_AT_TASK  Start playbook at first task matching this string (fuzzy, * wildcards added)"
 
+requirements: .keybase .make/roles venv
+
 # Configure .keybase for MacOS or Linux
 .keybase:
 	@for p in /Volumes/Keybase /keybase /run/keybase /var/lib/keybase "$$(keybase config get -d -b mountdir 2>/dev/null)"; do \
@@ -93,12 +94,12 @@ keybase: .keybase
 	done; \
 	[ $$broken -eq 0 ]
 
-vagrant: log/vagrant-plugin.log
+vagrant: .make/vagrant-plugins
 
-log/vagrant-plugin.log: Makefile
+.make/vagrant-plugins: Makefile | .make
 	mkdir -p log
 	VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install vagrant-hostsupdater
-	vagrant plugin list > log/vagrant-plugin.log
+	touch .make/vagrant-plugins
 
 venv: .venv/bin/activate
 
@@ -121,13 +122,13 @@ venv: .venv/bin/activate
 
 roles: .make/roles
 
-all: $(ANSIBLE_DEPENDENCIES)
+all: requirements
 	.venv/bin/ansible-playbook site.yml
 
-letsencrypt: $(ANSIBLE_DEPENDENCIES)
+letsencrypt: requirements
 	.venv/bin/ansible-playbook update-ssl-certs.yml
 
-retry: $(ANSIBLE_DEPENDENCIES) site.retry
+retry: requirements site.retry
 	.venv/bin/ansible-playbook site.yml -l @site.retry
 
 check-host:
@@ -137,16 +138,16 @@ ifndef host
 	@exit 1
 endif
 
-show-inventory: $(ANSIBLE_DEPENDENCIES)
+show-inventory: requirements
 	.venv/bin/ansible-inventory -i ./inventory/ec2-hosts --graph
 
-show-vars: check-host $(ANSIBLE_DEPENDENCIES)
+show-vars: check-host requirements
 	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m debug -a "var=hostvars[inventory_hostname]"
 
-show-facts: check-host $(ANSIBLE_DEPENDENCIES)
+show-facts: check-host requirements
 	.venv/bin/ansible -i ./inventory/ec2-hosts $(host) -m setup
 
-show-rds-facts: check-host $(ANSIBLE_DEPENDENCIES)
+show-rds-facts: check-host requirements
 	.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml --limit $(host) --tags facts -e "show_rds_debug=true"
 
 # Delete all files that are normally created by running make goals
@@ -173,36 +174,36 @@ ifndef STAGE
 endif
 
 # Checks only
-check-righttoknow: $(ANSIBLE_DEPENDENCIES) stage_required
+check-righttoknow: requirements stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l righttoknow$(_STAGE) --check --diff
-check-planningalerts: $(ANSIBLE_DEPENDENCIES) # stage_required
+check-planningalerts: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l planningalerts$(_STAGE) --check --diff
-check-theyvoteforyou: $(ANSIBLE_DEPENDENCIES) # stage_required
+check-theyvoteforyou: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l theyvoteforyou$(_STAGE) --check --diff
-check-oaf: $(ANSIBLE_DEPENDENCIES) # stage_required
+check-oaf: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l oaf$(_STAGE) --check --diff
-check-openaustralia: $(ANSIBLE_DEPENDENCIES) stage_required
+check-openaustralia: requirements stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l openaustralia$(_STAGE) --check --diff
-check-metabase: $(ANSIBLE_DEPENDENCIES) # stage_required
+check-metabase: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l metabase$(_STAGE) --check --diff
 
 # These make changes 
-apply-righttoknow: $(ANSIBLE_DEPENDENCIES) stage_required
+apply-righttoknow: requirements stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l righttoknow$(_STAGE) --diff
-apply-planningalerts: $(ANSIBLE_DEPENDENCIES) # stage_required
+apply-planningalerts: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l planningalerts$(_STAGE) --diff
-apply-theyvoteforyou: $(ANSIBLE_DEPENDENCIES) # stage_required
+apply-theyvoteforyou: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l theyvoteforyou$(_STAGE) --diff
-apply-oaf: $(ANSIBLE_DEPENDENCIES) # stage_required
+apply-oaf: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l oaf$(_STAGE) --diff
-apply-openaustralia: $(ANSIBLE_DEPENDENCIES) stage_required
+apply-openaustralia: requirements stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l openaustralia$(_STAGE) --diff
 
-apply-metabase: $(ANSIBLE_DEPENDENCIES) # stage_required
+apply-metabase: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory/ec2-hosts site.yml -l metabase$(_STAGE) --diff
 
 # Update ssh keys on all servers
-update-github-ssh-keys: $(ANSIBLE_DEPENDENCIES)
+update-github-ssh-keys: requirements
 	.venv/bin/ansible-playbook site.yml --tags userkeys
 
 yaml-lint: venv

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ There's a very handy `Makefile` included which will:
 Simply run
 
 ```
-make roles vagrant
+make requirements vagrant
 ```
 
 ### <a name='AddtheAnsibleVaultpassword'></a>Add the Ansible Vault password

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,7 +88,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Servers
     "web.metabase.oaf" => { node: 20,
                             box: "ubuntu/jammy64",
-                            groups: ["metabase", "requires_mysql", "requires_postgresql"] },
+                            groups: ["metabase", "requires_postgresql"] },
     "oaf" => { node: 21,
                box: "ubuntu/bionic64",
                groups: ["oaf"] },
@@ -113,7 +113,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "theyvoteforyou" => { node: 26,
                           box: "ubuntu/focal64",
                           aliases: STANDARD_ALIASES,
-                          groups: ["theyvoteforyou", "requires_mysql", "requires_postgresql"] },
+                          groups: ["theyvoteforyou", "requires_mysql"] },
     # FIXME: Has not been constructed, and is not in any (extra) group
     # "vpn.oaf" => { node: 27,
     #                       box: "ubuntu/jammy64",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,17 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+BASE_DOMAIN = "test"
+IP_NETWORK = "192.168.56"
+STANDARD_ALIASES = %w[www test www.test]
+
+unless File.exist?(".venv/bin/ansible") && Dir.exist?(".keybase") && Dir.exist?("roles/external")
+  warn "WARNING: .venv/bin/ansible is missing. Run `make requirements` first."
+end
+unless File.exist?(".make/vagrant-plugins")
+  warn "WARNING: .venv/bin/ansible is missing. Run `make vagrant` first."
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
@@ -53,6 +64,67 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
+  # noble (24.04 LTS) "standard" support ends in April 2029 (Yet to be used)
+  # jammy (22.04 LTS) "standard" support ends in April 2027
+  # focal (20.04 LTS) "standard" support ends in April 2025 EOL!
+  # bionic (18.04 LTS) "standard" support ends in April 2023 EOL!
+  # xenial (16.04 LTS) "standard" support ended in April 2021 EOL!
+  hosts = {
+    # Services required by the servers
+    "mysql" => { node: 10,
+                 box: "ubuntu/xenial64",
+                 groups: ["mysql"] },
+    # TODO: Do we want to seperate out the postgres for PA and everything else
+    "postgresql" => { node: 11,
+                      box: "ubuntu/jammy64",
+                      groups: ["postgresql"] },
+    "au.proxy.oaf" => { node: 12,
+                        box: "ubuntu/xenial64",
+                        groups: ["proxy"] },
+    "redis" => { node: 13,
+                 box: "ubuntu/jammy64",
+                 groups: ["redis"] },
+
+    # Servers
+    "web.metabase.oaf" => { node: 20,
+                            box: "ubuntu/jammy64",
+                            groups: ["metabase", "requires_mysql", "requires_postgresql"] },
+    "oaf" => { node: 21,
+               box: "ubuntu/bionic64",
+               groups: ["oaf"] },
+    "openaustralia" => { node: 22,
+                         box: "ubuntu/xenial64",
+                         aliases: STANDARD_ALIASES + ["data", "software"],
+                         groups: ["openaustralia", "openaustralia_old", "requires_mysql_5"] },
+    "newprod.openaustralia" => { node: 23,
+                                 box: "ubuntu/jammy64",
+                                 groups: ["openaustralia", "openaustralia_new", "requires_mysql"] },
+    "web.planningalerts" => { node: 24,
+                              box: "ubuntu/jammy64",
+                              groups: ["planningalerts", "requires_postgresql"] },
+    "staging.righttoknow" => { node: 25,
+                               box: "ubuntu/bionic64",
+                               aliases: STANDARD_ALIASES,
+                               groups: ["righttoknow", "righttoknow_staging", "requires_postgresql"] },
+    "prod.righttoknow" => { node: 25,
+                            box: "ubuntu/bionic64",
+                            aliases: STANDARD_ALIASES,
+                            groups: ["righttoknow", "righttoknow_production", "requires_postgresql"] },
+    "theyvoteforyou" => { node: 26,
+                          box: "ubuntu/focal64",
+                          aliases: STANDARD_ALIASES,
+                          groups: ["theyvoteforyou", "requires_mysql", "requires_postgresql"] },
+    # FIXME: Has not been constructed, and is not in any (extra) group
+    # "vpn.oaf" => { node: 27,
+    #                       box: "ubuntu/jammy64",
+    #                       groups: [] },
+
+    "openvpn" => { node: 28,
+                   box: "ubuntu/jammy64",
+                   groups: ["openvpn"] },
+
+  }
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
     ansible.compatibility_mode = "2.0"
@@ -62,44 +134,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.verbose = "vv"
 
     ansible.groups = {
-      "development" => [
-        "web.metabase.oaf.org.au.test",
-        "newprod.openaustralia.org.au.test",
-        "oaf.org.au.test",
-        "openaustralia.org.au.test",
-        "web.planningalerts.org.au.test",
-
-        "mysql.test",
-        "postgresql.test",
-        "au.proxy.oaf.org.au.test",
-        "redis.test",
-
-        "righttoknow.org.au.test",
-        "theyvoteforyou.org.au.test",
-
-      ],
-      # Services required by the servers 192.168.56.1x
-      "mysql" => ["mysql.test"],
-      "postgresql" => ["postgresql.test"],
-      "proxy" => ["au.proxy.oaf.org.au.test"],
-      "redis" => ["redis.test"],
-
-      # Servers 192.168.56.2x
-      "metabase" => ["web.metabase.oaf.org.au.test"],
-      "oaf" => ["oaf.org.au.test"],
-      "openaustralia" => ["openaustralia.org.au.test", "newprod.openaustralia.org.au.test"],
-      "openaustralia_old" => ["openaustralia.org.au.test"],
-      "openaustralia_new" => ["newprod.openaustralia.org.au.test"],
-      "planningalerts" => ["web.planningalerts.org.au.test"],
-      "righttoknow" => ["righttoknow.org.au.test"],
-      "righttoknow_production" => [],
-      "righttoknow_staging" => ["righttoknow.org.au.test"],
-      "theyvoteforyou" => ["theyvoteforyou.org.au.test"],
-
-      # Requirements
-      "requires_mysql" => ["newprod.openaustralia.org.au.test", "theyvoteforyou.org.au.test", "web.metabase.oaf.org.au.test"],
-      "requires_mysql_5" => ["openaustralia.org.au.test"],
-      "requires_postgresql" => ["theyvoteforyou.org.au.test", "righttoknow.org.au.test", "web.metabase.oaf.org.au.test", "web.planningalerts.org.au.test"],
+      "development" => [ ],
 
       # Empty list just so ansible doesn't complain it doesn't know about these cloud servers
       "ec2" => [],
@@ -108,15 +143,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "openvpn" => [],
       "plausible" => [],
     }
+    hosts.each do |hostname, details|
+      hostname = "#{hostname}.#{BASE_DOMAIN}"
+      ansible.groups["development"] << hostname
+      details[:groups]&.each do |group|
+        ansible.groups[group] ||= []
+        ansible.groups[group] << hostname
+      end
+    end
     tags = ENV["TAGS"].to_s.gsub(/[^A-Z0-9_]+/i, ",").split(",").reject { |s| s.to_s == "" }
     if tags.any?
+      tags = tags + ["facts"]
       puts "INFO: Only running TAGS: #{tags.inspect}"
       ansible.tags = tags if tags.any?
-    end
-    start_at_task = "*#{ENV.fetch('START_AT_TASK', nil)}*".gsub(/[^A-Z0-9_]+/i, "*")
-    if start_at_task != "*"
-      puts "INFO: Starting at task matching: #{start_at_task}"
-      ansible.start_at_task = start_at_task
     end
   end
 
@@ -126,58 +165,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.cpus = 2
   end
 
-  hosts = {
-    # Services required by the servers
-    "mysql.test" => "192.168.56.10",
-    "postgresql.test" => "192.168.56.11",
-    "au.proxy.oaf.org.au.test" => "192.168.56.12",
-    "redis.test" => "192.168.56.13",
-
-    # Servers
-    "web.metabase.oaf.org.au.test" => "192.168.56.20",
-    "oaf.org.au.test" => "192.168.56.21",
-    "openaustralia.org.au.test" => "192.168.56.22",
-    "newprod.openaustralia.org.au.test" => "192.168.56.23",
-    "web.planningalerts.org.au.test" => "192.168.56.24",
-    "righttoknow.org.au.test" => "192.168.56.25",
-    # so they can track production versions more accurately?
-    "theyvoteforyou.org.au.test" => "192.168.56.26",
-    # TODO: Do we want to seperate out the postgres for PA and everything else
-  }
-
   # Use this so that you don't need to give the machine name for all vagrant
   # commands. Set this to whatever you're most working on at the moment.
-  primary_host = "metabase.oaf.org.au.test"
+  primary_host = ENV.fetch("DEFAULT_VAGRANT_HOST", "metabase.oaf.#{BASE_DOMAIN}")
 
-  hosts.each do |hostname, ip|
+  hosts.each do |hostname, details|
+    hostname = "#{hostname}.#{BASE_DOMAIN}"
     config.vm.define hostname, primary: (hostname == primary_host) do |host|
-      host.vm.box = case hostname
-                    # Only a few services so far are using a more recent version of Ubuntu
-                    when "web.metabase.oaf.org.au.test", "redis.test", "web.planningalerts.org.au.test", "postgresql.test", "newprod.openaustralia.org.au.test"
-                      # jammy (22.04 LTS) "standard" support ends in April 2027
-                      "ubuntu/jammy64"
-                    when "theyvoteforyou.org.au.test"
-                      # focal (20.04 LTS) "standard" support ends in April 2025
-                      "ubuntu/focal64"
-                    when "righttoknow.org.au.test", "oaf.org.au.test"
-                      # bionic (18.04 LTS) "standard" support ends in April 2023
-                      "ubuntu/bionic64"
-                    when "openaustralia.org.au.test",
-                        "au.proxy.oaf.org.au.test", "mysql.test"
-                      # xenial (16.04 LTS) "standard" support ended in April 2021!
-                      "ubuntu/xenial64"
-                    else
-                      raise "Couldn't figure out version of ubuntu for #{hostname}"
-                    end
-      host.vm.network :private_network, ip: ip
+      host.vm.box = details[:box]
+      host.vm.network :private_network, ip: "#{IP_NETWORK}.#{details[:node]}"
       host.vm.hostname = hostname
       # For each host set up some common aliases
-      host.hostsupdater.aliases = [
-        "test.#{hostname}",
-        "www.#{hostname}",
-        "www.test.#{hostname}",
-        "api.#{hostname}"
-      ]
+      host.hostsupdater.aliases = details[:aliases].map { |a| "#{a}.#{hostname}" } if details[:aliases]
     end
   end
 end

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,5 +1,9 @@
 # File: group_vars/all.yml
 ---
+theyvoteforyou_domain: "theyvoteforyou.{{ base_domain }}"
+openaustralia_domain: "openaustralia.{{ base_domain }}"
+righttoknow_domain: "righttoknow.{{ base_domain }}"
+
 rds_admin_password: !vault |
           $ANSIBLE_VAULT;1.2;AES256;all
           30383165353964666234363861623736333762643130633934366361623739393636343933303962

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -1,9 +1,9 @@
-righttoknow_domain: righttoknow.org.au.test
+base_domain: test
+
 mysql_host: 192.168.56.10
 postgresql_host: 192.168.56.11
 planningalerts_db_host: 192.168.56.11
-openaustralia_domain: openaustralia.org.au.test
-theyvoteforyou_domain: theyvoteforyou.org.au.test
+
 newrelic_license_key: null
 devsite: true
 rds_admin_password: 1234567890

--- a/group_vars/ec2.yml
+++ b/group_vars/ec2.yml
@@ -1,10 +1,11 @@
 ---
-theyvoteforyou_domain: theyvoteforyou.org.au
-openaustralia_domain: openaustralia.org.au
-righttoknow_domain: righttoknow.org.au
+base_domain: org.au
+
 ansible_user: ubuntu
 ansible_ssh_private_key_file: 'terraform.pem'
+
 ec2_region: 'ap-southeast-2'
+
 # TODO: We only need this key to have limited privileges. It currently has too many privileges.
 aws_access_key: !vault |
           $ANSIBLE_VAULT;1.2;AES256;ec2

--- a/host_vars/righttoknow.org.au.test.yml
+++ b/host_vars/righttoknow.org.au.test.yml
@@ -1,4 +1,4 @@
-site_name: righttoknow.org.au.test
+site_name: righttoknow.test
 db_password_production: db_password_production
 db_password_staging: db_password_staging
 alavateli_incoming_email_secret: alavateli_incoming_email_secret

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -17,6 +17,7 @@
 # INVENTORY IN alphabetical order by group name
 
 [ec2]
+# NOTE: The planning alerts servers are NOT in ec2!
 theyvoteforyou.org.au
 openaustralia.org.au
 newprod.openaustralia.org.au

--- a/roles/internal/openaustralia/templates/apache/blog.conf
+++ b/roles/internal/openaustralia/templates/apache/blog.conf
@@ -2,6 +2,6 @@
 
 <VirtualHost *:80>
     ServerName blog.openaustralia.org
-    RedirectMatch permanent ^/$ https://www.openaustraliafoundation.org.au/blog
-    RedirectMatch permanent ^/(.*) https://www.openaustraliafoundation.org.au/$1
+    RedirectMatch permanent ^/$ https://www.openaustraliafoundation.{{ base_domain }}/blog
+    RedirectMatch permanent ^/(.*) https://www.openaustraliafoundation.{{ base_domain }}/$1
 </VirtualHost>

--- a/roles/internal/openvpn/defaults/main.yml
+++ b/roles/internal/openvpn/defaults/main.yml
@@ -6,7 +6,7 @@ openvpn_country: "AU"
 openvpn_province: "NSW"
 openvpn_city: "Sydney"
 openvpn_org: "OAF"
-openvpn_email: "admin@openaustraliafoundation.org.au"
+openvpn_email: "admin@openaustraliafoundation.{{ base_domain }}"
 openvpn_ou: "IT"
 openvpn_key_size: 2048
 openvpn_ca_expire: 3650

--- a/roles/internal/planningalerts/tasks/main.yml
+++ b/roles/internal/planningalerts/tasks/main.yml
@@ -84,4 +84,5 @@
   command: postconf -e "transport_maps=regexp:/etc/postfix/transport"
 
 - name: Set postfix destination  # noqa: no-changed-when
-  command: postconf -e "mydestination=planningalerts.org.au"
+  command: postconf -e "mydestination=planningalerts.{{ base_domain }}"
+

--- a/roles/internal/planningalerts/templates/incoming-email.sh
+++ b/roles/internal/planningalerts/templates/incoming-email.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 export PATH=/usr/local/bin:/usr/bin
-bin/rails action_mailbox:ingress:postfix URL=https://www.planningalerts.org.au/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD={{ ingress_password }} RAILS_ENV=production
+bin/rails action_mailbox:ingress:postfix URL=https://www.planningalerts.{{ base_domain }}/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD={{ ingress_password }} RAILS_ENV=production

--- a/roles/internal/planningalerts/templates/virtual_alias
+++ b/roles/internal/planningalerts/templates/virtual_alias
@@ -1,1 +1,1 @@
-/@planningalerts.org.au/ planningalerts
+/@planningalerts.{{ base_domain }}/ planningalerts

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -41,7 +41,7 @@
 - name: Set certificate configuration for staging
   set_fact:
     staging_certs:
-      - email: 'contact@oaf.org.au'
+      - email: 'contact@oaf.{{ base_domain }}'
         domains: 
           - "{{ righttoknow_domain }}"
           - "www.{{ righttoknow_domain }}"
@@ -50,7 +50,7 @@
 - name: Set certificate configuration for production
   set_fact:
     production_certs:
-      - email: 'contact@oaf.org.au'
+      - email: 'contact@oaf.{{ base_domain }}'
         domains: 
           - "{{ righttoknow_domain }}"
           - "www.{{ righttoknow_domain }}"

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -377,7 +377,7 @@
     site_name: "Right to Know (STAGING)"
     incoming_email_prefix: "foitest+"
     staging_site: "1"
-    override_all_public_body_request_emails: "contact@righttoknow.org.au"
+    override_all_public_body_request_emails: "contact@righttoknow.{{ base_domain }}"
     stage: staging
     stripe_publishable_key: "{{ stripe_publishable_key_test }}"
     stripe_secret_key: "{{ stripe_secret_key_test }}"

--- a/roles/internal/righttoknow/templates/general.yml
+++ b/roles/internal/righttoknow/templates/general.yml
@@ -100,7 +100,7 @@ TIME_ZONE: Australia/Sydney
 #   BLOG_FEED: https://www.mysociety.org/category/projects/whatdotheyknow/feed/
 #
 # ---
-BLOG_FEED: 'https://www.oaf.org.au/category/projects/righttoknow-org-au/feed/'
+BLOG_FEED: 'https://www.oaf.{{ base_domain }}/category/projects/righttoknow-org-au/feed/'
 
 # BLOG_TIMEOUT -  Integer seconds before reading the blog feed fails (default: 60)
 #
@@ -417,7 +417,7 @@ SKIP_ADMIN_AUTH: false
 # CONTACT_EMAIL: String email address (default: contact@localhost)
 #
 # ---
-CONTACT_EMAIL: 'contact@righttoknow.org.au'
+CONTACT_EMAIL: 'contact@righttoknow.{{ base_domain }}'
 
 # Email "from" name
 #
@@ -431,7 +431,7 @@ CONTACT_NAME: '{{ site_name }}'
 # TRACK_SENDER_EMAIL - String email address (default: contact@localhost)
 #
 # ---
-TRACK_SENDER_EMAIL: 'contact@righttoknow.org.au'
+TRACK_SENDER_EMAIL: 'contact@righttoknow.{{ base_domain }}'
 
 # Email "from" name for track messages
 #
@@ -576,7 +576,7 @@ MAXMIND_LICENSE_KEY: '{{ alaveteli_maxmind_license_key }}'
 #   FORWARD_NONBOUNCE_RESPONSES_TO: user-support@example.com
 #
 # ---
-FORWARD_NONBOUNCE_RESPONSES_TO: contact@righttoknow.org.au
+FORWARD_NONBOUNCE_RESPONSES_TO: contact@righttoknow.{{ base_domain }}
 
 # The email address to which non-bounce responses to emails sent out to
 # Alaveteli Professional users by Alaveteli should be forwarded
@@ -588,7 +588,7 @@ FORWARD_NONBOUNCE_RESPONSES_TO: contact@righttoknow.org.au
 #   FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@example.com
 #
 # ---
-FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro@righttoknow.org.au
+FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro@righttoknow.{{ base_domain }}
 
 # Email address used for sending exception notifications.
 #
@@ -708,7 +708,7 @@ MTA_LOG_TYPE: "postfix"
 #   DONATION_URL: http://www.mysociety.org/donate
 #
 # ---
-DONATION_URL: 'https://donate.oaf.org.au/'
+DONATION_URL: 'https://donate.oaf.{{ base_domain }}/'
 
 # If PUBLIC_BODY_STATISTICS_PAGE is set to true, Alaveteli will make a page of
 # statistics on the performance of public bodies (which you can see at
@@ -1048,7 +1048,7 @@ ENABLE_ALAVETELI_PRO: {{ enable_alaveteli_pro }}
 # PRO_CONTACT_EMAIL - String email address (default: pro-contact@localhost)
 #
 # ---
-PRO_CONTACT_EMAIL: 'pro@righttoknow.org.au'
+PRO_CONTACT_EMAIL: 'pro@righttoknow.{{ base_domain }}'
 
 # Contact name for Alaveteli Professional.
 # The corresponding name to address emails to when sending email to

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -165,8 +165,8 @@
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
   with_items:
-    - theyvoteforyou.org.au.test
-    - test.theyvoteforyou.org.au.test
+    - theyvoteforyou.test
+    - test.theyvoteforyou.test
   when: "'development' in group_names"
 
 # We need to setup the SSL certificates before we try to configure nginx
@@ -178,8 +178,8 @@
     dest: "/etc/letsencrypt/live/{{ item }}/fullchain.pem"
     mode: "0644"
   with_items:
-    - theyvoteforyou.org.au.test
-    - test.theyvoteforyou.org.au.test
+    - theyvoteforyou.test
+    - test.theyvoteforyou.test
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx reload
@@ -190,8 +190,8 @@
     dest: "/etc/letsencrypt/live/{{ item }}/privkey.pem"
     mode: "0640"
   with_items:
-    - theyvoteforyou.org.au.test
-    - test.theyvoteforyou.org.au.test
+    - theyvoteforyou.test
+    - test.theyvoteforyou.test
   # Only run this task when this machine is the development group
   when: "'development' in group_names"
   notify: nginx reload


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/414
* https://github.com/openaustralia/infrastructure/issues/435

Builds on PR:
* https://github.com/openaustralia/infrastructure/pull/412

## What does this do?

1. Introduces base_domain that all domains are based off, eg 

```
theyvoteforyou_domain: "theyvoteforyou.{{ base_domain }}"
openaustralia_domain: "openaustralia.{{ base_domain }}"
righttoknow_domain: "righttoknow.{{ base_domain }}"
```

Where group vars: 
* ec2 has `base_domain: org.au`
* development has `base_domain: test`

2. Refactor Vagrantfile for base_domain and align aliases with production
    
    * Makes hard-coded values into constants (network range, base domain and aliases)
    * warns if requirements are missing
    * Brings the inventory into one hosts hash so all the settings for each host are in one place
    * removes start_at_task as required rdf facts don't get set (use tags instead)

3. Added comments along the way, eg:
* NOTE: The planning alerts servers are NOT in ec2!

4. Add make requirements goal and update README.md accordingly

5. Some hosts where listed as requiring both mysql and postgresql - I checked what they needed and marked them accordingly in ec2-hosts and Vagrantfile

6. Aligned the hosts vagrant makes with hosts listed in ec2-hosts

## Why was this needed?

* Simplifies development (everything is *.test)
* Simplifies making development (vagrant) consistently use the development not production domain names

Re vagrant - I expanded vagrant target because I tripped over certs missing - when I understood what was happening, I  fix it once and for all!

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

