### PR TITLE
fix xapian via ansible, in openaustralia.org.au

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -99,6 +99,30 @@ environments:
 
 certbot_email: contact@oaf.org.au
 
+# Xapian pinning.
+#
+# We pin a single upstream version and use it for two things:
+#   1. apt installs libxapian-dev / libsearch-xapian-perl / xapian-tools
+#      from ppa:xapian/backports at this exact upstream version
+#      (the PPA's Debian-revision suffix varies by distro, hence the "*").
+#   2. the matching xapian-bindings tarball is downloaded from
+#      https://oligarchy.co.uk/xapian/<version>/ and verified against
+#      xapian_bindings_sha256.
+# Keeping these in lockstep avoids ABI mismatches between libxapian and
+# the PHP bindings.
+#
+# To bump to a new version:
+#   1. Check it's available from the PPA for the target distro:
+#        apt-cache madison libxapian-dev
+#   2. Confirm the upstream tarball exists:
+#        https://oligarchy.co.uk/xapian/<version>/xapian-bindings-<version>.tar.xz
+#   3. Compute its sha256:
+#        curl -sSL https://oligarchy.co.uk/xapian/<version>/xapian-bindings-<version>.tar.xz \
+#          | sha256sum
+#   4. Update both values below and commit.
+xapian_version: "1.4.22"
+xapian_bindings_sha256: "6b5454833ac52a3e32c0bb3a7290a5a2b50488d8918f2a45269557e4de9a31e5"
+
 # Disable backups for staging
 backup_profiles: []
 domains_for_certbot:

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -193,6 +193,7 @@
       - libmagickcore-dev
       - libmagickwand-dev
       - libmysqlclient-dev
+      - libsearch-xapian-perl
       - libxml-rss-perl
       - libxml-simple-perl
       - libxml-twig-perl
@@ -200,10 +201,14 @@
       - mysql-client
       - msmtp
 
-# Pin the xapian packages to the upstream version declared in
-# group_vars/openaustralia.yml. The "*" matches the PPA's Debian-revision
-# suffix (e.g. "-1.999jammy+1"), which varies by distro. See that file
-# for instructions on bumping the pin.
+# Pin the xapian library and tools to the upstream version declared in
+# group_vars/openaustralia.yml. We compile xapian-bindings from source
+# against these, so they must match the tarball version.
+#
+# Note: libsearch-xapian-perl is intentionally *not* pinned here. It
+# comes from Ubuntu's main repos (currently 1.2.25.4-1build1 on prod),
+# not from ppa:xapian/backports, and it's independent of the PHP
+# bindings we build from source.
 #
 # Why "=1.4.22*" rather than the full "=1.4.22-1.999jammy+1":
 # the PPA rebuilds the same upstream version with a different Debian
@@ -217,7 +222,6 @@
   apt:
     name:
       - "libxapian-dev={{ xapian_version }}*"
-      - "libsearch-xapian-perl={{ xapian_version }}*"
       - "xapian-tools={{ xapian_version }}*"
     state: present
 

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -252,8 +252,25 @@
 # xapian_version and xapian_bindings_sha256 are declared in
 # group_vars/openaustralia.yml and apply to both the apt install above
 # and the tarball download here.
+
+# Detect whether the PHP xapian extension is already installed at the
+# pinned version. If it is, skip the download/build/install cycle below.
+# Without this, get_url re-checks the upstream tarball every run, and -
+# more importantly - bumping xapian_version wouldn't trigger a reinstall
+# because the "creates" path on the install task is keyed on php_api_version,
+# not on xapian_version.
+- name: Check installed xapian PHP bindings version
+  tags: xapian
+  command: >
+    php -r 'echo extension_loaded("xapian") ? phpversion("xapian") : "";'
+  register: xapian_installed
+  changed_when: false
+  check_mode: false
+  failed_when: false
+
 - name: Download xapian bindings source
   tags: xapian
+  when: xapian_installed.stdout != xapian_version
   get_url:
     url: https://oligarchy.co.uk/xapian/{{ xapian_version }}/xapian-bindings-{{ xapian_version }}.tar.xz
     dest: /home/deploy
@@ -263,6 +280,7 @@
 
 - name: Unpack xapian bindings source
   tags: xapian
+  when: xapian_installed.stdout != xapian_version
   unarchive:
       src: /home/deploy/xapian-bindings-{{ xapian_version }}.tar.xz
       dest: /home/deploy
@@ -273,6 +291,7 @@
 
 - name: Configure xapian bindings
   tags: xapian
+  when: xapian_installed.stdout != xapian_version
   command: ./configure --with-php
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -281,6 +300,7 @@
 
 - name: Compile xapian bindings
   tags: xapian
+  when: xapian_installed.stdout != xapian_version
   command: make
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -289,10 +309,10 @@
 
 - name: Install xapian bindings
   tags: xapian
+  when: xapian_installed.stdout != xapian_version
   command: make install
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
-    creates: "/usr/lib/php/{{ php_api_version }}/xapian.so"
   notify: reload apache
 
 - name: Create xapian mods-available ini

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -193,15 +193,33 @@
       - libmagickcore-dev
       - libmagickwand-dev
       - libmysqlclient-dev
-      - libsearch-xapian-perl
-      - libxapian-dev
       - libxml-rss-perl
       - libxml-simple-perl
       - libxml-twig-perl
       - libxslt1-dev
       - mysql-client
       - msmtp
-      - xapian-tools
+
+# Pin the xapian packages to the upstream version declared in
+# group_vars/openaustralia.yml. The "*" matches the PPA's Debian-revision
+# suffix (e.g. "-1.999jammy+1"), which varies by distro. See that file
+# for instructions on bumping the pin.
+#
+# Why "=1.4.22*" rather than the full "=1.4.22-1.999jammy+1":
+# the PPA rebuilds the same upstream version with a different Debian
+# revision per Ubuntu release (jammy, noble, ...). Pinning the full
+# revision would silently break if this playbook ran against a
+# host on a different distro. The glob pins only the upstream version
+# (the part that needs to match the bindings tarball) and lets apt pick
+# whatever revision the PPA published for the host's distro.
+- name: Install xapian packages at pinned version
+  tags: xapian
+  apt:
+    name:
+      - "libxapian-dev={{ xapian_version }}*"
+      - "libsearch-xapian-perl={{ xapian_version }}*"
+      - "xapian-tools={{ xapian_version }}*"
+    state: present
 
 - name: Install required packages for php
   tags: xapian
@@ -227,18 +245,9 @@
 
 # FIXME: Do we really need libpq-dev ??
 
-- name: Get installed libxapian-dev version
-  tags: xapian
-  command: dpkg-query -W -f='${Version}' libxapian-dev
-  register: libxapian_pkg_version
-  changed_when: false
-
-- name: Set xapian_version from installed libxapian-dev
-  tags: xapian
-  set_fact:
-    xapian_version: "{{ libxapian_pkg_version.stdout | regex_replace('^(\\d+\\.\\d+\\.\\d+).*$', '\\1') }}"
-
-# Matching the version number of libxapian-dev above
+# xapian_version and xapian_bindings_sha256 are declared in
+# group_vars/openaustralia.yml and apply to both the apt install above
+# and the tarball download here.
 - name: Download xapian bindings source
   tags: xapian
   get_url:
@@ -246,7 +255,7 @@
     dest: /home/deploy
     owner: deploy
     group: deploy
-    # FIXME: handle gpg checksum: checksum: sha256:b15ca7984980a1d2aedd3378648ef5f3889cb39a047bac1522a8e5d04f0a8557
+    checksum: "sha256:{{ xapian_bindings_sha256 }}"
 
 - name: Unpack xapian bindings source
   tags: xapian

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -253,24 +253,25 @@
 # group_vars/openaustralia.yml and apply to both the apt install above
 # and the tarball download here.
 
-# Detect whether the PHP xapian extension is already installed at the
-# pinned version. If it is, skip the download/build/install cycle below.
-# Without this, get_url re-checks the upstream tarball every run, and -
-# more importantly - bumping xapian_version wouldn't trigger a reinstall
-# because the "creates" path on the install task is keyed on php_api_version,
-# not on xapian_version.
-- name: Check installed xapian PHP bindings version
+# Idempotency for the build-from-source chain below.
+#
+# We use a version-keyed stamp file rather than checking xapian.so or
+# phpversion("xapian"): the xapian PHP bindings don't report a useful
+# version string, and the .so path isn't version-keyed, so neither tells
+# us whether the *currently pinned* version is what's installed.
+#
+# First run on an existing host: the stamp won't exist, so a rebuild
+# will be triggered. To skip that one-off rebuild, ssh in and:
+#   sudo touch /var/lib/xapian-bindings-installed-{{ xapian_version }}
+- name: Stat xapian bindings install marker
   tags: xapian
-  command: >
-    php -r 'echo extension_loaded("xapian") ? phpversion("xapian") : "";'
-  register: xapian_installed
-  changed_when: false
-  check_mode: false
-  failed_when: false
+  stat:
+    path: "/var/lib/xapian-bindings-installed-{{ xapian_version }}"
+  register: xapian_stamp
 
 - name: Download xapian bindings source
   tags: xapian
-  when: xapian_installed.stdout != xapian_version
+  when: not xapian_stamp.stat.exists
   get_url:
     url: https://oligarchy.co.uk/xapian/{{ xapian_version }}/xapian-bindings-{{ xapian_version }}.tar.xz
     dest: /home/deploy
@@ -280,7 +281,7 @@
 
 - name: Unpack xapian bindings source
   tags: xapian
-  when: xapian_installed.stdout != xapian_version
+  when: not xapian_stamp.stat.exists
   unarchive:
       src: /home/deploy/xapian-bindings-{{ xapian_version }}.tar.xz
       dest: /home/deploy
@@ -289,9 +290,14 @@
       group: deploy
       creates: /home/deploy/xapian-bindings-{{ xapian_version }}/configure
 
+# The configure/compile/install tasks chdir into the unpacked source
+# directory, which doesn't exist during --check (unarchive only simulates).
+# Skip them in check mode rather than failing with "No such file or directory".
 - name: Configure xapian bindings
   tags: xapian
-  when: xapian_installed.stdout != xapian_version
+  when:
+    - not xapian_stamp.stat.exists
+    - not ansible_check_mode
   command: ./configure --with-php
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -300,7 +306,9 @@
 
 - name: Compile xapian bindings
   tags: xapian
-  when: xapian_installed.stdout != xapian_version
+  when:
+    - not xapian_stamp.stat.exists
+    - not ansible_check_mode
   command: make
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
@@ -309,11 +317,23 @@
 
 - name: Install xapian bindings
   tags: xapian
-  when: xapian_installed.stdout != xapian_version
+  when:
+    - not xapian_stamp.stat.exists
+    - not ansible_check_mode
   command: make install
   args:
     chdir: /home/deploy/xapian-bindings-{{ xapian_version }}
   notify: reload apache
+
+- name: Record installed xapian bindings version
+  tags: xapian
+  when:
+    - not xapian_stamp.stat.exists
+    - not ansible_check_mode
+  copy:
+    dest: "/var/lib/xapian-bindings-installed-{{ xapian_version }}"
+    content: ""
+    mode: '0644'
 
 - name: Create xapian mods-available ini
   tags: xapian

--- a/roles/internal/openaustralia/templates/php.ini
+++ b/roles/internal/openaustralia/templates/php.ini
@@ -866,6 +866,9 @@ default_socket_timeout = 60
 ; default extension directory.
 ;
 
+; extension=xapian.so
+; extension=mysqli
+
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
 ;;;;;;;;;;;;;;;;;;;

--- a/roles/internal/righttoknow/files/storage.yml
+++ b/roles/internal/righttoknow/files/storage.yml
@@ -37,7 +37,8 @@ raw_emails_test: &raw_emails_test
   root: <%= Rails.root.join('tmp/storage/raw_emails') %>
 
 raw_emails:
-  <<: *raw_emails_<%= Rails.env %>
+  service: Disk
+  root: "<%= Rails.env.test? ? Rails.root.join('tmp/storage/raw_emails') : Rails.root.join('storage/raw_emails') %>"
 
 ## Attachments ##
 
@@ -56,4 +57,5 @@ attachments_test: &attachments_test
   root: <%= Rails.root.join('tmp/storage/attachments') %>
 
 attachments:
-  <<: *attachments_<%= Rails.env %>
+  service: Disk
+  root: "<%= Rails.env.test? ? Rails.root.join('tmp/storage/attachments') : Rails.root.join('storage/attachments') %>"


### PR DESCRIPTION
## Relevant issue(s)

closes
 * https://github.com/openaustralia/openaustralia/issues/864

needs
 * https://github.com/openaustralia/infrastructure/pull/540

## What does this do?
Adds Xapian PHP bindings installation in the `openaustralia` role:

- Pins `libxapian-dev` and `xapian-tools` (from `ppa:xapian/backports`) to a specific upstream version declared in `group_vars/openaustralia.yml` (`xapian_version`, currently `1.4.22`), instead of taking whatever the PPA happens to ship.
- Verifies the downloaded `xapian-bindings-<version>.tar.xz` against a pinned SHA256 (`xapian_bindings_sha256`), retiring the existing `FIXME: handle gpg checksum` comment.
- Makes the build-from-source chain idempotent via a version-keyed stamp file at `/var/lib/xapian-bindings-installed-<version>`. Re-running the role no longer redownloads, reconfigures or rebuilds when the pinned version is already installed; bumping the pin automatically triggers a rebuild.
- Add `extension=xapian.so` / `extension=mysqli` lines in `templates/php.ini`
- fixes ansible lint failing on a yml file that isn’t actually for ansible
