### PR TITLE
Enable deletion of mysql 5.7 (main-database) - step 1/2

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -39,13 +39,14 @@ resource "aws_db_instance" "main" {
   auto_minor_version_upgrade = true
   apply_immediately          = false
   skip_final_snapshot        = false
+  final_snapshot_identifier  = "main-database-final"
   vpc_security_group_ids     = [aws_security_group.main_database.id]
   # The parameter group name below was automatically created during an upgrade to mysql 5.7
   # The commented out group name was the one we were using with mysql 5.6
   # TODO: Go through parameter group and see if anything is different than the 5.7 default and if so make a custom one for us
   # parameter_group_name       = aws_db_parameter_group.mysql_default.name
   parameter_group_name = "default.mysql5.7-db-3zfhxnxjf2w5aymy2dl3hbsk3m-upgrade"
-  deletion_protection  = true
+  deletion_protection  = false
 }
 
 resource "aws_iam_role" "rds-monitoring-role" {


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/465

## What does this do?

This is step 1: It allows the mysql 5.7 database to be deleted, and
Sets a name for final snapshot

## Why was this needed?

Can't delete the database otherwise.

## Implementation/Deploy Steps

(If I have understood @Br3nda 's changes correctly, they can't be used on database.tf)

```
make tf-plan
make tf-apply

#OR

make tf-init
terraform -chdir=terraform plan -target=aws_db_instance.main
terraform -chdir=terraform apply -target=aws_db_instance.main
```

## Notes to reviewer

Please check I am doing the right thing - I am new to terraform.

After approving, merge and deploy as above.

resource "aws_security_group" "main_database" is shared between old and new DB's so it wont be deleted.

This is step 1 of 2 - The remaining step is to actually delete the rds instance.