### PR TITLE
Update DMARC records to use CNAME delegation for Suped monitoring

### DIFF
--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -135,16 +135,13 @@ resource "cloudflare_record" "google_domainkey" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuVyV09pmp6w9YCOWQ9+2p/xe6w7mbZYgg0v4d+51GSoVrQNwp5RERtg76xhl3pbHSLVmtQyfdavLZN/r38/b3NS7E9AsD3dOUIa1iy60YklKVgcWr5eMIviL3E9FXqyQBULoffTWDj69Q/uVsmZmD1VFDICzEctlgKLs9cdtky4kssQQOfJ2KVMfa/GNCorF628jeHiqB6A2UsP/RQ40VVDunDatWO/0mmwHSRJSB61RSro2dYqzo8lzKOBWxnZDxkDO13Dg41VAlOReu4qDRn1MbCj3T79Ur1I6GJj09Em/va/VD4qKJPPt+lW7fKPqVlQ1RqEtSJUGMmiSEKlbYwIDAQAB"
 }
 
-# DMARC record for email authentication and reporting
-# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
-# Suped provides ongoing monitoring and analysis
-# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@morph.io
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.morph.io"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+yuyhziqptlw@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "morph.io.dmarc.dns.suped.com"
 }
 
 # CAA records

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -189,16 +189,13 @@ resource "cloudflare_record" "slack-domain-verification" {
   value   = "slack-domain-verification=JfbPnX8KjSbj2pDWCfKEJud0IjhrhH6WiMqTDRYH"
 }
 
-# DMARC record for email authentication and reporting
-# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
-# Suped provides ongoing monitoring and analysis
-# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@oaf.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "dmarc" {
   zone_id = var.oaf_org_au_zone_id
   name    = "_dmarc.oaf.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ff2eamlrqpn@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "oaf.org.au.dmarc.dns.suped.com"
 }
 
 # SPF include record containing all A records for OAF services
@@ -279,12 +276,11 @@ resource "cloudflare_record" "alt_domainkey_google" {
 # For the time being we're just using DMARC records to get some data on what's
 # happening with email that we're sending (and whether anyone else is impersonating
 # us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@openaustraliafoundation.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "alt_dmarc" {
   zone_id = var.openaustraliafoundation_org_au_zone_id
   name    = "_dmarc.openaustraliafoundation.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+tziobvarown@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  type    = "CNAME"
+  value   = "openaustraliafoundation.org.au.dmarc.dns.suped.com"
 }

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -144,14 +144,13 @@ resource "cloudflare_record" "google_domainkey" {
 # For the time being we're just using DMARC records to get some data on what's
 # happening with email that we're sending (and whether anyone else is impersonating
 # us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@openaustralia.org
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.org.id
   name    = "_dmarc.openaustralia.org"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; pct=100; rua=mailto:re+dkbgzuudi8i@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  type    = "CNAME"
+  value   = "openaustralia.org.dmarc.dns.suped.com"
 }
 
 ## openaustralia.org.au
@@ -297,14 +296,11 @@ resource "cloudflare_record" "alt_domainkey_google" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlL0dk9aaopGcbFKfugmxVqdUKCnpYTrnQj0Sz6RW1a+kFK44snSraBdMe6B14mvfUH1xkIuEiuKKWYIkYq5FHHZYcszVwt66FieU6HTaOvMNwDuXEJgU2zMIvGsUNiDO87CiEMZf0KhqyTrXIldVO/d9A5U7iZRy4poIKOQlm6NNEk6brfUXHct9S/Z4H6dlaowxUdjIp37838/U0AVTDiYYbSDrv2w60e1zTZy1y/9YXEGPlDpue4ijjJz1tjvJtS6cxfKT8elmXEOAo5j45K8NONJ4bEGNmTJxPMQwox0gBFwXwrf7pd4uYUpJW6GH9/vx7AW/jZe0SafCV/f0NQIDAQAB"
 }
 
-# DMARC record for email authentication and reporting
-# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
-# Suped provides ongoing monitoring and analysis
-# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@openaustralia.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "alt_dmarc" {
   zone_id = cloudflare_zone.org_au.id
   name    = "_dmarc.openaustralia.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+no6xy3wrymr@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "openaustralia.org.au.dmarc.dns.suped.com"
 }

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -136,14 +136,11 @@ resource "cloudflare_record" "domainkey_google" {
   value   = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkUq+EPS6XemyHdVi5CCW7+M+X1XMrAg85Y2oYEUYVcB2IU+1HF/fGUdY9w8wvphSC/28wznJOOTl92pj6/DvwRcfpogRrjITYmPZQMOC0SQ4/4nOeL5ug6fNWFg74LZQvQJqWGAQuUhiSiwxUpkUHAv6H5iE/EKDVOdeWjPWjsIkoAC5HdAie0WCcq3gDlfDJZ3L6K7/nGorPd96764EYG/pdsN43/jzcU23vVGJlhw9my1jvkxNnMS1xRkUuk/JcCIRWp4RkgQOkK7JEoNXB2u+bgW+8mLlGX66dag2l67CR+qzOuE1nHcOu5ADLqVh42MOTNMhw75TzugEbtn0QQIDAQAB"
 }
 
-# DMARC record for email authentication and reporting
-# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
-# Suped provides ongoing monitoring and analysis
-# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to contact@oaf.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.planningalerts.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+b1g0fn6boqu@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "planningalerts.org.au.dmarc.dns.suped.com"
 }

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -129,16 +129,15 @@ resource "cloudflare_record" "google_domainkey" {
 }
 
 ## 2024-09-02 - Set DMARC to quarantine emails that don't meet the DMARC requirements.
-# DMARC record for email authentication and reporting
-# Reports are sent to both Suped (for monitoring) and Postmark (legacy weekly reports)
-# Suped provides ongoing monitoring and analysis
-# Postmark generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@righttoknow.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
+# IMPORTANT: this domain runs p=quarantine (not the p=none default) - the
+# quarantine policy must be set in Suped or enforcement silently downgrades.
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.main.id
   name    = "_dmarc.righttoknow.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=quarantine; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+aysyay6u9ct@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "righttoknow.org.au.dmarc.dns.suped.com"
 }
 
 # Staging environment DNS records

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -167,14 +167,13 @@ resource "cloudflare_record" "tvfy_domainkey_google" {
 # For the time being we're just using DMARC records to get some data on what's
 # happening with email that we're sending (and whether anyone else is impersonating
 # us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@theyvoteforyou.org.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "tvfy_dmarc" {
   zone_id = cloudflare_zone.org_au.id
   name    = "_dmarc.theyvoteforyou.org.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ldnqce6nisu@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "theyvoteforyou.org.au.dmarc.dns.suped.com"
 }
 
 ## theyvoteforyou.org
@@ -198,14 +197,13 @@ resource "cloudflare_record" "alt1_www" {
 # For the time being we're just using DMARC records to get some data on what's
 # happening with email that we're sending (and whether anyone else is impersonating
 # us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@theyvoteforyou.org
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "tvfy_alt1_dmarc" {
   zone_id = cloudflare_zone.org.id
   name    = "_dmarc.theyvoteforyou.org"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+qbce7gaoklg@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "theyvoteforyou.org.dmarc.dns.suped.com"
 }
 
 ## theyvoteforyou.com.au
@@ -229,12 +227,11 @@ resource "cloudflare_record" "alt2_www" {
 # For the time being we're just using DMARC records to get some data on what's
 # happening with email that we're sending (and whether anyone else is impersonating
 # us).
-# We're using a free service provided by https://dmarc.postmarkapp.com/
-# This generates a weekly DMARC report which gets sent by email on Monday mornings
-# Report goes to webmaster@theyvoteforyou.com.au
+# DMARC delegated to Suped via CNAME (https://suped.com/).
+# Record content and policy (p=) are managed in the Suped dashboard, not here.
 resource "cloudflare_record" "tvfy_alt2_dmarc" {
   zone_id = cloudflare_zone.com_au.id
   name    = "_dmarc.theyvoteforyou.com.au"
-  type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:dmarc.dpdztvxlz24gajbdj6yz@mail.suped.com,mailto:re+ffljniarmuh@dmarc.postmarkapp.com; pct=100; adkim=r; aspf=r; fo=1; ri=86400"
+  type    = "CNAME"
+  value   = "theyvoteforyou.com.au.dmarc.dns.suped.com"
 }


### PR DESCRIPTION
## Description
Migrate DMARC records across multiple domains to use CNAME delegation for Suped monitoring, enhancing email authentication and reporting.

## Motivation and Context
This change is required to streamline DMARC management by delegating record content and policy to the Suped dashboard, improving monitoring capabilities.

We have been using Suped for some time now, and this is a better way of ensuring that our DMARC settings are better managed.

## How Has This Been Tested?
Testing has NOT been performed, as this change requires deployment via `tf apply` only after the relevant configuration change is made in Suped.

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

