### PR TITLE
Update server entry for They Vote For You

### DIFF
--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -75,5 +75,5 @@ prod.righttoknow.org.au
 staging.righttoknow.org.au
 
 [theyvoteforyou]
-theyvoteforyou.org.au
+srv.theyvoteforyou.org.au
 

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -16,7 +16,7 @@
 
 [ec2]
 # NOTE: The planning alerts servers are NOT in ec2!
-theyvoteforyou.org.au
+srv.theyvoteforyou.org.au
 openaustralia.org.au
 staging.righttoknow.org.au
 prod.righttoknow.org.au


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
Updates the server entry for They Vote For You in the EC2 hosts file.

## Why was this needed?
They Vote For You sits behind Cloudflare, so we need to target the server directly.

## Implementation/Deploy Steps (Optional)
You should be able to run `make check-theyvoteforyou` and the server should now connect.

## Notes to reviewer (Optional)
