### PR TITLE
Update htpasswd file to be readable to apache without being world rea…

### DIFF
--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -305,10 +305,13 @@
     - cli
 
 - name: Copy test/test password
+  tags: htpasswd
   copy:
     src: htpasswd
     dest: /srv/www/{{ item }}/shared
-    mode: '0600'
+    mode: '0640'
+    owner: root
+    group: www-data
   with_items: "{{ environments }}"
   notify: reload apache
 

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -215,10 +215,13 @@
   when: "'ec2' in group_names"
 
 - name: Copy test/test password for staging site
+  tags: htpasswd
   copy:
     src: htpasswd
     dest: /etc/nginx/
-    mode: '0600'
+    mode: '0640'
+    owner: root
+    group: www-data
   notify: nginx restart
 
 - name: Copy nginx main configuration


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Update htpasswd file to be readable to apache without being world readable

## Why was this needed?

The next `make apply-openaustralia` would have broken test

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

These rules have already been applied using

    TAGS=htpasswd make check-openaustralia
    TAGS=shtpasswd make apply-openaustralia
