### PR TITLE
Add non-proxy A record for srv.theyvoteforyou.org.au

### DIFF
--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -27,6 +27,15 @@ resource "cloudflare_record" "root" {
   proxied = true
 }
 
+### TODO: Remove this when we have the OpenVPN configured
+resource "cloudflare_record" "non_proxy_root" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "srv.theyvoteforyou.org.au"
+  type    = "A"
+  value   = aws_eip.main.public_ip
+  proxied = false
+}
+
 # CNAME records
 
 resource "cloudflare_record" "www" {


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
Adds a non-proxy A record for the domain srv.theyvoteforyou.org.au.

## Why was this needed?
This change allows direct access to the server without proxying through Cloudflare, which is necessary until OpenVPN is configured.

## Implementation/Deploy Steps (Optional)
Do not deploy this - change has been made manually - there is a config misalignment in terraform currently.

## Notes to reviewer (Optional)
Changes have been applied manually in Cloudflare
