### PR TITLE
Add Google Postmaster Tools verification records for multiple domains

### DIFF
--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -105,6 +105,14 @@ resource "cloudflare_record" "google_site_verification" {
   value   = "google-site-verification=in8HCE8-6fspAg-ak4TpaWthQ2ix6Ne8sBIzAPwFdDc"
 }
 
+resource "cloudflare_record" "google_site_verification_postmaster_tools" {
+  zone_id = cloudflare_zone.main.id
+  name    = "morph.io"
+  type    = "TXT"
+  value   = "google-site-verification=NONJQb5wOBp2O2pF1c8Ly8yFFZUJdl6S7paXN3t-CWI"
+}
+
+
 # TODO: Remove this once the one below is up and running
 resource "cloudflare_record" "domainkey" {
   zone_id = cloudflare_zone.main.id

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -107,6 +107,14 @@ resource "cloudflare_record" "google_site_verification" {
   value   = "google-site-verification=RLhe_zgIDJMxpFFYFewv0KaRlWQvH-JDBxxpEV-8noY"
 }
 
+resource "cloudflare_record" "google_site_verification_postmaster_tools" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "oaf.org.au"
+  type    = "TXT"
+  value   = "google-site-verification=IFIoBjxQqagUuE0twx28St9tSVJheGEpV7-PhlYqvIQ"
+}
+
+
 resource "cloudflare_record" "facebook_domain_verification" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -112,6 +112,13 @@ resource "cloudflare_record" "spf" {
   value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
 }
 
+resource "cloudflare_record" "google_site_verification_postmaster_tools" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "openaustralia.org.au"
+  type    = "TXT"
+  value   = "google-site-verification=NMrCE8wbE8mEodpPYd_RY30JbAu99A3HjWkyR6dmrK4"
+}
+
 # TODO: Remove this once the one below is up and running
 resource "cloudflare_record" "cuttlefish_domainkey" {
   zone_id = cloudflare_zone.org.id
@@ -267,6 +274,13 @@ resource "cloudflare_record" "alt_google_site_verification" {
   name    = "openaustralia.org.au"
   type    = "TXT"
   value   = "google-site-verification=1xl-YdNs-D67htH3q438bFSGf1ThVHap5vXIFS6J0dI"
+}
+
+resource "cloudflare_record" "alt_google_site_verification_postmaster_tools" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "openaustralia.org.au"
+  type    = "TXT"
+  value   = "google-site-verification=Vd5DN8gzLQUkHOGNtGd6p_zPIb_df7QELe4me2tCnEM"
 }
 
 resource "cloudflare_record" "alt_facebook_domain_verification" {

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -133,6 +133,14 @@ resource "cloudflare_record" "google_site_verification" {
   value   = "google-site-verification=DHISCv3WoPmTzUWzYfzpeBd5NivPxC5a2s4uBdWZoY8"
 }
 
+resource "cloudflare_record" "google_site_verification_postmaster_tools" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "theyvoteforyou.org.au"
+  type    = "TXT"
+  value   = "google-site-verification=7EELkDsXsoWm7VbkyTpqwoo0ZezPrOeLMc9Jpu9pjNg"
+}
+
+
 resource "cloudflare_record" "facebook_domain_verification" {
   zone_id = cloudflare_zone.org_au.id
   name    = "theyvoteforyou.org.au"


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
Adds Google Postmaster Tools verification TXT records for Morph, OpenAustralia.org, OpenAustralia.org.au and TheyVoteForYou.

## Why was this needed?
Enables verification of the specified domains with Google Postmaster Tools for improved email deliverability insights.

## Implementation/Deploy Steps (Optional)
1. Check changes first by running `make tf-plan`
2. Apply chhanges by running `make tf-apply`
3. Once this is done Ben will need to verify the domains at https://postmaster.google.com/v2/manage_domains 

## Notes to reviewer (Optional)
- Please approve only, do not merge
