### PR TITLE
Exclude Right to Know from Ruby Manager Tasks

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -168,10 +168,10 @@
     - role: geerlingguy.swap
       when: swap_file_size_mb is defined or (swap_file_state | default('present')) == 'absent'
 
-- hosts: all
+- hosts: "all:!righttoknow" # Exclude RTK - Workaround for Issue #523
   name: "Remove unused ruby managers"
   become: true
-  tags: 
+  tags:
     - cleanup
     - ruby
   tasks:
@@ -187,20 +187,20 @@
     - name: Remove rvm
       import_role:
         name: internal/remove_rvm
-      tags: 
+      tags:
         - rvm
       when: "ruby_manager != 'rvm'"
     - name: Remove mise
       import_role:
         name: internal/remove_mise
-      tags: 
+      tags:
         - mise
       when: "ruby_manager != 'mise'"
 
-- hosts: all
+- hosts: "all:!righttoknow" # Exclude RTK - Workaround for Issue #523
   name: "Setup ruby managers and install versions"
   become: true
-  tags: 
+  tags:
     - ruby
   tasks:
     # NOTE: rbenv uses the latest bin/ruby-build so there will usually be changes if you are checking


### PR DESCRIPTION
## Relevant issue(s)
#523

## What does this do?
Excludes the Right to Know (RTK) application from the Ruby manager tasks in the Ansible playbook.

## Why was this needed?
Running the `make check-righttoknow STAGE=staging` command was inadvertently removing rbenv, which is a requirement for RTK. This change prevents the removal of rbenv when executing the playbook.

## Implementation/Deploy Steps (Optional)
1. Test by running `make check-righttoknow STAGE=all TAGS=ruby`
2. Ensure that there are no referenes to the "Setup ruby managers and install versions" or "Remove unused ruby managers" tasks. 

## Notes to reviewer (Optional)
This is a temporary workaround to address the issue until a more permanent solution can be implemented.

