### PR TITLE
Feature/add terraform lint to makefile and github workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,3 +27,12 @@ jobs:
       - run: pip install virtualenv
       - run: make venv
       - run: make yaml-lint
+
+  tf-lint:
+    name: "Terraform Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: make tf-init
+      - run: make tf-lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,10 +29,9 @@ jobs:
       - run: make yaml-lint
 
   tf-lint:
-    name: "Terraform Lint"
+    name: "Terraform check format"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
-      - run: make tf-init
-      - run: make tf-lint
+      - run: make tf-check-fmt

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,12 @@ tf-plan: .make/terraform
 	terraform -chdir=terraform plan
 tf-apply: .make/terraform
 	terraform -chdir=terraform apply
-tf-lint: .make/terraform
-	terraform -chdir=terraform fmt -check
-	terraform -chdir=terraform validate && echo "PASSED tf-lint!"
+tf-validate: tf-check-fmt .make/terraform
+	terraform -chdir=terraform validate 
+	@echo "PASSED tf-validate!"
+tf-check-fmt:
+	terraform -chdir=terraform fmt -check 
+	@echo "PASSED tf-check-fmt!"
 
 stage_required:
 ifndef STAGE
@@ -214,10 +217,11 @@ update-github-ssh-keys: requirements
 	.venv/bin/ansible-playbook site.yml --tags userkeys
 
 yaml-lint: venv
-	.venv/bin/yamllint roles/internal/ roles/*.yml site.yml && echo "PASSED yamllint!"
+	.venv/bin/yamllint roles/internal/ roles/*.yml site.yml 
+	@echo "PASSED yamllint!"
 
 ansible-lint: venv roles
-	ANSIBLE_ROLES_PATH=roles:roles/internal:roles/external .venv/bin/ansible-lint roles/internal/ roles/*.yml site.yml && echo "PASSED ansible-lint!"
+	ANSIBLE_ROLES_PATH=roles:roles/internal:roles/external .venv/bin/ansible-lint roles/internal/ roles/*.yml site.yml 
+	@echo "PASSED ansible-lint!"
 
-lint: yaml-lint ansible-lint tf-lint
-
+lint: yaml-lint ansible-lint tf-check-fmt tf-validate

--- a/Makefile
+++ b/Makefile
@@ -161,12 +161,19 @@ clobber: clean
 	# TODO: Should we delete terraform/terraform.tfstate.* ?
 
 # Terraform
-tf-init:
+tf-init: .make/terraform
+
+.make/terraform: terraform/*.tf terraform/*/*.tf | .make
 	terraform -chdir=terraform init
-tf-plan:
+	touch .make/terraform
+
+tf-plan: .make/terraform
 	terraform -chdir=terraform plan
-tf-apply:
+tf-apply: .make/terraform
 	terraform -chdir=terraform apply
+tf-lint: .make/terraform
+	terraform -chdir=terraform fmt -check
+	terraform -chdir=terraform validate && echo "PASSED tf-lint!"
 
 stage_required:
 ifndef STAGE
@@ -212,4 +219,5 @@ yaml-lint: venv
 ansible-lint: venv roles
 	ANSIBLE_ROLES_PATH=roles:roles/internal:roles/external .venv/bin/ansible-lint roles/internal/ roles/*.yml site.yml && echo "PASSED ansible-lint!"
 
-lint: yaml-lint ansible-lint
+lint: yaml-lint ansible-lint tf-lint
+


### PR DESCRIPTION
## Relevant issue(s) / PRs:

* https://github.com/openaustralia/infrastructure/pull/439

## What does this do?

* Adds basic terraform format and validation check Makefile
* Performs format check in github actions (validation required AWS credentials, so its not performed)

## Why was this needed?

I was not able to check @benrfairless PR without at least a basic lint and validation check, so I added it to the other checks we do for PRs

## Implementation/Deploy Steps (Optional)

Once this PR is merged, everything based on main will have these checks performed

## Notes to reviewer (Optional)

I used the commands to manually check the PR, as there was a chicken and egg problem.