### PR TITLE
Hotfix: Check for and use latest letsencrypt dir

### DIFF
--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -332,6 +332,27 @@
   when: item.key != '000-default'
   with_dict: "{{ apache_sites }}"
 
+
+- name: Find latest certbot live dir for each domain
+  tags: sites_available
+  shell: |
+    (ls -d /etc/letsencrypt/live/{{ item.value.domain }}-[0-9]* 2>/dev/null ; echo /etc/letsencrypt/live/{{ item.value.domain }}) | sort | tail -1
+  register: certbot_live_dirs
+  changed_when: false
+  check_mode: no
+  with_dict: "{{ apache_sites }}"
+  when: item.key != '000-default'
+
+- name: Build certbot_live_dir_map fact
+  tags: sites_available
+  set_fact:
+    certbot_live_dir_map: >-
+      {{ certbot_live_dir_map | default({}) |
+         combine({item.item.value.domain: item.stdout | default('/etc/letsencrypt/live/' + item.item.value.domain)}) }}
+  check_mode: no
+  with_items: "{{ certbot_live_dirs.results }}"
+  when: item.skipped is not defined
+
 - name: Ensure each site has an apache configuration
   template:
     src: "apache/{{ item.value.template | default(item.key) }}.conf"

--- a/roles/internal/openaustralia/templates/apache/000-default.conf
+++ b/roles/internal/openaustralia/templates/apache/000-default.conf
@@ -18,8 +18,8 @@
         RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
 
         ErrorLog "/srv/www/production/log/default_redirect_error.log"
         CustomLog "/srv/www/production/log/default_redirect_access.log" combined

--- a/roles/internal/openaustralia/templates/apache/blog.conf
+++ b/roles/internal/openaustralia/templates/apache/blog.conf
@@ -21,7 +21,7 @@
         CustomLog "/srv/www/production/log/blog_access.log" combined
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
     </VirtualHost>
 </IfModule>

--- a/roles/internal/openaustralia/templates/apache/data.conf
+++ b/roles/internal/openaustralia/templates/apache/data.conf
@@ -43,8 +43,8 @@
         RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
 
         ErrorLog "/srv/www/production/log/data_redirect_error.log"
         CustomLog "/srv/www/production/log/data_redirect_access.log" combined
@@ -68,7 +68,7 @@
         </Directory>
 
        SSLEngine on
-       SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-       SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+       SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+       SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
     </VirtualHost>
 </IfModule>

--- a/roles/internal/openaustralia/templates/apache/production.conf
+++ b/roles/internal/openaustralia/templates/apache/production.conf
@@ -25,8 +25,8 @@
         RedirectMatch permanent ^/(.*) https://{{ domain }}/$1
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
 
         ErrorLog "/srv/www/production/log/{{ stage }}_redirect_error.log"
         CustomLog "/srv/www/production/log/{{ stage }}_redirect_access.log" combined
@@ -259,7 +259,7 @@
         #RewriteRule /down.html / [R]
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
     </VirtualHost>
 </IfModule>

--- a/roles/internal/openaustralia/templates/apache/software.conf
+++ b/roles/internal/openaustralia/templates/apache/software.conf
@@ -21,8 +21,8 @@
         RedirectMatch permanent / https://openaustralia.github.io/openaustralia/
 
         SSLEngine on
-        SSLCertificateKeyFile    /etc/letsencrypt/live/{{ domain }}/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/{{ domain }}/fullchain.pem
+        SSLCertificateKeyFile    {{ certbot_live_dir_map[domain] }}/privkey.pem
+        SSLCertificateFile       {{ certbot_live_dir_map[domain] }}/fullchain.pem
 
         ErrorLog "/srv/www/production/log/software_error.log"
         CustomLog "/srv/www/production/log/software_access.log" combined


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/481

## What does this do?

Check for and use /etc/letsencrypt/live/{{ domain }}*-NNNN dir if it exists

## Why was this needed?

I updated the apache config files log dirs, and it reverted to standard file paths - certbot dynamically updates the apache config files as well when the list of cert domains changes. 

The ansible tasks now detect when sequenced live dirs are present and use the latest, eg:

```
-        SSLCertificateKeyFile    /etc/letsencrypt/live/www.openaustralia.org.au/privkey.pem
-        SSLCertificateFile       /etc/letsencrypt/live/www.openaustralia.org.au/fullchain.pem
+        SSLCertificateKeyFile    /etc/letsencrypt/live/www.openaustralia.org.au-0001/privkey.pem
+        SSLCertificateFile       /etc/letsencrypt/live/www.openaustralia.org.au-0001/fullchain.pem
```

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

I have checked then applied this hotfix to the openaustralia server using:

```
TAGS=sites_available make check-openaustralia
TAGS=sites_available make apply-openaustralia
```