### PR TITLE
Update database host references to db_host

### DIFF
--- a/roles/internal/metabase/tasks/main.yml
+++ b/roles/internal/metabase/tasks/main.yml
@@ -32,14 +32,14 @@
 
 - name: Create database
   postgresql_db:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     name: "metabase"
 
 - name: Create posgresql role
   postgresql_user:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     db: "metabase"

--- a/roles/internal/metabase/templates/docker-compose.yml
+++ b/roles/internal/metabase/templates/docker-compose.yml
@@ -10,5 +10,5 @@ services:
       MB_DB_PORT: 5432
       MB_DB_USER: metabase
       MB_DB_PASS: {{ db_password }}
-      MB_DB_HOST: {{ postgresql_host }}
+      MB_DB_HOST: {{ db_host }}
     restart: always

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -250,7 +250,7 @@
 
 - name: Create database
   postgresql_db:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     name: "rtk-{{ item }}"
@@ -258,7 +258,7 @@
 
 - name: Create posgresql role
   postgresql_user:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     db: "rtk-{{ item }}"
@@ -270,7 +270,7 @@
 
 - name: Create posgresql user rtk-production-readonly for metabase
   postgresql_user:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     db: "rtk-production"
@@ -281,7 +281,7 @@
 
 - name: Give the user rtk-production-readonly readonly access to the production righttoknow database
   postgresql_privs:
-    login_host: "{{ postgresql_host }}"
+    login_host: "{{ db_host }}"
     login_user: root
     login_password: "{{ rds_admin_password }}"
     db: "rtk-production"

--- a/roles/internal/righttoknow/templates/database.yml
+++ b/roles/internal/righttoknow/templates/database.yml
@@ -1,6 +1,6 @@
 production:
   adapter: postgresql
-  host: {{ postgresql_host }}
+  host: {{ db_host }}
   database: "rtk-{{ stage }}"
   username: "rtk-{{ stage }}"
   password: {{ password }}


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Updates the remaining references of `postgresql_host` to `db_host` in configuration files and tasks.

## Why was this needed?
We changed the variable from postgresql_host to db_host

## Implementation/Deploy Steps (Optional)
No deployment required (however you can run `make check` commands

## Notes to reviewer (Optional)

