### PR TITLE
Resolve ansible-lint errors: Set file permissions for various tasks in Ansible playbooks

### DIFF
--- a/roles/internal/awscloudwatch/tasks/main.yml
+++ b/roles/internal/awscloudwatch/tasks/main.yml
@@ -28,6 +28,7 @@
   template:
     src: config.json
     dest: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+    mode: '0644'
   when: "'ec2' in group_names"
   notify:
     - restart CloudWatch Agent

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -7,6 +7,7 @@
   file:
     state: directory
     path: /data
+    mode: '0755'
 
 # On EC2 we're using a seperate EBS volume to hold application data
 - name: Create filesystem on attached block storage
@@ -31,6 +32,7 @@
     owner: deploy
     group: deploy
     state: directory
+    mode: '0755'
   with_nested:
     - "{{ environments }}"
     - ['images/mps', 'images/mpsL', 'images/mpsXL', 'pwdata', 'html_cache', 'regmem_scan', 'regmem_scan_old', 'search/searchdb']
@@ -41,6 +43,7 @@
     owner: deploy
     group: deploy
     state: directory
+    mode: '0755'
   with_nested:
     - "{{ environments }}"
     - ['log', 'releases', 'shared/config', 'shared/rss/mp', 'shared/sitemaps']
@@ -120,6 +123,7 @@
   file:
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
+    mode: '0755'
   with_items: "{{ apache_sites.values() | map(attribute='domain') | list }}"
   when: "'development' in group_names"
 
@@ -255,6 +259,7 @@
   template:
     src: php.ini
     dest: /etc/php/{{ php_version }}/{{ item }}/php.ini
+    mode: '0644'
   notify: reload apache
   with_items:
     - apache2
@@ -264,6 +269,7 @@
   copy:
     src: htpasswd
     dest: /srv/www/{{ item }}/shared
+    mode: '0600'
   with_items: "{{ environments }}"
   notify: reload apache
 
@@ -291,6 +297,7 @@
   template:
     src: "apache/{{ item.value.template | default(item.key) }}.conf"
     dest: "/etc/apache2/sites-available/{{ item.key}}.conf"
+    mode: '0644'
   vars:
     stage: "{{ item.key }}"
     domain: "{{ item.value.domain }}"
@@ -331,6 +338,7 @@
     dest: "/srv/www/{{ item }}/shared"
     owner: deploy
     group: deploy
+    mode: '0644'
   vars:
     db_password: "{{ apache_sites[item].db_password }}"
     stage: "{{ item }}"
@@ -344,6 +352,7 @@
     dest: "/srv/www/{{ item }}/shared"
     owner: deploy
     group: deploy
+    mode: '0644'
   vars:
     stage: "{{ item }}"
   with_items: "{{ environments }}"
@@ -352,7 +361,10 @@
 
 - name: Copy msmtp configuration
   tags: msmtp
-  template: src=msmtprc dest=/etc/
+  template:
+    src: msmtprc
+    dest: /etc/
+    mode: '0644'
 
 - name: "Ensure /usr/local/bin exists"
   file:
@@ -472,4 +484,5 @@
   copy:
     src: deploy_can_restart_apache
     dest: /etc/sudoers.d/
+    mode: '0440'
     validate: visudo -cf %s

--- a/roles/internal/planningalerts/tasks/main.yml
+++ b/roles/internal/planningalerts/tasks/main.yml
@@ -19,6 +19,7 @@
     owner: deploy
     group: deploy
     path: "{{ item }}"
+    mode: '0755'
   with_items:
     - /srv/www/production
     - /srv/www/production/shared
@@ -44,11 +45,13 @@
     dest: "/srv/www/production/shared/config/credentials/production.key"
     owner: deploy
     group: deploy
+    mode: '0600'
 
 - name: Allow deploy user to control services
   template:
     src: deploy_service_control
     dest: /etc/sudoers.d/deploy_service_control
+    mode: '0440'
     validate: visudo -cf %s
 
 - name: Install postfix to handle incoming email
@@ -59,6 +62,7 @@
   template:
     src: "{{ item }}"
     dest: /etc/postfix
+    mode: '0644'
   with_items:
     - transport
     - virtual_alias

--- a/roles/internal/righttoknow/tasks/certificates.yml
+++ b/roles/internal/righttoknow/tasks/certificates.yml
@@ -3,6 +3,7 @@
   file:
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
+    mode: '0755'
   with_items: "{{ [righttoknow_domain] + ([] if ('righttoknow_staging' in group_names) else ['test.' + righttoknow_domain]) }}"
   when: "'development' in group_names"
 

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -30,6 +30,7 @@
   file:
     state: directory
     path: /data
+    mode: '0755'
 
 # On EC2 we're using a seperate EBS volume to hold application data
 - name: Create filesystem on attached block storage
@@ -54,6 +55,7 @@
     owner: deploy
     group: deploy
     state: directory
+    mode: '0755'
   with_nested:
     - "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
     - ['cache', 'bundle', 'storage', 'xapiandbs']
@@ -64,6 +66,7 @@
     owner: deploy
     group: deploy
     path: "/srv/www/{{ item[0] }}/{{ item[1] }}"
+    mode: '0755'
   with_nested:
     - "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
     - ['', 'shared']
@@ -81,24 +84,28 @@
   copy:
     content: "{{ ruby_version_production }}"
     dest: /srv/www/production/shared/rbenv-version
+    mode: '0644'
   when: "'righttoknow_production' in group_names"
 
 - name: Set the ruby version for the alaveteli deploy (staging)
   copy:
     content: "{{ ruby_version_staging }}"
     dest: /srv/www/staging/shared/rbenv-version
+    mode: '0644'
   when: "'righttoknow_staging' in group_names"
 
 - name: Another Aleveteli config to force production environment
   template:
     src: rails_env.rb
     dest: /srv/www/{{ item }}/shared
+    mode: '0644'
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
 
 - name: Add newrelic configuration to disable agent
   template:
     src: newrelic.yml
     dest: /srv/www/{{ item }}/shared/
+    mode: '0644'
   vars:
     newrelic_app_name: "Right To Know{{ (item == 'production') | ternary('', ' Staging') }}"
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
@@ -289,6 +296,7 @@
     dest: "/srv/www/{{ item }}/shared/database.yml"
     owner: deploy
     group: deploy
+    mode: '0644'
   vars:
     stage: "{{ item }}"
     password: "{{ (item == 'production') | ternary(db_password_production, db_password_staging) }}"
@@ -310,6 +318,7 @@
   template:
     src: "nginx/{{ item }}"
     dest: /etc/nginx
+    mode: '0644'
   with_items:
     - nginx.conf
     - htpasswd
@@ -353,6 +362,7 @@
     dest: /srv/www/production/shared/
     owner: deploy
     group: deploy
+    mode: '0644'
   vars:
     domain: "{{ righttoknow_domain }}"
     site_name: "Right to Know"
@@ -375,6 +385,7 @@
     dest: /srv/www/production/shared/
     owner: deploy
     group: deploy
+    mode: '0644'
   notify: nginx restart
   when: "'righttoknow_production' in group_names"
 
@@ -384,6 +395,7 @@
     dest: /srv/www/staging/shared/
     owner: deploy
     group: deploy
+    mode: '0644'
   vars:
     domain: "{{ righttoknow_domain }}"
     site_name: "Right to Know (STAGING)"
@@ -406,6 +418,7 @@
     dest: /srv/www/{{ item }}/shared/storage.yml
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
   notify: nginx restart
 
@@ -415,6 +428,7 @@
     dest: "/srv/www/{{ item }}/shared/user_spam_scorer.yml"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
   notify: nginx restart
 
@@ -424,6 +438,7 @@
     dest: "/srv/www/{{ item }}/shared/sidekiq.yml"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
   notify: restart sidekiq
 
@@ -441,12 +456,14 @@
   copy:
     src: default.vcl
     dest: /etc/varnish
+    mode: '0644'
   notify: restart varnish
 
 - name: Update varnish startup config
   copy:
     src: varnish.service
     dest: /lib/systemd/system/varnish.service
+    mode: '0644'
   notify: restart varnish
 
 - import_tasks: certificates.yml
@@ -492,6 +509,7 @@
     owner: opendkim
     group: postfix
     state: directory
+    mode: '0755'
 
 - name: Postfix needs to be part of opendkim group to access the socket
   user:
@@ -502,12 +520,14 @@
   template:
     src: "opendkim.conf"
     dest: /etc
+    mode: '0644'
   notify: restart opendkim
 
 - name: Update postfix configuration
   template:
     src: "postfix/{{ item }}"
     dest: /etc/postfix
+    mode: '0644'
   with_items:
     - master.cf
     - main.cf
@@ -519,12 +539,14 @@
   template:
     src: mailname
     dest: /etc/mailname
+    mode: '0644'
   notify: restart postfix
 
 - name: Configure postfix logs to go to their own directory
   copy:
     src: 50-default.conf
     dest: /etc/rsyslog.d
+    mode: '0644'
   notify: restart rsyslog
 
 - name: Install memcached

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -87,6 +87,7 @@
     owner: deploy
     group: deploy
     path: '{{ item }}'
+    mode: '0755'
   with_items:
     - /srv/www
     - /srv/www/production
@@ -106,6 +107,7 @@
     dest: "/srv/www/{{ item }}/shared/config/settings.yml"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items:
     - production
     - staging
@@ -117,6 +119,7 @@
     dest: "/srv/www/{{ item }}/shared/config/database.yml"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items:
     - production
     - staging
@@ -128,6 +131,7 @@
     dest: "/srv/www/{{ item }}/shared/config/credentials/production.key"
     owner: deploy
     group: deploy
+    mode: '0600'
   with_items:
     - production
     - staging
@@ -139,6 +143,7 @@
     dest: "/srv/www/{{ item }}/shared/config/"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items:
     - production
     - staging
@@ -150,6 +155,7 @@
     dest: "/srv/www/{{ item }}/shared/config/"
     owner: deploy
     group: deploy
+    mode: '0644'
   with_items:
     - production
     - staging
@@ -164,6 +170,7 @@
   file:
     state: directory
     path: "/etc/letsencrypt/live/{{ item }}"
+    mode: '0755'
   with_items:
     - "theyvoteforyou.{{ base_domain }}"
     - "test.theyvoteforyou.{{ base_domain }}"
@@ -211,18 +218,21 @@
   copy:
     src: htpasswd
     dest: /etc/nginx/
+    mode: '0600'
   notify: nginx restart
 
 - name: Copy nginx main configuration
   copy:
     src: nginx.conf
     dest: /etc/nginx/
+    mode: '0644'
   notify: nginx restart
 
 - name: Copy nginx site configuration
   template:
     src: "{{ item }}"
     dest: /etc/nginx/sites-available/
+    mode: '0644'
   with_items:
     - default
     - production
@@ -244,6 +254,7 @@
   copy:
     src: theyvoteforyou_foreman
     dest: /etc/sudoers.d/
+    mode: '0440'
     validate: visudo -cf %s
   # notify: sudo reload
 
@@ -329,6 +340,7 @@
   file:
     state: directory
     path: /data
+    mode: '0755'
 
 # On EC2 we're using a seperate EBS volume to hold application data
 - name: Create filesystem on attached block storage
@@ -353,6 +365,7 @@
     owner: deploy
     group: deploy
     state: directory
+    mode: '0755'
   with_nested:
     - "{{ environments }}"
     - ['public', 'public/cards']


### PR DESCRIPTION
## Resolves
- https://github.com/openaustralia/infrastructure/issues/443 

## What does this do?
Sets appropriate file permissions for various tasks in Ansible playbooks to comply with ansible-lint requirements.

## Why was this needed?
Ensures that the playbooks adhere to best practices for file permissions, enhancing security and functionality.

## Implementation/Deploy Steps (Optional)
No deployment required

## Notes to reviewer (Optional)
I have verified that the permissions set here are the same as those that currently exist on the server.
