### PR TITLE
Add missing package libxml-simple-perl

### DIFF
--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -184,6 +184,7 @@
       - libsearch-xapian-perl
       - libxapian-dev
       - libxml-rss-perl
+      - libxml-simple-perl
       - libxml-twig-perl
       - libxslt1-dev
       - mysql-client


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/809

## What does this do?

Add a missing package we discovered in adding lint-perl to work on mpinfoin.pl to test dailyupdate cron job

## Why was this needed?

Perl lint was failing on a missing library

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
