### PR TITLE
Update GitHub user management for deployment

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -37,9 +37,6 @@ github_users:
     "br3nda",
     "ianheggie-oaf",
     "jamezpolley",
-    "jattree",
-    "mlandauer",
-    "simonzippy",
   ]
 
 

--- a/group_vars/righttoknow.yml
+++ b/group_vars/righttoknow.yml
@@ -1,16 +1,7 @@
 # TODO: Unify this with the domain. It's currently only used to name
 # things on New Relic.
 site_name: righttoknow.org.au
-github_users:
-  [
-    "benrfairless",
-    "br3nda",
-    "ianheggie-oaf",
-    "jamezpolley",
-    "jattree",
-    "mlandauer",
-    "simonzippy",
-  ]
+
 cron_enabled: true
 certbot_webserver: nginx
 certbot_webroot: /usr/share/nginx/html

--- a/roles/internal/deploy-user/tasks/main.yml
+++ b/roles/internal/deploy-user/tasks/main.yml
@@ -11,22 +11,55 @@
     shell: /bin/bash
     group: deploy
 
-
-
-## This will ensure that the listed keys are present
-## but it does not remove other keys. If we have a need to revoke
-## access we'll have to do something different.
-- name: Create authorized_keys files for local accounts
-  become: true
-  authorized_key:
-    user: "{{ item[0] }}"
-    key: https://github.com/{{ item[1] }}.keys
-    comment: "{{ item[1] }}"
+- name: Refuse to manage authorized_keys without a populated github_users list
+  ansible.builtin.assert:
+    that:
+      - github_users is defined
+      - github_users | length > 0
+    fail_msg: >-
+      github_users is empty or undefined. Refusing to apply exclusive
+      authorized_keys, which would lock everyone out of deploy/ubuntu/root.
   tags:
     - userkeys
-  with_nested:
-    - ['deploy', 'ubuntu', 'root']
-    - "{{ github_users }}"
+
+- name: Fetch SSH public keys from GitHub for permitted users
+  ansible.builtin.uri:
+    url: "https://github.com/{{ item }}.keys"
+    return_content: true
+  loop: "{{ github_users }}"
+  register: github_keys_fetched
+  check_mode: false
+  tags:
+    - userkeys
+
+- name: Derive terraform.pem public key
+  ansible.builtin.set_fact:
+    terraform_public_key: "{{ lookup('pipe', 'ssh-keygen -y -f ' + playbook_dir + '/terraform.pem') | trim }}"
+  tags:
+    - userkeys
+
+- name: Set authorized_keys for local accounts (only listed github_users + terraform)
+  become: true
+  authorized_key:
+    user: "{{ item }}"
+    exclusive: true
+    key: "{{ permitted_keys_for_account }}"
+  vars:
+    github_keys: |-
+      {% for result in github_keys_fetched.results -%}
+      {% for line in result.content.splitlines() if line | trim %}
+      {{ line }} {{ result.item }}
+      {% endfor %}
+      {% endfor %}
+    terraform_key_root: 'no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo ''Please login as the user \"ubuntu\" rather than the user \"root\".'';echo;sleep 10;exit 142" {{ terraform_public_key }} terraform'
+    terraform_key_plain: "{{ terraform_public_key }} terraform"
+    permitted_keys_for_account: "{{ github_keys }}\n{{ terraform_key_root if item == 'root' else terraform_key_plain }}"
+  loop:
+    - deploy
+    - ubuntu
+    - root
+  tags:
+    - userkeys
   register: add_authorized_keys
 
 - name: Only allow ssh access with keys


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/oaf-internal/issues/231

## What does this do?
- Removes the specific github_users list for righttoknow
- Remove jattree, mlandauer, simonzippy from server access
- Update deploy-user ansible role to support the removal of users/keys.
- Add safety gate to deploy-user ansible role so that it doesn't manage authorised keys without a github_users list
- Ensure that terraform.pem is included in the authorised keys list.

## Why was this needed?
- Makes it easier to add/remove users to deploy servers
- Removes users who no longer need SSH access to servers
- Ensures that only the correct keys are configured on each server


## Implementation/Deploy Steps (Optional)
- Run `make update-github-ssh-keys` to apply to all servers

## Notes to reviewer (Optional)
- Please double check this configuration before approving, as it is destructive (eg: removes keys).