### PR TITLE
Refactor SSH key management for enhanced security

### DIFF
--- a/roles/internal/deploy-user/tasks/main.yml
+++ b/roles/internal/deploy-user/tasks/main.yml
@@ -51,16 +51,22 @@
       {{ line }} {{ result.item }}
       {% endfor %}
       {% endfor %}
-    terraform_key_root: 'no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo ''Please login as the user \"ubuntu\" rather than the user \"root\".'';echo;sleep 10;exit 142" {{ terraform_public_key }} terraform'
     terraform_key_plain: "{{ terraform_public_key }} terraform"
-    permitted_keys_for_account: "{{ github_keys }}\n{{ terraform_key_root if item == 'root' else terraform_key_plain }}"
+    permitted_keys_for_account: "{{ github_keys }}\n{{ terraform_key_plain }}"
   loop:
     - deploy
     - ubuntu
-    - root
   tags:
     - userkeys
   register: add_authorized_keys
+
+- name: Remove any existing authorized_keys for root (root is console-only)
+  become: true
+  ansible.builtin.file:
+    path: /root/.ssh/authorized_keys
+    state: absent
+  tags:
+    - userkeys
 
 - name: Only allow ssh access with keys
   become: true
@@ -70,4 +76,13 @@
     regexp: "^#?PasswordAuthentication"
     line: "PasswordAuthentication no"
   when: add_authorized_keys is success
+  notify: sshd restart
+
+- name: Disallow root SSH login (console only)
+  become: true
+  ansible.builtin.lineinfile:
+    dest: /etc/ssh/sshd_config
+    state: present
+    regexp: "^#?PermitRootLogin"
+    line: "PermitRootLogin no"
   notify: sshd restart


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/oaf-internal/issues/231

## What does this do?
Refactor SSH key management by removing root's authorized_keys and disallowing root SSH login.

## Why was this needed?
Enhances security by preventing root SSH access and ensuring only designated users can log in via SSH.

## Implementation/Deploy Steps (Optional)
- Run make update-github-ssh-keys to apply to all servers
 
## Notes to reviewer (Optional)
Creating this as a DRAFT for discussion before we implement. Would appreciate feedback.