### PR TITLE
Vagrant VM memory and cpu can be set by ENV vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,8 +160,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     # More cpus and crank up the memory for a faster build
-    v.memory = 2048
-    v.cpus = 2
+    v.memory = (ENV['VAGRANT_MEMORY'] || 2048).to_i
+    v.cpus   = (ENV['VAGRANT_CPUS']   || 2).to_i
   end
 
   # Use this so that you don't need to give the machine name for all vagrant


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/414

## What does this do?

Allows you to drop down to one cpu per VM

## Why was this needed?

I want to reduce the cpu contention to hopefully fix my system pausing for long periods when I run up many of the VMs (I have AMD Ryzen 5 3600 6-Core Processor, 12 threads) 

I want the testing of final mysql8 changes to be as quick as possible.

## Implementation/Deploy Steps (Optional)

Set VAGRANT_CPUS=1 to reduce cpu core contention.

## Notes to reviewer (Optional)

Alternately allows you to change settings as per existing comment: More cpus and crank up the memory for a faster build
