### PR TITLE
Add 512MB swap for both planningalerts app servers

### DIFF
--- a/group_vars/planningalerts.yml
+++ b/group_vars/planningalerts.yml
@@ -69,3 +69,20 @@ logs:
 ruby_manager: 'rvm'
 ruby_versions:
     - ruby-3.3.4
+
+# Sized to cover (approximate figures):
+#  1,480 MB Puma workers anon (3 workers x ~500 MB)
+#           -> working set, must stay in RAM for performance
+#    260 MB Sidekiq anon (fresh restart ~250 MB, capped at 500 MB by systemd)
+#           -> working set, must stay in RAM for performance
+#    290 MB Idle processes (snapd, cloudwatch, newrelic, postfix, ssm-agent etc)
+#           -> can swap with negligible impact
+#     30 MB Puma master + skylightd + memcached
+#  --------
+#  2,060 MB Physical RAM (3,836 MB available, ~1,780 MB headroom)
+
+# If we need more than this, we need to upgrade the ec2 instance size!
+swap_file_size_mb: '512'
+# Strongly prefer RAM - only swap genuinely idle processes under pressure
+# Puma and Sidekiq working sets must not be swapped
+swap_swappiness: '10'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/planningalerts/issues/2057

## What does this do?

Adds 512MB of swap so idle processes can be swapped out to make more space

The following PR must be merged first:
* https://github.com/openaustralia/infrastructure/pull/534

## Why was this needed?

NewRelic was complaining about excessive memory usage

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

I have deployed this to production (tag planningalerts_20260531142536-swap), having tested it on openaustralia first