### PR TITLE
Feature/ add swap space

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -171,3 +171,20 @@ apache_sites:
   software:
     domain: "software.{{ openaustralia_domain }}"
     server_aliases: "{{ (base_domain == 'org.au') | ternary(extra_software_server_aliases, []) }}"
+
+
+# Sized to cover (approximate figures):
+#  1,600 MB Xapian anon (index.pl cron job)
+#           -> true peak will be higher, only observable once swap is added
+#    120 MB Idle processes (snapd, cloudwatch, newrelic, postfix etc)
+#           -> can swap with negligible impact
+#    168 MB Apache workers anon
+#           -> can be swapped but with site performance impact
+#     42 MB Locked in memory (unevictable kernel pages, mlocked)
+#  --------
+#  1,930 MB Physical RAM
+
+# If we need more than this, we need to upgrade the ec2 instance size!
+swap_file_size_mb: '1024'
+# Prefer RAM but swap out genuinely idle processes under pressure
+swap_swappiness: '35'

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -30,5 +30,8 @@ roles:
   - src: oefenweb.postfix
     version: v2.6.2
 
+  - src: geerlingguy.swap
+    version: 2.0.0
+
 collections:
   - community.postgresql

--- a/site.yml
+++ b/site.yml
@@ -161,6 +161,14 @@
     - internal/base-server
 
 - hosts: all
+  tags: swap
+  become: true
+  name: "Configure swap file"
+  roles:
+    - role: geerlingguy.swap
+      when: swap_file_size_mb is defined or (swap_file_state | default('present')) == 'absent'
+
+- hosts: all
   name: "Remove unused ruby managers"
   become: true
   tags: 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/420

## What does this do?

Adds 1GB of swap space so I can discover how much memory the xapian index process actually needs

## Why was this needed?

OOM-kill has killed a number of perl script cron jobs in the last month at the 1,600 MB mark. Adding swap hopefully allows it to run to completion so we can get statistics.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

Tested on top of these PRs so `vagrant up --provision openaustralia.test` works:

* https://github.com/openaustralia/infrastructure/pull/472
* https://github.com/openaustralia/infrastructure/pull/473

( i have a prs local branch that merges all of these PRs)

I have applied this change to the live server:

```
TAGS=swap make check-openaustralia
TAGS=swap make apply-openaustralia
```
