### PR TITLE
Revert Gitlab domain verification configuration

### DIFF
--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -151,13 +151,13 @@ resource "cloudflare_record" "github_challenge2" {
   value   = "209f2b7179"
 }
 
-# Gitlab Domain Verification
-resource "cloudflare_record" "gitlab_verification" {
-  zone_id = var.oaf_org_au_zone_id
-  name    = "_gitlab-pages-verification-code.oaf.org.au"
-  type    = "TXT"
-  value   = "gitlab-pages-verification-code=fcb94ff091fea3d91d027677d3c35e9e"
-}
+# # Gitlab Domain Verification
+# resource "cloudflare_record" "gitlab_verification" {
+#   zone_id = var.oaf_org_au_zone_id
+#   name    = "_gitlab-pages-verification-code.oaf.org.au"
+#   type    = "TXT"
+#   value   = "gitlab-pages-verification-code=fcb94ff091fea3d91d027677d3c35e9e"
+# }
 
 # Apple for Business Verification
 resource "cloudflare_record" "apple_business_verification" {


### PR DESCRIPTION
## Description
Revert the Gitlab domain verification configuration in the DNS settings.

## Motivation and Context
I shouldn't have applied this to the root domain

## How Has This Been Tested?
Changes were reviewed in the Terraform configuration to ensure the Gitlab verification record is properly commented out.

## Screenshots (if appropriate):
N/A

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

