### PR TITLE
Add log files for each vhost, and split out common bots

### DIFF
--- a/roles/internal/openaustralia/meta/main.yml
+++ b/roles/internal/openaustralia/meta/main.yml
@@ -151,7 +151,7 @@ dependencies:
   - role: nickhammond.logrotate
     logrotate_scripts:
       - name: production
-        path: "/srv/www/production/log/*_log"
+        path: "/srv/www/production/log/*.log"
         options:
           - daily
           - rotate 30
@@ -159,7 +159,7 @@ dependencies:
           - missingok
           - copytruncate
       - name: staging
-        path: "/srv/www/staging/shared/log/*_log"
+        path: "/srv/www/staging/shared/log/*.log"
         options:
           - daily
           - rotate 30

--- a/roles/internal/openaustralia/templates/apache/000-default.conf
+++ b/roles/internal/openaustralia/templates/apache/000-default.conf
@@ -8,6 +8,9 @@
 # Redirect everything to the www subdomain
 <VirtualHost *:80>
     RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
+
+    ErrorLog "/srv/www/production/log/default_redirect_error.log"
+    CustomLog "/srv/www/production/log/default_redirect_access.log" combined
 </VirtualHost>
 
 <IfModule mod_ssl.c>
@@ -17,5 +20,8 @@
         SSLEngine on
         SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
         SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+
+        ErrorLog "/srv/www/production/log/default_redirect_error.log"
+        CustomLog "/srv/www/production/log/default_redirect_access.log" combined
     </VirtualHost>
 </IfModule>

--- a/roles/internal/openaustralia/templates/apache/blog.conf
+++ b/roles/internal/openaustralia/templates/apache/blog.conf
@@ -6,6 +6,9 @@
     ServerName {{ domain }}
     RedirectMatch permanent ^/$ https://oaf.{{ base_domain }}/blog
     RedirectMatch permanent ^/(.*) https://oaf.{{ base_domain }}/$1
+
+    ErrorLog "/srv/www/production/log/blog_error.log"
+    CustomLog "/srv/www/production/log/blog_access.log" combined
 </VirtualHost>
 
 <IfModule mod_ssl.c>
@@ -13,6 +16,9 @@
         ServerName {{ domain }}
         RedirectMatch permanent ^/$ https://oaf.{{ base_domain }}/blog
         RedirectMatch permanent ^/(.*) https://oaf.{{ base_domain }}/$1
+
+        ErrorLog "/srv/www/production/log/blog_error.log"
+        CustomLog "/srv/www/production/log/blog_access.log" combined
 
         SSLEngine on
         SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem

--- a/roles/internal/openaustralia/templates/apache/data.conf
+++ b/roles/internal/openaustralia/templates/apache/data.conf
@@ -10,14 +10,16 @@
     {% endfor %}
 
     RedirectMatch permanent ^/(.*) http://{{ domain }}/$1
+    ErrorLog "/srv/www/production/log/data_redirect_error.log"
+    CustomLog "/srv/www/production/log/data_redirect_access.log" combined
 </VirtualHost>
 {% endif %}
 
 <VirtualHost *:80>
     ServerName {{ domain }}
 
-    ErrorLog "/srv/www/production/log/error_log"
-    CustomLog /srv/www/production/log/access_log common
+    ErrorLog "/srv/www/production/log/data_error.log"
+    CustomLog "/srv/www/production/log/data_access.log" combined
 
     DocumentRoot "/srv/www/production/shared/pwdata"
 
@@ -43,14 +45,17 @@
         SSLEngine on
         SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
         SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+
+        ErrorLog "/srv/www/production/log/data_redirect_error.log"
+        CustomLog "/srv/www/production/log/data_redirect_access.log" combined
     </VirtualHost>
     {% endif %}
 
     <VirtualHost *:443>
         ServerName {{ domain }}
 
-        ErrorLog "/srv/www/production/log/error_log"
-        CustomLog /srv/www/production/log/access_log common
+        ErrorLog "/srv/www/production/log/data_error.log"
+        CustomLog "/srv/www/production/log/data_access.log" combined
 
         DocumentRoot "/srv/www/production/shared/pwdata"
 

--- a/roles/internal/openaustralia/templates/apache/production.conf
+++ b/roles/internal/openaustralia/templates/apache/production.conf
@@ -10,6 +10,9 @@
         {% endif %}
 
         RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
+
+        ErrorLog "/srv/www/production/log/{{ stage }}_redirect_error.log"
+        CustomLog "/srv/www/production/log/{{ stage }}_redirect_access.log" combined
     </VirtualHost>
 
     {% if server_aliases %}
@@ -24,13 +27,43 @@
         SSLEngine on
         SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
         SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+
+        ErrorLog "/srv/www/production/log/{{ stage }}_redirect_error.log"
+        CustomLog "/srv/www/production/log/{{ stage }}_redirect_access.log" combined
     </VirtualHost>
     {% endif %}
 
     <VirtualHost *:443>
         ServerName {{ domain }}
-        ErrorLog "/srv/www/{{ stage }}/log/error_log"
-        CustomLog /srv/www/{{ stage }}/log/access_log common
+
+        SetEnvIf User-Agent "CensysInspect"    is_bot
+        SetEnvIf User-Agent "MojeekBot"        is_bot
+        SetEnvIf User-Agent "PerplexityBot"    is_bot
+        SetEnvIf User-Agent "bingbot"          is_bot
+        SetEnvIf User-Agent "Sogou"            is_bot
+        SetEnvIf User-Agent "GenomeCrawlerd"   is_bot
+        SetEnvIf User-Agent "cooperate-rss"    is_bot
+        SetEnvIf User-Agent "zgrab"            is_bot
+        SetEnvIf User-Agent "Turnitin"         is_bot
+        SetEnvIf User-Agent "Gort"             is_bot
+        SetEnvIf User-Agent "Palo Alto"        is_bot
+        SetEnvIf User-Agent "visionheight"     is_bot
+        SetEnvIf User-Agent "ddg_"             is_bot
+        SetEnvIf User-Agent "facebookexternalhit" is_bot
+        SetEnvIf User-Agent "python-httpx"     is_bot
+        SetEnvIf User-Agent "curl"             is_bot
+        SetEnvIf User-Agent "aiohttp"          is_bot
+        SetEnvIf User-Agent "WPMU"             is_bot
+        # suspiciously frequently used: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.6943.141 Safari/537.36
+
+        SetEnvIf Remote_Addr "127.0.0.1" is_internal
+        SetEnvIf Remote_Addr "::1"       is_internal
+
+        ErrorLog "/srv/www/{{ stage }}/log/error.log"
+
+        CustomLog /srv/www/{{ stage }}/log/bot_access.log combined env=is_bot,!is_internal
+        CustomLog /srv/www/{{ stage }}/log/access.log combined env=!is_bot,!is_internal
+        CustomLog /srv/www/{{ stage }}/log/internal_access.log combined env=is_internal
 
         DocumentRoot "/srv/www/{{ stage }}/current/twfy/www/docs/"
         php_admin_value newrelic.appname "OpenAustralia.org"

--- a/roles/internal/openaustralia/templates/apache/software.conf
+++ b/roles/internal/openaustralia/templates/apache/software.conf
@@ -7,6 +7,9 @@
     ServerAlias {{ alias }}
     {% endfor %}
     RedirectMatch permanent / https://openaustralia.github.io/openaustralia/
+
+    ErrorLog "/srv/www/production/log/software_error.log"
+    CustomLog "/srv/www/production/log/software_access.log" combined
 </VirtualHost>
 
 <IfModule mod_ssl.c>
@@ -20,5 +23,8 @@
         SSLEngine on
         SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
         SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+
+        ErrorLog "/srv/www/production/log/software_error.log"
+        CustomLog "/srv/www/production/log/software_access.log" combined
     </VirtualHost>
 </IfModule>

--- a/roles/internal/openaustralia/templates/php.ini
+++ b/roles/internal/openaustralia/templates/php.ini
@@ -974,7 +974,7 @@ smtp_port = 25
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
 ; http://php.net/sendmail-path
 ;sendmail_path =
-{% if ('catch_all_mail' in group_names) and (catch_mail_host is not defined) %}
+{% if ('catch_all_mail' in group_names) and (not catch_mail_host) %}
 sendmail_path = "/usr/local/bin/log_not_sendmail"
 {% else %}
 sendmail_path = "msmtp --read-envelope-from -t"


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Add log files for each vhost, and split out common bots to their own log file to make diagnostics easier

Based on:
* https://github.com/openaustralia/infrastructure/pull/459

## Why was this needed?

I was trying to diagnose an issue and I could not see my accesses in the midst of all the bot accesses and redirections

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
