### PR TITLE
Speed up ansible mysql provisioning by caching apt update for 1 hour

### DIFF
--- a/roles/internal/mysql/tasks/main.yml
+++ b/roles/internal/mysql/tasks/main.yml
@@ -6,6 +6,7 @@
   apt:
     pkg: mysql-server
     update_cache: true
+    cache_valid_time: 3600
 
 - name: Install dependency for following command
   apt: pkg=python3-mysqldb


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Speeds up ansible mysql provisioning by caching apt update for 1 hour (mysqld server for vagrant)

## Why was this needed?

Found inefficiency when I was working on openaustralia rules and I applied it elsewhere for consistancy

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

The speed up is when apt is refreshed multiple times