### PR TITLE
Fix/462 reset password fails with there was a technical problem sending the email message

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -55,9 +55,9 @@ bundle_path: "{{ ruby_manager_bundle_path[ruby_manager] }}"
 
 ruby_manager: none
 
-catch_mail_host: "{{ lookup('env', 'CATCH_MAIL_HOST') | default(omit) }}"
-catch_mail_port: "{{ lookup('env', 'CATCH_MAIL_PORT') | default(omit) }}"
-catch_mail_user: "{{ lookup('env', 'CATCH_MAIL_USER') | default(omit) }}"
-catch_mail_password: "{{ lookup('env', 'CATCH_MAIL_PASSWORD') | default(omit) }}"
+catch_mail_host: "{{ lookup('env', 'CATCH_MAIL_HOST') | default('') }}"
+catch_mail_port: "{{ lookup('env', 'CATCH_MAIL_PORT') | default('') }}"
+catch_mail_user: "{{ lookup('env', 'CATCH_MAIL_USER') | default('') }}"
+catch_mail_password: "{{ lookup('env', 'CATCH_MAIL_PASSWORD') | default('') }}"
 catch_mail_auth: "{{ lookup('env', 'CATCH_MAIL_AUTH') | default('plain') }}"
 

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -351,6 +351,7 @@
 
 
 - name: Copy msmtp configuration
+  tags: msmtp
   template: src=msmtprc dest=/etc/
 
 - name: "Ensure /usr/local/bin exists"

--- a/roles/internal/openaustralia/templates/msmtprc
+++ b/roles/internal/openaustralia/templates/msmtprc
@@ -1,43 +1,45 @@
 # {{ ansible_managed }}
 
-account catch_email
-syslog LOG_MAIL
-{% if catch_mail_host is defined %}
-# Send caught mail to remote service
-tls off
-host {{ catch_mail_host }}
-port {{ catch_mail_port }}
-{% if catch_mail_user is defined and catch_mail_user %}
-auth {{ catch_mail_auth }}
-user {{ catch_mail_user }}
-{% if catch_mail_password is defined and catch_mail_password %}
-password {{ catch_mail_password }}
-{% endif %}
-{% else %}
-auth off
-{% endif %}
-{% else %}
-# No CATCH_MAIL_HOST defined when provisioning, logging header and failing on closed port
-tls off
-host 127.0.0.1
-port 4
-auth off
-{% endif %}
-
 {% if 'catch_all_mail' in group_names %}
-# All email is caught
-{% else %}
-account cuttlefish
-tls on
-# For some reason we're not able to correctly verify the certs
-# TODO: Figure out what's going on and fix this
-#tls_trust_file /etc/ssl/certs/ca-certificates.crt
-tls_certcheck off
-host cuttlefish.oaf.org.au
-port 2525
-auth on
-user {{ cuttlefish_username }}
-password {{ cuttlefish_password }}
-{% endif %}
+    # All email is caught
 
-account default : catch_email
+    account catch_email
+    syslog LOG_MAIL
+    {% if catch_mail_host %}
+        # Send caught mail to remote service
+        tls off
+        host {{ catch_mail_host }}
+        port {{ catch_mail_port }}
+        {% if catch_mail_user %}
+            auth {{ catch_mail_auth }}
+            user {{ catch_mail_user }}
+            {% if catch_mail_password %}
+                password {{ catch_mail_password }}
+            {% endif %}
+        {% else %}
+            auth off
+        {% endif %}
+    {% else %}
+        # No CATCH_MAIL_HOST defined when provisioning, logging header and failing on closed port
+        tls off
+        host 127.0.0.1
+        port 4
+        auth off
+    {% endif %}
+
+    account default : catch_email
+{% else %}
+    account cuttlefish
+    tls on
+    # For some reason we're not able to correctly verify the certs
+    # TODO: Figure out what's going on and fix this
+    #tls_trust_file /etc/ssl/certs/ca-certificates.crt
+    tls_certcheck off
+    host cuttlefish.oaf.org.au
+    port 2525
+    auth on
+    user {{ cuttlefish_username }}
+    password {{ cuttlefish_password }}
+
+    account default : cuttlefish
+{% endif %}


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/462

## What does this do?

Fixes email.

## Why was this needed?

Emails where broken (eg reset password)

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

Already applied to production and fixed reset password emails