### PR TITLE
Update Terraform configuration to reflect current state

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -1,4 +1,5 @@
-resource "aws_db_instance" "main" {
+# This is the old MySQL 5.6 instance. Terraform wants to keep creating it so I'm going to comment it out for the moment
+/* resource "aws_db_instance" "main" {
   # kedumba has a 150GB disk so let's start with 50GB of database
   allocated_storage = 50
 
@@ -47,7 +48,7 @@ resource "aws_db_instance" "main" {
   # parameter_group_name       = aws_db_parameter_group.mysql_default.name
   parameter_group_name = "default.mysql5.7-db-3zfhxnxjf2w5aymy2dl3hbsk3m-upgrade"
   deletion_protection  = false
-}
+} */
 
 resource "aws_iam_role" "rds-monitoring-role" {
   name = "rds-monitoring-role"

--- a/terraform/openaustralia/main.tf
+++ b/terraform/openaustralia/main.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "main" {
   ebs_optimized = true
   key_name      = "test"
   tags = {
-    Name = "openaustralia"
+    Name = "OLD openaustralia"
   }
   vpc_security_group_ids  = [var.security_group_webserver.id, var.security_group_service.id]
   availability_zone       = aws_ebs_volume.data.availability_zone
@@ -25,7 +25,7 @@ resource "aws_instance" "main" {
 resource "aws_eip" "main" {
   instance = aws_instance.main.id
   tags = {
-    Name = "openaustralia"
+    Name = "OLD openaustralia"
   }
 }
 
@@ -42,7 +42,7 @@ resource "aws_ebs_volume" "data" {
   size = 20
   type = "gp3"
   tags = {
-    Name = "openaustralia_data"
+    Name = "OLD openaustralia_data"
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/infrastructure/issues/516

## What does this do?
1. Comments out the MySQL 5.6 database so that terraform doesn't try to recreate it
2. Renames all the old openaustralia.org AWS config to OLD so we can see that in AWS

## Why was this needed?
1. We don't want to create a new MySQL 5.6 DB by accident
2. We should be able to tell the difference between old and new servers in AWS

## Implementation/Deploy Steps (Optional)
1. `make tf-plan` to verify
2. `make tf-apply` to apply changes

## Notes to reviewer (Optional)
There are a number of DNS changes which were approved in a previous PR - these are additions only and are safe to apply.