### PR TITLE
Add Lima as an Apple Silicon / amd64-via-Rosetta alternative to Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 
 .vagrant
 .keybase
+
+# Lima generated state
+/lima/inventory/lima-hosts
+/lima/.state/
+/lima/bin/__pycache__/
+
 roles/external
 collections/
 test.pem

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
         check-host check-metabase check-oaf check-openaustralia check-planningalerts check-righttoknow \
         check-rtk-prod check-rtk-staging check-theyvoteforyou check-target \
         scan-oaf scan-openaustralia scan-planningalerts \
-        clean clobber help install-linters keybase letsencrypt lint production retry roles \
+        clean clobber help install-linters keybase letsencrypt lint \
+        lima lima-requirements lima-up lima-provision lima-destroy lima-status lima-hosts-sync lima-clean \
+        production retry roles \
         show-facts show-inventory show-rds-facts show-vars stage_required tf-apply tf-apply-target tf-init tf-plan \
         tf-plan-target update-github-ssh-keys vagrant venv yaml-lint
 
@@ -51,6 +53,12 @@ help:
 	@echo "  tf-apply                            Run terraform apply in the terraform directory"
 	@echo "  update-github-ssh-keys              Update SSH keys on all servers from GitHub"
 	@echo "  vagrant                             Install vagrant plugins and ensure requirements are present"
+	@echo "  lima                                Apple Silicon / amd64-via-Rosetta alternative to vagrant (see docs/local-dev-with-lima.md)"
+	@echo "  lima-up [HOSTS=a,b]                 Bring up Lima VMs from lima/hosts.yml"
+	@echo "  lima-provision [HOSTS=a,b]          Run site.yml against the Lima fleet"
+	@echo "  lima-destroy [HOSTS=a,b]            Stop and delete Lima VMs"
+	@echo "  lima-status                         Show status of Lima fleet"
+	@echo "  lima-hosts-sync                     Update macOS /etc/hosts for the live fleet (needs sudo)"
 	@echo ""
 	@echo "  clean                               Remove virtualenv, external roles, retry file, collections, keybase symlink"
 	@echo "  clobber                             clobber everything make all created (clean + removes .vagrant and log)"
@@ -101,6 +109,40 @@ keybase: .keybase
 	[ $$broken -eq 0 ]
 
 vagrant: .make/vagrant-plugins .make/certificates requirements
+
+# --- Lima (Apple Silicon / amd64-via-Rosetta alternative to Vagrant) -------
+# See docs/local-dev-with-lima.md for one-time setup (brew install lima
+# socket_vmnet, sudoers, etc).
+
+lima: lima-requirements lima-up lima-hosts-sync lima-provision
+
+lima-requirements: .make/certificates requirements
+	@command -v limactl >/dev/null || { echo "ERROR: limactl not found. See docs/local-dev-with-lima.md."; exit 1; }
+	@.venv/bin/python -c "import yaml" 2>/dev/null || .venv/bin/pip install pyyaml
+
+lima-up: lima-requirements
+	.venv/bin/python lima/bin/lima-up $(subst $(comma), ,$(HOSTS))
+
+lima-provision: lima-requirements
+	HOSTS="$(HOSTS)" TAGS="$(TAGS)" SKIP_TAGS="$(SKIP_TAGS)" ANSIBLE_VERBOSE="$(ANSIBLE_VERBOSE)" \
+	  lima/bin/lima-provision
+
+lima-destroy:
+	.venv/bin/python lima/bin/lima-destroy $(subst $(comma), ,$(HOSTS))
+
+lima-status:
+	.venv/bin/python lima/bin/lima-status
+
+lima-hosts-sync:
+	sudo .venv/bin/python lima/bin/lima-hosts-sync
+
+lima-clean: lima-destroy
+	sudo .venv/bin/python lima/bin/lima-hosts-sync -d || true
+	rm -rf lima/.state lima/inventory/lima-hosts
+
+# Helper to translate HOSTS=a,b on the command line into a space-separated list.
+comma := ,
+# ---------------------------------------------------------------------------
 
 generate-certificates: .make/certificates
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ _Umm. 7 years later, plus one day. That's weird._
 
 In the past, the tools in this repo were well supported across most common Linux platforms (including WSL), and OS X. However, newer versions of OSX only run on ARM chips, and older versions of OS X are increasingly unsupported by tools such as VirtualBox and Docker.
 
-As of today, the only platform that we know works is debian-based Linux systems. Other linuxes probably work, including WSL; and there are probably two releases of MacOS which still run on the last generations of Intel Macs which might work.
+For ARM/Apple Silicon developers, there is now a [Lima](https://lima-vm.io/)-based local fleet alongside the existing Vagrant flow — see [docs/local-dev-with-lima.md](docs/local-dev-with-lima.md). Lima pins every guest to `linux/amd64` and uses Apple's Rosetta to translate amd64 instructions, so locally-tested behaviour matches production exactly.
 
-We'd like to expand this in future, when we have time
+For Linux and Intel macOS contributors the Vagrant path continues to work; Lima also runs on Linux on amd64 hosts if you prefer the same tooling.
 
 #### <a name='RightToKnowDevplatform'></a>RightToKnow Dev platform
 
@@ -330,6 +330,22 @@ If it's already up, you can re-run Ansible provisioning with:
 Or combine with:
 
     vagrant up --provision staging.righttoknow.test
+
+### <a name='ProvisioninglocaldevelopmentserversusingLima'></a>Provisioning local development servers using Lima (Apple Silicon / amd64 via Rosetta)
+
+For Apple Silicon (and as an alternative on Linux/Intel Mac), Lima brings up the same fleet
+with amd64 guests via Apple's Rosetta. One-time setup (`brew install lima socket_vmnet`, sudoers)
+is documented in [docs/local-dev-with-lima.md](docs/local-dev-with-lima.md).
+
+Day-to-day:
+
+    make lima-requirements                              # one-time per checkout
+    HOSTS=mysql.test,web.planningalerts.test make lima-up
+    sudo make lima-hosts-sync                           # macOS /etc/hosts updated for the fleet
+    HOSTS=mysql.test,web.planningalerts.test make lima-provision
+
+`TAGS=`, `SKIP_TAGS=`, and `ANSIBLE_VERBOSE=` work exactly like with the `apply-*` targets.
+Tear down with `make lima-destroy` or `make lima-clean`.
 
 ### <a name='Provisioningproductionservers'></a>Provisioning production servers
 

--- a/docs/local-dev-with-lima.md
+++ b/docs/local-dev-with-lima.md
@@ -1,0 +1,162 @@
+# Local development with Lima (Apple Silicon / amd64 via Rosetta)
+
+Lima is an alternative to Vagrant for spinning up the local Ansible
+development fleet. Unlike Vagrant + VirtualBox, it runs on Apple Silicon
+(M1+) using Apple's Virtualization.framework with Rosetta to translate
+amd64 instructions at near-native speed. Every guest is `linux/amd64`,
+matching production exactly.
+
+The Vagrant flow remains supported for contributors who prefer it; both
+paths use the same Ansible playbook against the same `development` host
+group.
+
+## Requirements
+
+| Host                           | Hypervisor (auto-picked) | Performance                |
+| ------------------------------ | ------------------------ | -------------------------- |
+| macOS 13+ on Apple Silicon     | `vz` + Rosetta           | Fast — Rosetta translation |
+| macOS on Intel                 | `vz` (or `qemu`)         | Native                     |
+| Linux on amd64                 | `qemu` + KVM             | Native                     |
+
+Lima ≥ **0.20** is required for the Rosetta-on-vz support that this
+setup depends on.
+
+### macOS one-time setup
+
+```bash
+brew install lima socket_vmnet
+
+# Allow Lima to manage the shared L2 network without prompting per command.
+# `socket_vmnet` is the macOS bridge that gives both host↔VM and VM↔VM
+# connectivity — the closest equivalent to Vagrant's private host-only
+# network.
+limactl sudoers | sudo tee /etc/sudoers.d/lima
+
+# (Optional) Verify Rosetta and macOS version.
+sw_vers -productVersion        # must be ≥ 13.0
+limactl --version              # must be ≥ 0.20
+```
+
+### Linux one-time setup
+
+```bash
+# Debian/Ubuntu:
+sudo apt install lima qemu-system-x86 qemu-utils
+```
+
+`socket_vmnet` is macOS-only. On Linux, `lima/bin/lima-up` falls back to
+the `user-v2` network, which gives VM↔VM connectivity but reaches VMs
+from the host via port forwards rather than direct IP. Most Linux
+contributors will still find Vagrant + VirtualBox more convenient there;
+Lima on Linux is provided primarily for amd64-Linux contributors who
+also want to test changes on Apple Silicon machines.
+
+## Day-to-day workflow
+
+```bash
+make lima-requirements                              # one-time per checkout
+HOSTS=mysql.test,web.planningalerts.test \
+  make lima-up                                      # subset of fleet
+sudo make lima-hosts-sync                           # add VM names to /etc/hosts
+HOSTS=mysql.test,web.planningalerts.test \
+  make lima-provision                               # run site.yml
+
+# To re-run only a tagged subset (same env vars as `make apply-*`):
+TAGS=apache HOSTS=web.planningalerts.test make lima-provision
+
+# Status / teardown:
+make lima-status
+HOSTS=mysql.test make lima-destroy                  # one VM
+make lima-clean                                     # all VMs + /etc/hosts block
+```
+
+## Memory and CPU
+
+Defaults: 2 GB RAM, 2 vCPU per VM (matching the Vagrant defaults
+described at [README.md](../README.md)). The full fleet is 14 VMs and
+will not fit in a typical laptop. Boot only what you need — usually
+mysql or postgresql plus the one app server you're working on.
+
+Override per `make lima-up` invocation:
+
+```bash
+LIMA_MEMORY=4GiB LIMA_CPUS=4 make lima-up HOSTS=web.planningalerts.test
+```
+
+## How it works
+
+1. [lima/hosts.yml](../lima/hosts.yml) declares the fleet (one entry per
+   inventory hostname, with Ubuntu release, groups, and aliases).
+2. `lima/bin/lima-up` reads it, picks the matching template from
+   [lima/templates/](../lima/templates/), substitutes the hostname / CPU /
+   memory / network block, and calls `limactl create` + `limactl start`.
+3. Each VM's `provision:` block (in the template) sets the hostname,
+   grants the Lima user's SSH key to `root`, and ensures `python3` is
+   present — so Ansible's existing `remote_user = root` and `gather_facts`
+   work without changes.
+4. After all VMs are up, `lima-up` writes
+   [lima/inventory/lima-hosts](../lima/inventory/) — an Ansible inventory
+   with the same group shape as the `Vagrantfile`.
+5. `make lima-provision` invokes `.venv/bin/ansible-playbook -i
+   lima/inventory/lima-hosts site.yml` with the same tag/skip/verbose
+   plumbing the rest of the Makefile uses.
+
+## Capistrano deploys to Lima VMs
+
+The `lima:shared` network gives the macOS host direct L3 access to VM
+IPs, so once `lima-hosts-sync` has updated `/etc/hosts`, Capistrano
+flows from app repositories (Alaveteli, planningalerts-app, etc.) work
+exactly as they do with Vagrant. For example, with `server:
+righttoknow.test` in `config/deploy.yml`:
+
+```bash
+cd ../alaveteli
+bundle exec cap -S stage=development deploy:cold
+```
+
+## Troubleshooting
+
+### `limactl start` hangs on first boot
+
+First-boot downloads the Ubuntu cloud image (~500 MB per release). Watch
+progress with `limactl shell <instance> -- journalctl -u cloud-final -f`
+once SSH is reachable, or `tail -F ~/.lima/<instance>/serial.log`.
+
+### Provision probe fails: "root SSH and python3 ready"
+
+Inspect the per-VM serial log:
+
+```bash
+tail -200 ~/.lima/<instance>/serial.log
+```
+
+Common causes: cloud-init didn't finish (bad Ubuntu image URL), Lima
+default user differs from `$USER` (set `LIMA_USER=<user>` in the
+environment before `make lima-up`), or the template's
+`PermitRootLogin` edit failed.
+
+### `vagrant up` and `make lima-up` together
+
+Both can coexist on the same checkout. They use different VM tools and
+different inventories. The Ansible-side change (`group_vars/development.yml`
+referring to `mysql.test` rather than `192.168.56.10`) is satisfied by:
+
+- **Vagrant:** `vagrant-hostsupdater` writes the macOS host /etc/hosts,
+  and the new `internal/dev-hosts` role writes the guest /etc/hosts.
+- **Lima:** `lima-hosts-sync` writes the macOS host /etc/hosts, and the
+  same `internal/dev-hosts` role writes the guest /etc/hosts.
+
+### "address already in use" port clashes
+
+Lima auto-assigns SSH ports starting at 60022 — usually no conflict.
+For port forwards to host (e.g. Capistrano needs port 22 on the VM
+IP), `lima:shared` uses the assigned VM IP so the host port 22 is not
+touched.
+
+## Removing the Lima setup
+
+```bash
+make lima-clean             # destroy all VMs, remove /etc/hosts block
+brew uninstall lima socket_vmnet
+sudo rm /etc/sudoers.d/lima
+```

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -1,8 +1,10 @@
 base_domain: test
 
-mysql_host: 192.168.56.10
-postgresql_host: 192.168.56.11
-planningalerts_db_host: 192.168.56.11
+# Resolved by the internal/dev-hosts role, which writes /etc/hosts entries on
+# every development VM from inventory. Works for both Vagrant and Lima.
+mysql_host: mysql.test
+postgresql_host: postgresql.test
+planningalerts_db_host: postgresql.test
 
 db_host: "{{ postgresql_host if 'requires_postgresql' in group_names else mysql_host }}"
 

--- a/lima/bin/lima-destroy
+++ b/lima/bin/lima-destroy
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Stop and delete Lima VMs defined in lima/hosts.yml.
+
+Usage:
+    lima/bin/lima-destroy                   # destroy every host in hosts.yml
+    lima/bin/lima-destroy mysql.test
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "ERROR: PyYAML not installed. Run `make lima-requirements` first.\n"
+    )
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+HOSTS_YML = ROOT / "hosts.yml"
+
+
+def lima_instance_for(host: str, spec: dict) -> str:
+    return spec.get("lima_instance") or host.replace(".", "-")
+
+
+def existing_instances() -> set[str]:
+    out = subprocess.run(
+        ["limactl", "list", "--json"], check=True, capture_output=True, text=True
+    ).stdout
+    names = set()
+    for line in out.splitlines():
+        line = line.strip()
+        if line:
+            names.add(json.loads(line)["name"])
+    return names
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("hosts", nargs="*")
+    ap.add_argument(
+        "-y", "--yes", action="store_true", help="Skip confirmation prompt."
+    )
+    args = ap.parse_args()
+
+    fleet = yaml.safe_load(HOSTS_YML.read_text())["hosts"]
+    if args.hosts:
+        unknown = [h for h in args.hosts if h not in fleet]
+        if unknown:
+            sys.stderr.write(f"ERROR: unknown host(s): {unknown}\n")
+            return 1
+        selected = {h: fleet[h] for h in args.hosts}
+    else:
+        selected = fleet
+
+    instances = sorted({lima_instance_for(h, s) for h, s in selected.items()})
+    extant = existing_instances()
+    to_delete = [i for i in instances if i in extant]
+    if not to_delete:
+        print("Nothing to destroy.")
+        return 0
+
+    print("Will destroy:")
+    for i in to_delete:
+        print(f"  - {i}")
+    if not args.yes and os.isatty(0):
+        ans = input("Proceed? [y/N] ").strip().lower()
+        if ans != "y":
+            print("Aborted.")
+            return 1
+
+    for i in to_delete:
+        subprocess.run(["limactl", "stop", "--force", i], check=False)
+        subprocess.run(["limactl", "delete", "--force", i], check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lima/bin/lima-hosts-sync
+++ b/lima/bin/lima-hosts-sync
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Add/refresh /etc/hosts entries on the *host* machine for live Lima VMs.
+
+This is the moral equivalent of the `vagrant-hostsupdater` plugin: it
+writes a marker-delimited block to /etc/hosts so the developer machine
+can resolve `mysql.test`, `web.planningalerts.test`, etc., to the right
+VM IPs.
+
+The script edits /etc/hosts with sudo. It's idempotent — re-running
+replaces the block in place.
+
+Usage:
+    sudo lima/bin/lima-hosts-sync       # write block from live VMs
+    sudo lima/bin/lima-hosts-sync -d    # remove the block (no entries)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "ERROR: PyYAML not installed. Run `make lima-requirements` first.\n"
+    )
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+HOSTS_YML = ROOT / "hosts.yml"
+HOSTS_FILE = Path("/etc/hosts")
+BEGIN = "# BEGIN lima-managed (OAF infrastructure)"
+END = "# END lima-managed (OAF infrastructure)"
+
+
+def lima_instance_for(host: str, spec: dict) -> str:
+    return spec.get("lima_instance") or host.replace(".", "-")
+
+
+def list_instances() -> dict[str, dict]:
+    out = subprocess.run(
+        ["limactl", "list", "--json"], check=True, capture_output=True, text=True
+    ).stdout
+    return {
+        json.loads(line)["name"]: json.loads(line)
+        for line in out.splitlines()
+        if line.strip()
+    }
+
+
+def pick_ip(inst: dict) -> str | None:
+    for net in inst.get("network", []) or []:
+        if net.get("address"):
+            return net["address"]
+    for addr in inst.get("addresses", []) or []:
+        if not addr.startswith("127."):
+            return addr
+    return None
+
+
+def build_block(fleet: dict, instances: dict) -> str:
+    lines = [BEGIN]
+    for host, spec in fleet.items():
+        instance = lima_instance_for(host, spec)
+        inst = instances.get(instance)
+        ip = pick_ip(inst) if inst else None
+        if not ip:
+            lines.append(f"# (skipped) {host}: instance {instance} not running")
+            continue
+        names = " ".join([host, *(spec.get("aliases") or [])])
+        lines.append(f"{ip}\t{names}")
+    lines.append(END)
+    return "\n".join(lines) + "\n"
+
+
+def replace_block(content: str, new_block: str) -> str:
+    pattern = re.compile(rf"{re.escape(BEGIN)}.*?{re.escape(END)}\n?", re.S)
+    if pattern.search(content):
+        return pattern.sub(new_block, content)
+    if not content.endswith("\n"):
+        content += "\n"
+    return content + "\n" + new_block
+
+
+def remove_block(content: str) -> str:
+    pattern = re.compile(rf"\n?{re.escape(BEGIN)}.*?{re.escape(END)}\n?", re.S)
+    return pattern.sub("", content)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "-d", "--delete", action="store_true", help="Remove the managed block."
+    )
+    args = ap.parse_args()
+
+    if os.geteuid() != 0:
+        sys.stderr.write(
+            "ERROR: must be run as root (e.g. `sudo lima/bin/lima-hosts-sync`).\n"
+        )
+        return 1
+
+    current = HOSTS_FILE.read_text()
+    if args.delete:
+        new = remove_block(current)
+    else:
+        fleet = yaml.safe_load(HOSTS_YML.read_text())["hosts"]
+        new = replace_block(current, build_block(fleet, list_instances()))
+
+    if new == current:
+        print("No changes.")
+        return 0
+
+    backup = HOSTS_FILE.with_suffix(".lima.bak")
+    backup.write_text(current)
+    HOSTS_FILE.write_text(new)
+    print(f"Updated {HOSTS_FILE} (previous content saved to {backup}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lima/bin/lima-provision
+++ b/lima/bin/lima-provision
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run site.yml against the Lima fleet inventory.
+#
+# Usage:
+#   lima/bin/lima-provision                       # all hosts
+#   lima/bin/lima-provision mysql.test            # subset (one or more)
+#   HOSTS=mysql.test,postgresql.test lima/bin/lima-provision  # subset via env
+#   TAGS=apache lima/bin/lima-provision           # tags forwarded to ansible-playbook
+#
+# Extra `ansible-playbook` arguments may be passed after `--`:
+#   lima/bin/lima-provision -- --diff --start-at-task='Install nginx'
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INVENTORY="${ROOT}/lima/inventory/lima-hosts"
+
+if [ ! -s "${INVENTORY}" ]; then
+  echo "ERROR: ${INVENTORY} is missing or empty. Run lima/bin/lima-up first." >&2
+  exit 1
+fi
+
+ANSIBLE="${ROOT}/.venv/bin/ansible-playbook"
+if [ ! -x "${ANSIBLE}" ]; then
+  echo "ERROR: ${ANSIBLE} not found. Run 'make requirements' first." >&2
+  exit 1
+fi
+
+# Collect host subset from positional args or HOSTS env var.
+hosts_args=()
+if [ "$#" -gt 0 ] && [ "$1" != "--" ]; then
+  for h in "$@"; do
+    [ "$h" = "--" ] && break
+    hosts_args+=("$h")
+    shift
+  done
+fi
+if [ "${HOSTS:-}" != "" ]; then
+  IFS=',' read -ra extra <<< "${HOSTS}"
+  hosts_args+=("${extra[@]}")
+fi
+
+limit_arg=()
+if [ "${#hosts_args[@]}" -gt 0 ]; then
+  IFS=',' joined="${hosts_args[*]}"
+  limit_arg=(--limit "${joined}")
+fi
+
+# Drop leading -- if present so remaining "$@" is passthrough args.
+if [ "${1:-}" = "--" ]; then shift; fi
+
+opts=()
+if [ "${TAGS:-}" != "" ]; then
+  cleaned_tags=$(echo "${TAGS}" | sed 's/[^A-Z0-9_]\+/,/gi' | sed 's/,\+/,/g' | sed 's/^,//;s/,$//')
+  opts+=(--tags "${cleaned_tags},facts")
+  echo "INFO: TAGS=${cleaned_tags},facts"
+fi
+if [ "${SKIP_TAGS:-}" != "" ]; then
+  cleaned_skip=$(echo "${SKIP_TAGS}" | sed 's/[^A-Z0-9_]\+/,/gi' | sed 's/,\+/,/g' | sed 's/^,//;s/,$//')
+  opts+=(--skip-tags "${cleaned_skip}")
+  echo "INFO: SKIP_TAGS=${cleaned_skip}"
+fi
+if [ "${ANSIBLE_VERBOSE:-}" != "" ]; then
+  opts+=("-${ANSIBLE_VERBOSE}")
+fi
+
+cd "${ROOT}"
+exec "${ANSIBLE}" -i "${INVENTORY}" site.yml "${limit_arg[@]}" "${opts[@]}" --diff "$@"

--- a/lima/bin/lima-status
+++ b/lima/bin/lima-status
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Print status of Lima VMs defined in lima/hosts.yml."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "ERROR: PyYAML not installed. Run `make lima-requirements` first.\n"
+    )
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+HOSTS_YML = ROOT / "hosts.yml"
+
+
+def lima_instance_for(host: str, spec: dict) -> str:
+    return spec.get("lima_instance") or host.replace(".", "-")
+
+
+def main() -> int:
+    fleet = yaml.safe_load(HOSTS_YML.read_text())["hosts"]
+    fleet_instances = {lima_instance_for(h, s) for h, s in fleet.items()}
+
+    out = subprocess.run(
+        ["limactl", "list", "--json"], check=True, capture_output=True, text=True
+    ).stdout
+    by_name = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if line:
+            inst = json.loads(line)
+            by_name[inst["name"]] = inst
+
+    width = max((len(h) for h in fleet), default=10)
+    print(f"{'HOST'.ljust(width)}  INSTANCE                     STATUS     ARCH")
+    for host, spec in fleet.items():
+        instance = lima_instance_for(host, spec)
+        inst = by_name.get(instance)
+        if inst is None:
+            status = "not-created"
+            arch = "-"
+        else:
+            status = inst.get("status", "?")
+            arch = inst.get("arch", "?")
+        print(
+            f"{host.ljust(width)}  {instance.ljust(28)} {status.ljust(10)} {arch}"
+        )
+
+    extras = sorted(by_name) - fleet_instances
+    if extras:
+        print("\nLima instances not in hosts.yml:")
+        for name in extras:
+            print(f"  - {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lima/bin/lima-up
+++ b/lima/bin/lima-up
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Bring up Lima VMs defined in lima/hosts.yml.
+
+Usage:
+    lima/bin/lima-up                     # bring up every host in hosts.yml
+    lima/bin/lima-up mysql.test postgresql.test
+    LIMA_MEMORY=4GiB LIMA_CPUS=4 lima/bin/lima-up mysql.test
+
+After all VMs are running, writes lima/inventory/lima-hosts (an Ansible
+inventory file) for use by `make lima-provision`.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "ERROR: PyYAML not installed. Run `make lima-requirements` first.\n"
+    )
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+HOSTS_YML = ROOT / "hosts.yml"
+TEMPLATES_DIR = ROOT / "templates"
+STATE_DIR = ROOT / ".state"
+INVENTORY = ROOT / "inventory" / "lima-hosts"
+LIMA_USER = os.environ.get("LIMA_USER", os.environ.get("USER", "lima"))
+MIN_LIMA_VERSION = (0, 20)
+
+
+def die(msg: str, code: int = 1) -> None:
+    sys.stderr.write(f"ERROR: {msg}\n")
+    sys.exit(code)
+
+
+def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, **kw)
+
+
+def check_lima() -> None:
+    if not shutil.which("limactl"):
+        die("limactl not found in PATH. See docs/local-dev-with-lima.md.")
+    out = subprocess.run(
+        ["limactl", "--version"], check=True, capture_output=True, text=True
+    ).stdout
+    m = re.search(r"(\d+)\.(\d+)", out)
+    if not m:
+        die(f"Could not parse Lima version from: {out!r}")
+    found = (int(m.group(1)), int(m.group(2)))
+    if found < MIN_LIMA_VERSION:
+        die(
+            f"Lima >= {MIN_LIMA_VERSION[0]}.{MIN_LIMA_VERSION[1]} required, "
+            f"found {found[0]}.{found[1]}"
+        )
+
+
+def network_block() -> str:
+    """YAML block for `networks:` — varies by host OS.
+
+    macOS: socket_vmnet shared network (host↔VM and VM↔VM).
+    Linux: user-v2 (no extra deps; host reaches VMs by IP not name; see docs).
+    """
+    if platform.system() == "Darwin":
+        return "networks:\n  - lima: shared"
+    return "networks:\n  - lima: user-v2"
+
+
+def render_template(host: str, spec: dict) -> str:
+    release = spec["release"]
+    template_path = TEMPLATES_DIR / f"{release}.yaml"
+    if not template_path.exists():
+        die(f"No template for release '{release}' (host {host}).")
+    cpus = int(os.environ.get("LIMA_CPUS") or spec.get("cpus") or 2)
+    memory = os.environ.get("LIMA_MEMORY") or spec.get("memory") or "2GiB"
+    instance = lima_instance_for(host, spec)
+    body = template_path.read_text()
+    return (
+        body.replace("{{HOSTNAME}}", host)
+        .replace("{{LIMA_INSTANCE}}", instance)
+        .replace("{{LIMA_USER}}", LIMA_USER)
+        .replace("{{CPUS}}", str(cpus))
+        .replace("{{MEMORY}}", memory)
+        .replace("{{NETWORK_BLOCK}}", network_block())
+    )
+
+
+def lima_instance_for(host: str, spec: dict) -> str:
+    return spec.get("lima_instance") or host.replace(".", "-")
+
+
+def list_instances() -> dict[str, dict]:
+    """Return {instance_name: instance_json} from `limactl list --json`."""
+    out = subprocess.run(
+        ["limactl", "list", "--json"], check=True, capture_output=True, text=True
+    ).stdout
+    instances = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        inst = json.loads(line)
+        instances[inst["name"]] = inst
+    return instances
+
+
+def ensure_instance(instance: str, rendered_path: Path) -> None:
+    instances = list_instances()
+    current = instances.get(instance)
+    if current is None:
+        print(f"==> creating {instance}", flush=True)
+        run(["limactl", "create", f"--name={instance}", str(rendered_path)])
+    if (current or {}).get("status") != "Running":
+        print(f"==> starting {instance}", flush=True)
+        run(["limactl", "start", instance])
+    else:
+        print(f"==> {instance} already running", flush=True)
+
+
+def write_inventory(hosts: dict[str, dict]) -> None:
+    """Write Ansible inventory at lima/inventory/lima-hosts.
+
+    Includes group memberships from hosts.yml plus the implicit
+    `development` group. Each host has `ansible_host=<ip>` taken from
+    `limactl list --json`.
+    """
+    instances = list_instances()
+    groups: dict[str, list[str]] = {"development": []}
+    host_lines: list[str] = []
+    for host, spec in hosts.items():
+        instance = lima_instance_for(host, spec)
+        inst = instances.get(instance)
+        if not inst:
+            sys.stderr.write(f"WARN: {instance} not found; skipping in inventory\n")
+            continue
+        ip = pick_ip(inst)
+        aliases = " ".join(spec.get("aliases") or [])
+        line = f"{host} ansible_host={ip} ansible_user=root"
+        if aliases:
+            line += f' dev_aliases="[{",".join(repr(a) for a in spec.get("aliases") or [])}]"'
+        host_lines.append(line)
+        groups["development"].append(host)
+        for g in spec.get("groups") or []:
+            groups.setdefault(g, []).append(host)
+
+    INVENTORY.parent.mkdir(parents=True, exist_ok=True)
+    with INVENTORY.open("w") as f:
+        f.write("# Generated by lima/bin/lima-up — do not edit by hand.\n")
+        f.write("[all:vars]\nansible_python_interpreter=/usr/bin/python3\n\n")
+        for line in host_lines:
+            f.write(line + "\n")
+        f.write("\n")
+        for group, members in sorted(groups.items()):
+            f.write(f"[{group}]\n")
+            for h in sorted(set(members)):
+                f.write(f"{h}\n")
+            f.write("\n")
+    print(f"==> wrote {INVENTORY}")
+
+
+def pick_ip(inst: dict) -> str:
+    """Pick a usable IP from a `limactl list --json` entry.
+
+    Prefer the address on the lima-shared/lima0 network; fall back to
+    `sshLocalPort` over 127.0.0.1 if no other address is reachable.
+    """
+    for net in inst.get("network", []) or []:
+        addr = net.get("interface") and net.get("address")
+        if addr:
+            return net["address"]
+    # Newer Lima exposes addresses under `addresses`.
+    for addr in inst.get("addresses", []) or []:
+        if not addr.startswith("127."):
+            return addr
+    return "127.0.0.1"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("hosts", nargs="*", help="Subset of hosts to bring up.")
+    args = ap.parse_args()
+
+    check_lima()
+
+    fleet = yaml.safe_load(HOSTS_YML.read_text())["hosts"]
+    if args.hosts:
+        unknown = [h for h in args.hosts if h not in fleet]
+        if unknown:
+            die(f"Unknown host(s): {unknown}. Known: {list(fleet)}")
+        selected = {h: fleet[h] for h in args.hosts}
+    else:
+        selected = fleet
+
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Dedupe by lima instance (so righttoknow staging/prod share one VM).
+    by_instance: dict[str, tuple[str, dict]] = {}
+    for host, spec in selected.items():
+        instance = lima_instance_for(host, spec)
+        by_instance.setdefault(instance, (host, spec))
+
+    def boot(instance_and_pair: tuple[str, tuple[str, dict]]) -> None:
+        instance, (host, spec) = instance_and_pair
+        rendered = STATE_DIR / f"{instance}.yaml"
+        rendered.write_text(render_template(host, spec))
+        ensure_instance(instance, rendered)
+
+    workers = min(4, max(1, len(by_instance)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        list(pool.map(boot, by_instance.items()))
+
+    # Write inventory using the full fleet (so partial-up workflows still
+    # produce inventory entries for the running subset; missing ones are
+    # warned about and skipped).
+    write_inventory(fleet)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lima/hosts.yml
+++ b/lima/hosts.yml
@@ -1,0 +1,91 @@
+# Declarative fleet topology for the Lima-based local development setup.
+# This is the source of truth that lima/bin/lima-up reads to render per-VM
+# Lima YAMLs (from lima/templates/<release>.yaml) and to generate the
+# Ansible inventory at lima/inventory/lima-hosts.
+#
+# Mirrors the `hosts` Ruby hash in Vagrantfile so the two paths stay in
+# step. When adding/removing/renaming a host, update both.
+#
+# Per-host fields:
+#   release       Ubuntu release codename — picks lima/templates/<release>.yaml
+#   groups        Ansible inventory groups this host belongs to
+#                 (the implicit `development` group is added by lima-up)
+#   aliases       Extra hostnames written into /etc/hosts on every dev VM
+#                 (also written to the macOS host /etc/hosts by lima-hosts-sync)
+#   lima_instance Override the lima instance name. Defaults to the key with
+#                 dots replaced by dashes. Use this to share one VM across
+#                 multiple inventory entries (e.g. righttoknow staging+prod).
+#   memory_gib    Per-VM memory override (default: 2). Honoured by lima-up.
+#   cpus          Per-VM CPU override (default: 2).
+
+hosts:
+  # --- Service VMs (mimic AWS RDS / ElastiCache locally) -----------------
+  mysql.test:
+    release: jammy
+    groups: [mysql]
+
+  postgresql.test:
+    release: jammy
+    groups: [postgresql]
+
+  redis.test:
+    release: jammy
+    groups: [redis]
+
+  au.proxy.oaf.test:
+    release: xenial
+    groups: [proxy]
+
+  openvpn.test:
+    release: jammy
+    groups: [openvpn]
+
+  # --- Application VMs ---------------------------------------------------
+  web.metabase.oaf.test:
+    release: jammy
+    groups: [metabase, requires_postgresql]
+
+  oaf.test:
+    release: bionic
+    groups: [oaf]
+
+  openaustralia.test:
+    release: jammy
+    aliases:
+      - www.openaustralia.test
+      - test.openaustralia.test
+      - www.test.openaustralia.test
+      - data.openaustralia.test
+      - software.openaustralia.test
+    groups: [openaustralia, requires_mysql]
+
+  web.planningalerts.test:
+    release: jammy
+    groups: [planningalerts, requires_postgresql]
+
+  # staging and prod RTK share one VM (Vagrantfile uses node: 25 for both)
+  staging.righttoknow.test:
+    release: bionic
+    lima_instance: righttoknow-test
+    aliases:
+      - www.staging.righttoknow.test
+      - test.staging.righttoknow.test
+      - www.test.staging.righttoknow.test
+    groups: [righttoknow, righttoknow_staging, requires_postgresql]
+
+  prod.righttoknow.test:
+    release: bionic
+    lima_instance: righttoknow-test
+    aliases:
+      - www.prod.righttoknow.test
+      - test.prod.righttoknow.test
+      - www.test.prod.righttoknow.test
+    groups: [righttoknow, righttoknow_production, requires_postgresql]
+
+  theyvoteforyou.test:
+    release: focal
+    aliases:
+      - www.theyvoteforyou.test
+      - test.theyvoteforyou.test
+      - www.test.theyvoteforyou.test
+    groups: [theyvoteforyou, requires_mysql]

--- a/lima/templates/README.md
+++ b/lima/templates/README.md
@@ -1,0 +1,23 @@
+# Lima per-release templates
+
+Each `<release>.yaml` is a Lima instance config with placeholders that
+[lima/bin/lima-up](../bin/lima-up) substitutes at render time.
+
+Placeholders (only ever appear at substitution sites, never in comments):
+
+| Placeholder         | Substituted with                              |
+| ------------------- | --------------------------------------------- |
+| `{{HOSTNAME}}`      | Full FQDN, e.g. `mysql.test`                  |
+| `{{LIMA_INSTANCE}}` | Lima instance name, e.g. `mysql-test`         |
+| `{{LIMA_USER}}`     | Default user inside the Lima VM (usually `$USER`) |
+| `{{CPUS}}`          | CPU count (default 2; override via `LIMA_CPUS=`) |
+| `{{MEMORY}}`        | Memory string, e.g. `2GiB` (override via `LIMA_MEMORY=`) |
+| `{{NETWORK_BLOCK}}` | YAML block for `networks:` — `lima: shared` on macOS, `lima: user-v2` on Linux |
+
+Every guest is pinned to `linux/amd64` regardless of host architecture.
+On macOS 13+ Apple Silicon this runs via Rosetta translation through
+Virtualization.framework.
+
+Adding a new Ubuntu release: copy one of the existing templates and
+update the cloud-image URL plus any release-specific package quirks
+(e.g. xenial lacks `python-is-python3` and `sshd_config.d`).

--- a/lima/templates/bionic.yaml
+++ b/lima/templates/bionic.yaml
@@ -1,0 +1,75 @@
+# Ubuntu 18.04 (bionic) Lima template. See jammy.yaml for placeholder docs.
+#
+# bionic is EOL (April 2023). The cloud image is still published at the
+# /releases/ path for archival use; expect older cloud-init (18.x).
+arch: x86_64
+cpus: {{CPUS}}
+memory: "{{MEMORY}}"
+disk: "20GiB"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+
+{{NETWORK_BLOCK}}
+
+mounts: []
+
+containerd:
+  system: false
+  user: false
+
+ssh:
+  loadDotSSHPubKeys: false
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      hostnamectl set-hostname "{{HOSTNAME}}"
+      if ! grep -qE "^127\.0\.1\.1[[:space:]]+{{HOSTNAME}}\b" /etc/hosts; then
+        sed -i '/^127\.0\.1\.1/d' /etc/hosts
+        echo "127.0.1.1 {{HOSTNAME}}" >> /etc/hosts
+      fi
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      install -d -m 700 /root/.ssh
+      cp /home/{{LIMA_USER}}/.ssh/authorized_keys /root/.ssh/authorized_keys
+      chmod 600 /root/.ssh/authorized_keys
+      chown -R root:root /root/.ssh
+      # bionic sshd may not support sshd_config.d; edit main config idempotently.
+      if [ -d /etc/ssh/sshd_config.d ]; then
+        cat > /etc/ssh/sshd_config.d/10-lima-ansible.conf <<EOF
+      PermitRootLogin prohibit-password
+      EOF
+      else
+        sed -i 's/^[# ]*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+        grep -qE '^PermitRootLogin ' /etc/ssh/sshd_config || \
+          echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
+      fi
+      systemctl reload ssh || systemctl reload sshd || true
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      # bionic: python3 is present; python-is-python3 doesn't exist (it's a jammy+
+      # transitional package). Site.yml's bootstrap play handles python2 fallback
+      # for older roles that need it.
+      set -eu
+      command -v python3 >/dev/null && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq python3
+
+probes:
+  - description: "root SSH and python3 ready"
+    script: |
+      #!/bin/bash
+      set -eu
+      test -s /root/.ssh/authorized_keys
+      command -v python3 >/dev/null
+    hint: "Provision scripts didn't complete. Check `limactl shell {{LIMA_INSTANCE}} -- systemctl status cloud-final`."

--- a/lima/templates/focal.yaml
+++ b/lima/templates/focal.yaml
@@ -1,0 +1,63 @@
+# Ubuntu 20.04 (focal) Lima template. See jammy.yaml for placeholder docs.
+arch: x86_64
+cpus: {{CPUS}}
+memory: "{{MEMORY}}"
+disk: "20GiB"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+
+{{NETWORK_BLOCK}}
+
+mounts: []
+
+containerd:
+  system: false
+  user: false
+
+ssh:
+  loadDotSSHPubKeys: false
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      hostnamectl set-hostname "{{HOSTNAME}}"
+      if ! grep -qE "^127\.0\.1\.1[[:space:]]+{{HOSTNAME}}\b" /etc/hosts; then
+        sed -i '/^127\.0\.1\.1/d' /etc/hosts
+        echo "127.0.1.1 {{HOSTNAME}}" >> /etc/hosts
+      fi
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      install -d -m 700 /root/.ssh
+      cp /home/{{LIMA_USER}}/.ssh/authorized_keys /root/.ssh/authorized_keys
+      chmod 600 /root/.ssh/authorized_keys
+      chown -R root:root /root/.ssh
+      mkdir -p /etc/ssh/sshd_config.d
+      cat > /etc/ssh/sshd_config.d/10-lima-ansible.conf <<EOF
+      PermitRootLogin prohibit-password
+      EOF
+      systemctl reload ssh || systemctl reload sshd || true
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      command -v python3 >/dev/null && command -v python >/dev/null && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq python3 python-is-python3
+
+probes:
+  - description: "root SSH and python3 ready"
+    script: |
+      #!/bin/bash
+      set -eu
+      test -s /root/.ssh/authorized_keys
+      command -v python3 >/dev/null
+    hint: "Provision scripts didn't complete. Check `limactl shell {{LIMA_INSTANCE}} -- systemctl status cloud-final`."

--- a/lima/templates/jammy.yaml
+++ b/lima/templates/jammy.yaml
@@ -1,0 +1,77 @@
+# Ubuntu 22.04 (jammy) Lima template. See README.md in this directory
+# for the list of placeholders and how they're substituted.
+#
+# vmType deliberately unset — Lima auto-picks vz on Darwin (Rosetta on
+# Apple Silicon, native on Intel) and qemu on Linux (KVM on amd64 hosts).
+arch: x86_64
+cpus: {{CPUS}}
+memory: "{{MEMORY}}"
+disk: "20GiB"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img"
+    arch: "x86_64"
+
+{{NETWORK_BLOCK}}
+
+# We don't need home shared into the VM; apps live in /srv/www on the guest.
+mounts: []
+
+# No containerd — we're not running k8s/docker in the VM.
+containerd:
+  system: false
+  user: false
+
+# Don't auto-share the user's SSH keys into the guest (we manage SSH access
+# explicitly below).
+ssh:
+  loadDotSSHPubKeys: false
+
+# First-boot setup. Each provision script is idempotent so re-running is safe.
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      hostnamectl set-hostname "{{HOSTNAME}}"
+      if ! grep -qE "^127\.0\.1\.1[[:space:]]+{{HOSTNAME}}\b" /etc/hosts; then
+        sed -i '/^127\.0\.1\.1/d' /etc/hosts
+        echo "127.0.1.1 {{HOSTNAME}}" >> /etc/hosts
+      fi
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      # Ansible (per ansible.cfg) connects as root. Allow the lima user's
+      # SSH key for root, since the cloud image disables root login by default.
+      set -eu
+      install -d -m 700 /root/.ssh
+      # The default lima user is `{{LIMA_USER}}`; its authorized_keys is
+      # populated by Lima at first boot from ~/.lima/_config/user.pub.
+      cp /home/{{LIMA_USER}}/.ssh/authorized_keys /root/.ssh/authorized_keys
+      chmod 600 /root/.ssh/authorized_keys
+      chown -R root:root /root/.ssh
+      mkdir -p /etc/ssh/sshd_config.d
+      cat > /etc/ssh/sshd_config.d/10-lima-ansible.conf <<EOF
+      PermitRootLogin prohibit-password
+      EOF
+      systemctl reload ssh || systemctl reload sshd || true
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      # Ensure python3 is available before Ansible's gather_facts runs.
+      set -eu
+      command -v python3 >/dev/null && command -v python >/dev/null && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq python3 python-is-python3
+
+probes:
+  - description: "root SSH and python3 ready"
+    script: |
+      #!/bin/bash
+      set -eu
+      test -s /root/.ssh/authorized_keys
+      command -v python3 >/dev/null
+    hint: "Provision scripts didn't complete. Check `limactl shell {{LIMA_INSTANCE}} -- systemctl status cloud-final`."

--- a/lima/templates/xenial.yaml
+++ b/lima/templates/xenial.yaml
@@ -1,0 +1,69 @@
+# Ubuntu 16.04 (xenial) Lima template. See jammy.yaml for placeholder docs.
+#
+# xenial is deeply EOL (April 2021). The cloud-current image lives at the
+# /xenial/current/ path; cloud-init is 0.7.x and lacks several modern keys
+# (e.g. no sshd_config.d, no python-is-python3, default user `ubuntu` may
+# differ from Lima's convention).
+arch: x86_64
+cpus: {{CPUS}}
+memory: "{{MEMORY}}"
+disk: "20GiB"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
+    arch: "x86_64"
+
+{{NETWORK_BLOCK}}
+
+mounts: []
+
+containerd:
+  system: false
+  user: false
+
+ssh:
+  loadDotSSHPubKeys: false
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      hostnamectl set-hostname "{{HOSTNAME}}"
+      if ! grep -qE "^127\.0\.1\.1[[:space:]]+{{HOSTNAME}}\b" /etc/hosts; then
+        sed -i '/^127\.0\.1\.1/d' /etc/hosts
+        echo "127.0.1.1 {{HOSTNAME}}" >> /etc/hosts
+      fi
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eu
+      install -d -m 700 /root/.ssh
+      cp /home/{{LIMA_USER}}/.ssh/authorized_keys /root/.ssh/authorized_keys
+      chmod 600 /root/.ssh/authorized_keys
+      chown -R root:root /root/.ssh
+      # No sshd_config.d on xenial.
+      sed -i 's/^[# ]*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+      grep -qE '^PermitRootLogin ' /etc/ssh/sshd_config || \
+        echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
+      systemctl reload ssh || service ssh reload || true
+
+  - mode: system
+    script: |
+      #!/bin/bash
+      # xenial: python (2) is system; python3 may need installing for Ansible 2.10+.
+      set -eu
+      command -v python3 >/dev/null && exit 0
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq python3 python3-minimal
+
+probes:
+  - description: "root SSH and python3 ready"
+    script: |
+      #!/bin/bash
+      set -eu
+      test -s /root/.ssh/authorized_keys
+      command -v python3 >/dev/null
+    hint: "Provision scripts didn't complete. Check `limactl shell {{LIMA_INSTANCE}} -- journalctl -u cloud-final`."

--- a/roles/internal/dev-hosts/tasks/main.yml
+++ b/roles/internal/dev-hosts/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# Write /etc/hosts entries for every peer in the `development` inventory
+# group, so apps can reach `mysql.test`, `postgresql.test`, etc. by name.
+#
+# Applies to both Vagrant and Lima dev VMs. Production uses real DNS and
+# isn't in the `development` group, so this play is a no-op there.
+
+- name: Render dev-hosts /etc/hosts block
+  ansible.builtin.blockinfile:
+    path: /etc/hosts
+    marker: "# {mark} ANSIBLE MANAGED: dev-hosts"
+    block: |
+      {% for host in groups['development'] | sort %}
+      {{ hostvars[host].ansible_host | default(host) }} {{ host }}{% for alias in (hostvars[host].dev_aliases | default([])) %} {{ alias }}{% endfor %}
+
+      {% endfor %}

--- a/site.yml
+++ b/site.yml
@@ -153,6 +153,15 @@
         - rds
       when: "(show_rds_debug | default(false) | bool) and (planningalerts_db_name is defined)"
 
+- hosts: development
+  name: "Write peer /etc/hosts entries on development VMs"
+  tags:
+    - dev-hosts
+    - facts
+  become: true
+  roles:
+    - internal/dev-hosts
+
 - hosts: all
   tags: base-server
   become: true


### PR DESCRIPTION
## Relevant issue(s)
- https://github.com/openaustralia/infrastructure/issues/175

## What does this do?

Adds a [Lima](https://lima-vm.io/)-based local development path alongside the existing Vagrant flow:

- **`lima/hosts.yml`** — declarative fleet topology mirroring `Vagrantfile`'s host hash. Includes a shared VM for righttoknow staging + prod (Vagrantfile's `node: 25` sharing).
- **`lima/templates/{jammy,focal,bionic,xenial}.yaml`** — one per Ubuntu release the production fleet uses, including EOL releases so prod parity is preserved. Each pins `arch: x86_64`, leaves `vmType` unset so Lima auto-picks `vz` on macOS and `qemu` on Linux, and uses idempotent `provision:` blocks for first-boot setup (hostname, root SSH, `python3`).
- **`lima/bin/{lima-up, lima-provision, lima-destroy, lima-status, lima-hosts-sync}`** — small driver scripts. `lima-hosts-sync` is the macOS `/etc/hosts` equivalent of `vagrant-hostsupdater`.
- **`roles/internal/dev-hosts`** — new role that writes `/etc/hosts` on every dev VM from Ansible inventory. Used by both Vagrant and Lima dev VMs, so peer resolution (e.g. `mysql.test` from `web.planningalerts.test`) now works inside the guests without relying on host-side hostsfile plumbing.
- **`docs/local-dev-with-lima.md`** — install steps (`brew install lima socket_vmnet`, sudoers tweak), Linux notes, troubleshooting.
- **Makefile** — new `lima`, `lima-up`, `lima-provision`, `lima-destroy`, `lima-status`, `lima-hosts-sync`, `lima-clean` targets that reuse the existing `.venv` / `ANSIBLE_OPTS` / certificates plumbing. `TAGS=`, `SKIP_TAGS=`, `ANSIBLE_VERBOSE=` work exactly like the `apply-*` / `check-*` targets do today.

Cross-cutting changes (small, intentional, beneficial regardless of VM tool):

- `group_vars/development.yml` — hostnames (`mysql.test`, `postgresql.test`) instead of hard-coded `192.168.56.x` IPs. The Vagrant flow is unaffected: `vagrant-hostsupdater` still writes the host-side `/etc/hosts`, and the new `dev-hosts` role writes the guest-side `/etc/hosts`.
- `site.yml` — one new play applies the `dev-hosts` role to the `development` group only. Production groups are untouched.

The `Vagrantfile` itself is **unchanged**. A follow-up PR can delete it cleanly once everyone has migrated; the `dev-hosts` role and hostname-based `group_vars` would stay either way.

## Why was this needed?

Vagrant + VirtualBox doesn't work on Apple Silicon, so ARM-based contributors had no way to bring up the local fleet. Lima with `vmType: vz` runs amd64 Ubuntu guests on Apple Silicon under Apple's Virtualization.framework with Rosetta translation — fast enough for day-to-day use, and pinning to `linux/amd64` means architecture-specific bugs that only show up on prod amd64 also show up locally.

The same Lima setup runs natively on amd64 Linux and Intel macOS, so contributors who'd rather use one tool everywhere can adopt Lima even without Apple Silicon.

## Implementation/Deploy Steps (Optional)

End-to-end check on Apple Silicon:

```bash
brew install lima socket_vmnet
limactl sudoers | sudo tee /etc/sudoers.d/lima
make lima-requirements
HOSTS=mysql.test,web.planningalerts.test make lima-up
sudo make lima-hosts-sync
HOSTS=mysql.test,web.planningalerts.test make lima-provision
```

Regression check on Vagrant (anywhere with VirtualBox):

```bash
vagrant up mysql.test
vagrant provision mysql.test
```

Must still pass — confirms the `group_vars/development.yml` rename from IPs to hostnames and the new `dev-hosts` role haven't broken the Vagrant flow.

## Notes to reviewer (Optional)

- **Networking on macOS** uses `lima:shared` (socket_vmnet), which gives host↔VM *and* VM↔VM connectivity — the closest analogue to Vagrant's host-only network. The one-time `brew install socket_vmnet` + sudoers tweak is the moral equivalent of `vagrant plugin install vagrant-hostsupdater` that contributors already do today.
- **On Linux**, socket_vmnet doesn't exist; `lima-up` falls back to `user-v2` networking. Linux contributors don't lose anything (Vagrant still works for them), this is just a bonus path for amd64-Linux users who want Lima too.
- **Resource budget**: the full fleet is 14 VMs × 2 GB ≈ 28 GB RAM — too much for most laptops. The docs and `make help` flag this and recommend the `HOSTS=` subset workflow (mysql + one app server ≈ 6 GB).
- **EOL releases** (xenial, bionic): cloud images for these are still published; the templates account for `sshd_config.d` absence on xenial and `python-is-python3` absence on bionic.