### PR TITLE
Fix/xapian ansible rules

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -104,9 +104,6 @@ domains_for_certbot:
     domains:
       - "{{ openaustralia_domain }}"
 
-# Control what version is installed
-xapian_version: 1.4.25
-
 # PHP has two version numbers :( - make sure they are in sync
 php_version: 8.3
 php_api_version: "20230831"

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -156,6 +156,11 @@
   apt_repository:
     repo: 'ppa:ondrej/php'
 
+- name: Add xapian backports PPA for newer libxapian
+  tags: xapian
+  apt_repository:
+    repo: 'ppa:xapian/backports'
+
 - name: Install required packages
   tags: xapian
   apt:
@@ -202,9 +207,19 @@
 
 # FIXME: Do we really need libpq-dev ??
 
+- name: Get installed libxapian-dev version
+  tags: xapian
+  command: dpkg-query -W -f='${Version}' libxapian-dev
+  register: libxapian_pkg_version
+  changed_when: false
+
+- name: Set xapian_version from installed libxapian-dev
+  tags: xapian
+  set_fact:
+    xapian_version: "{{ libxapian_pkg_version.stdout | regex_replace('^(\\d+\\.\\d+\\.\\d+).*$', '\\1') }}"
+
 # Matching the version number of libxapian-dev above
 - name: Download xapian bindings source
-  when: "xapian_version is defined"
   tags: xapian
   get_url:
     url: https://oligarchy.co.uk/xapian/{{ xapian_version }}/xapian-bindings-{{ xapian_version }}.tar.xz
@@ -214,7 +229,6 @@
     # FIXME: handle gpg checksum: checksum: sha256:b15ca7984980a1d2aedd3378648ef5f3889cb39a047bac1522a8e5d04f0a8557
 
 - name: Unpack xapian bindings source
-  when: "xapian_version is defined"
   tags: xapian
   unarchive:
       src: /home/deploy/xapian-bindings-{{ xapian_version }}.tar.xz
@@ -225,7 +239,6 @@
       creates: /home/deploy/xapian-bindings-{{ xapian_version }}/configure
 
 - name: Configure xapian bindings
-  when: "xapian_version is defined"
   tags: xapian
   command: ./configure --with-php
   args:
@@ -234,7 +247,6 @@
   become_user: deploy
 
 - name: Compile xapian bindings
-  when: "xapian_version is defined"
   tags: xapian
   command: make
   args:
@@ -243,7 +255,6 @@
   become_user: deploy
 
 - name: Install xapian bindings
-  when: "xapian_version is defined"
   tags: xapian
   command: make install
   args:

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -152,10 +152,12 @@
 
 # Install php5 on xenial requires a few more jumps than usual
 - name: Add repo for installing php5
+  tags: xapian
   apt_repository:
     repo: 'ppa:ondrej/php'
 
 - name: Install required packages
+  tags: xapian
   apt:
     name:
       - apache2
@@ -177,6 +179,7 @@
     update_cache: true
 
 - name: Install required packages for php
+  tags: xapian
   when: "php_version is defined"
   apt:
     name:
@@ -190,6 +193,7 @@
       - php{{ php_version }}-zip
 
 - name: Set default PHP version
+  tags: xapian
   community.general.alternatives:
     name: php
     path: /usr/bin/php{{ php_version }}
@@ -201,6 +205,7 @@
 # Matching the version number of libxapian-dev above
 - name: Download xapian bindings source
   when: "xapian_version is defined"
+  tags: xapian
   get_url:
     url: https://oligarchy.co.uk/xapian/{{ xapian_version }}/xapian-bindings-{{ xapian_version }}.tar.xz
     dest: /home/deploy
@@ -210,6 +215,7 @@
 
 - name: Unpack xapian bindings source
   when: "xapian_version is defined"
+  tags: xapian
   unarchive:
       src: /home/deploy/xapian-bindings-{{ xapian_version }}.tar.xz
       dest: /home/deploy
@@ -220,6 +226,7 @@
 
 - name: Configure xapian bindings
   when: "xapian_version is defined"
+  tags: xapian
   command: ./configure --with-php
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -228,6 +235,7 @@
 
 - name: Compile xapian bindings
   when: "xapian_version is defined"
+  tags: xapian
   command: make
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -236,6 +244,7 @@
 
 - name: Install xapian bindings
   when: "xapian_version is defined"
+  tags: xapian
   command: make install
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -251,6 +260,7 @@
     - ssl
 
 - name: Copy across the php config
+  tags: xapian
   when: "php_version is defined"
   template:
     src: php.ini
@@ -347,8 +357,6 @@
   vars:
     stage: "{{ item }}"
   with_items: "{{ environments }}"
-
-
 
 - name: Copy msmtp configuration
   tags: msmtp

--- a/roles/internal/openaustralia/templates/general
+++ b/roles/internal/openaustralia/templates/general
@@ -72,11 +72,7 @@ define ("REGMEMPDFPATH", "regmem/scan/");
 define ("METADATAPATH", BASEDIR . "/../includes/easyparliament/metadata.php");
 
 // Search related. If non-empty will use XAPIAN search instead of mysql search
-{% if xapian_version is defined %}
 define ("XAPIANDB", '/srv/www/{{ stage }}/shared/search/searchdb');
-{% else %}
-define ("XAPIANDB", '');
-{% endif %}
 
 // Location of the parliamentary recess data file. You can access this remotely
 // from the main theyworkforyou site if you use

--- a/roles/internal/openaustralia/templates/php.ini
+++ b/roles/internal/openaustralia/templates/php.ini
@@ -866,9 +866,7 @@ default_socket_timeout = 60
 ; default extension directory.
 ;
 
-{% if xapian_version is defined %}
 extension=xapian.so
-{% endif %}
 extension=mysqli
 
 ;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/471
* https://github.com/openaustralia/infrastructure/issues/420 - discovered the problem whilst researching this

## What does this do?

Builds on the following PR - review and merge it FIRST:
* https://github.com/openaustralia/infrastructure/pull/472

* Always installs xapian for openaustralia
* Adds xapian package source as manually configured on newprod
* Auto detects `xapian_version` from the libxapian-dev package that was installed (removed the option to disable xapian build)
* Fixes xapian being built with a different version of the xapian library
* Adds xapian tags to make it quick to rerun the provisioning

```
TAGS=xapian time vagrant up --provision openaustralia.test
``` 

## Why was this needed?

I was unable to provision openaustralia.test.
newprod only worked because the ansible rules skip when an existing installation is detected

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

remember to `make vagrant` and `vagrant up mysql.test ` first