### PR TITLE
hotfix: Fix apt update failure messages for passenger

### DIFF
--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -40,8 +40,7 @@
 
 - name: Install libyaml packages
   apt:
-    pkg:
-      - libyaml-dev
+    pkg: libyaml-dev
     state: present
 
 # We want this directory to exist in development too so that

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -4,21 +4,43 @@
     name: apache2
     state: absent
 
+# Based on https://www.phusionpassenger.com/docs/advanced_guides/install_and_upgrade/standalone/install/oss/jammy.html
+
+- name: Add HTTPS support for APT
+  tags: passenger
+  apt:
+    pkg:
+      - dirmngr
+      - gnupg
+      - apt-transport-https
+      - ca-certificates
+      - curl
+    state: present
+
 - name: Add key for passenger
+  tags: passenger
   ansible.builtin.get_url:
-    url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt
+    url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt
     dest: /usr/share/keyrings/phusionpassenger-archive-keyring.asc
+
 - name: Add passenger apt repository
+  tags: passenger
   apt_repository:
     repo: 'deb [signed-by=/usr/share/keyrings/phusionpassenger-archive-keyring.asc] https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
     state: present
     update_cache: true
 
-- name: Install nginx, passenger and libyaml packages
+- name: Install nginx and passenger packages
+  tags: passenger
   apt:
     pkg:
       - libnginx-mod-http-passenger
       - nginx
+    state: present
+
+- name: Install libyaml packages
+  apt:
+    pkg:
       - libyaml-dev
     state: present
 

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -23,10 +23,10 @@
     url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt
     dest: /usr/share/keyrings/phusionpassenger-archive-keyring.asc
 
-- name: Apt add passenger to list
+- name: Add passenger apt repository
   tags: passenger
   apt_repository:
-    repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
+    repo: 'deb [signed-by=/usr/share/keyrings/phusionpassenger-archive-keyring.asc] https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
     state: present
     update_cache: true
 

--- a/roles/internal/theyvoteforyou/tasks/main.yml
+++ b/roles/internal/theyvoteforyou/tasks/main.yml
@@ -4,23 +4,34 @@
     name: apache2
     state: absent
 
-- name: Add key for passenger
-  apt_key:
-    url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xAC40B2F7"
+# Based on https://www.phusionpassenger.com/docs/advanced_guides/install_and_upgrade/standalone/install/oss/jammy.html
+
+- name: Add HTTPS support for APT
+  tags: passenger
+  apt:
+    pkg:
+      - dirmngr
+      - gnupg
+      - apt-transport-https
+      - ca-certificates
+      - curl
     state: present
 
-- name: Apt via https
-  apt:
-    name: apt-transport-https
-    state: present
+- name: Add key for passenger
+  tags: passenger
+  ansible.builtin.get_url:
+    url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt
+    dest: /usr/share/keyrings/phusionpassenger-archive-keyring.asc
 
 - name: Apt add passenger to list
+  tags: passenger
   apt_repository:
     repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
     state: present
     update_cache: true
 
-- name: Install nginx and passenger
+- name: Install nginx and passenger packages
+  tags: passenger
   apt:
     pkg:
       - libnginx-mod-http-passenger


### PR DESCRIPTION
## Relevant issue(s)

Fixes:
* https://github.com/openaustralia/infrastructure/issues/526

## What does this do?

Updates the passenger key details as per
https://www.phusionpassenger.com/docs/advanced_guides/install_and_upgrade/standalone/install/oss/jammy.html

## Why was this needed?

Errors with the initial check that python modules are installed
relating to passenger apt keys being out of date

## Implementation/Deploy Steps (Optional)

Already deployed to related servers

## Notes to reviewer (Optional)
