### PR TITLE
Add guarded postal DKIM records for each sending domain

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,6 +8,8 @@ module "postal" {
   source         = "./postal"
   zone_id        = cloudflare_zone.oaf_org_au.id
   authorized_key = data.external.id_rsa.result["id_rsa"]
+  # TODO(postal setup): set from `postal default-dkim-record` on the box
+  # return_path_dkim_record = "k=rsa; p=..."
 }
 
 module "docs-internal" {
@@ -33,6 +35,10 @@ module "planningalerts" {
   availability_zones            = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
   cloudflare_account_id         = var.cloudflare_account_id
   instance_count                = 2
+  # TODO(postal cutover): set from the postal web interface once the
+  # planningalerts.org.au domain is added there
+  # postal_dkim_record_name  = "postal-<tag>._domainkey.planningalerts.org.au"
+  # postal_dkim_record_value = "k=rsa; p=..."
   # blue environment setup
   blue_enabled  = true
   blue_weight   = 1
@@ -51,6 +57,10 @@ module "theyvoteforyou" {
   security_group_service = aws_security_group.theyvoteforyou
   instance_profile       = aws_iam_instance_profile.logging
   cloudflare_account_id  = var.cloudflare_account_id
+  # TODO(postal cutover): set from the postal web interface once the
+  # theyvoteforyou.org.au domain is added there
+  # postal_dkim_record_name  = "postal-<tag>._domainkey.theyvoteforyou.org.au"
+  # postal_dkim_record_value = "k=rsa; p=..."
 }
 
 module "righttoknow" {
@@ -68,6 +78,10 @@ module "righttoknow" {
 module "morph" {
   source                = "./morph"
   cloudflare_account_id = var.cloudflare_account_id
+  # TODO(postal cutover): set from the postal web interface once the
+  # morph.io domain is added there
+  # postal_dkim_record_name  = "postal-<tag>._domainkey.morph.io"
+  # postal_dkim_record_value = "k=rsa; p=..."
 }
 
 module "metabase" {
@@ -90,6 +104,10 @@ module "openaustralia" {
   ubuntu_22_ami            = var.ubuntu_22_ami
   ubuntu_24_ami            = var.ubuntu_24_ami
   cloudflare_account_id    = var.cloudflare_account_id
+  # TODO(postal cutover): set from the postal web interface once the
+  # openaustralia.org domain is added there
+  # postal_dkim_record_name  = "postal-<tag>._domainkey.openaustralia.org"
+  # postal_dkim_record_value = "k=rsa; p=..."
 }
 
 module "oaf" {
@@ -101,6 +119,10 @@ module "oaf" {
   righttoknow_production_ip              = module.righttoknow.production_public_ip
   righttoknow_staging_ip                 = module.righttoknow.staging_public_ip
   cuttlefish_ip                          = module.cuttlefish.ipv4_address
+  # TODO(postal cutover): set from the postal web interface once the
+  # oaf.org.au domain is added there (wordpress mail)
+  # postal_dkim_record_name  = "postal-<tag>._domainkey.oaf.org.au"
+  # postal_dkim_record_value = "k=rsa; p=..."
 }
 
 module "campaign-monitor" {

--- a/terraform/morph/postal.tf
+++ b/terraform/morph/postal.tf
@@ -1,0 +1,22 @@
+# DKIM record for mail sent via postal (docs/postal-migration.md). The
+# selector name (postal-<tag>._domainkey.morph.io) and value are shown in the
+# postal web interface once the domain is added there; set both in this
+# module's call in terraform/main.tf.
+
+variable "postal_dkim_record_name" {
+  description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.morph.io"
+  default     = ""
+}
+
+variable "postal_dkim_record_value" {
+  description = "Value of the postal DKIM TXT record (k=rsa; p=...)"
+  default     = ""
+}
+
+resource "cloudflare_record" "postal_domainkey" {
+  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  zone_id = cloudflare_zone.main.id
+  name    = var.postal_dkim_record_name
+  type    = "TXT"
+  value   = var.postal_dkim_record_value
+}

--- a/terraform/morph/postal.tf
+++ b/terraform/morph/postal.tf
@@ -6,6 +6,14 @@
 variable "postal_dkim_record_name" {
   description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.morph.io"
   default     = ""
+
+  validation {
+    condition = (
+      (var.postal_dkim_record_name == "" && var.postal_dkim_record_value == "") ||
+      (var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "")
+    )
+    error_message = "postal_dkim_record_name and postal_dkim_record_value must either both be set or both be empty."
+  }
 }
 
 variable "postal_dkim_record_value" {
@@ -14,7 +22,7 @@ variable "postal_dkim_record_value" {
 }
 
 resource "cloudflare_record" "postal_domainkey" {
-  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  count   = var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "" ? 1 : 0
   zone_id = cloudflare_zone.main.id
   name    = var.postal_dkim_record_name
   type    = "TXT"

--- a/terraform/oaf/postal.tf
+++ b/terraform/oaf/postal.tf
@@ -1,0 +1,23 @@
+# DKIM record for mail the oaf.org.au wordpress site sends via postal
+# (docs/postal-migration.md), replacing the badly-named civicrm_37 cuttlefish
+# record eventually. The selector name (postal-<tag>._domainkey.oaf.org.au)
+# and value are shown in the postal web interface once the domain is added
+# there; set both in this module's call in terraform/main.tf.
+
+variable "postal_dkim_record_name" {
+  description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.oaf.org.au"
+  default     = ""
+}
+
+variable "postal_dkim_record_value" {
+  description = "Value of the postal DKIM TXT record (k=rsa; p=...)"
+  default     = ""
+}
+
+resource "cloudflare_record" "postal_domainkey" {
+  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  zone_id = var.oaf_org_au_zone_id
+  name    = var.postal_dkim_record_name
+  type    = "TXT"
+  value   = var.postal_dkim_record_value
+}

--- a/terraform/oaf/postal.tf
+++ b/terraform/oaf/postal.tf
@@ -7,6 +7,14 @@
 variable "postal_dkim_record_name" {
   description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.oaf.org.au"
   default     = ""
+
+  validation {
+    condition = (
+      (var.postal_dkim_record_name == "" && var.postal_dkim_record_value == "") ||
+      (var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "")
+    )
+    error_message = "postal_dkim_record_name and postal_dkim_record_value must either both be set or both be empty."
+  }
 }
 
 variable "postal_dkim_record_value" {
@@ -15,7 +23,7 @@ variable "postal_dkim_record_value" {
 }
 
 resource "cloudflare_record" "postal_domainkey" {
-  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  count   = var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "" ? 1 : 0
   zone_id = var.oaf_org_au_zone_id
   name    = var.postal_dkim_record_name
   type    = "TXT"

--- a/terraform/openaustralia/postal.tf
+++ b/terraform/openaustralia/postal.tf
@@ -1,0 +1,24 @@
+# DKIM record for mail sent via postal (docs/postal-migration.md). The app
+# sends from contact@openaustralia.org, so this lives in the .org zone (like
+# the existing cuttlefish DKIM records). The selector name
+# (postal-<tag>._domainkey.openaustralia.org) and value are shown in the
+# postal web interface once the domain is added there; set both in this
+# module's call in terraform/main.tf.
+
+variable "postal_dkim_record_name" {
+  description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.openaustralia.org"
+  default     = ""
+}
+
+variable "postal_dkim_record_value" {
+  description = "Value of the postal DKIM TXT record (k=rsa; p=...)"
+  default     = ""
+}
+
+resource "cloudflare_record" "postal_domainkey" {
+  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  zone_id = cloudflare_zone.org.id
+  name    = var.postal_dkim_record_name
+  type    = "TXT"
+  value   = var.postal_dkim_record_value
+}

--- a/terraform/openaustralia/postal.tf
+++ b/terraform/openaustralia/postal.tf
@@ -8,6 +8,14 @@
 variable "postal_dkim_record_name" {
   description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.openaustralia.org"
   default     = ""
+
+  validation {
+    condition = (
+      (var.postal_dkim_record_name == "" && var.postal_dkim_record_value == "") ||
+      (var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "")
+    )
+    error_message = "postal_dkim_record_name and postal_dkim_record_value must either both be set or both be empty."
+  }
 }
 
 variable "postal_dkim_record_value" {
@@ -16,7 +24,7 @@ variable "postal_dkim_record_value" {
 }
 
 resource "cloudflare_record" "postal_domainkey" {
-  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  count   = var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "" ? 1 : 0
   zone_id = cloudflare_zone.org.id
   name    = var.postal_dkim_record_name
   type    = "TXT"

--- a/terraform/planningalerts/postal.tf
+++ b/terraform/planningalerts/postal.tf
@@ -1,0 +1,22 @@
+# DKIM record for mail sent via postal (docs/postal-migration.md). The
+# selector name (postal-<tag>._domainkey.planningalerts.org.au) and value are
+# shown in the postal web interface once the domain is added there; set both
+# in this module's call in terraform/main.tf.
+
+variable "postal_dkim_record_name" {
+  description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.planningalerts.org.au"
+  default     = ""
+}
+
+variable "postal_dkim_record_value" {
+  description = "Value of the postal DKIM TXT record (k=rsa; p=...)"
+  default     = ""
+}
+
+resource "cloudflare_record" "postal_domainkey" {
+  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  zone_id = cloudflare_zone.main.id
+  name    = var.postal_dkim_record_name
+  type    = "TXT"
+  value   = var.postal_dkim_record_value
+}

--- a/terraform/planningalerts/postal.tf
+++ b/terraform/planningalerts/postal.tf
@@ -6,6 +6,14 @@
 variable "postal_dkim_record_name" {
   description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.planningalerts.org.au"
   default     = ""
+
+  validation {
+    condition = (
+      (var.postal_dkim_record_name == "" && var.postal_dkim_record_value == "") ||
+      (var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "")
+    )
+    error_message = "postal_dkim_record_name and postal_dkim_record_value must either both be set or both be empty."
+  }
 }
 
 variable "postal_dkim_record_value" {
@@ -14,7 +22,7 @@ variable "postal_dkim_record_value" {
 }
 
 resource "cloudflare_record" "postal_domainkey" {
-  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  count   = var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "" ? 1 : 0
   zone_id = cloudflare_zone.main.id
   name    = var.postal_dkim_record_name
   type    = "TXT"

--- a/terraform/theyvoteforyou/postal.tf
+++ b/terraform/theyvoteforyou/postal.tf
@@ -1,0 +1,22 @@
+# DKIM record for mail sent via postal (docs/postal-migration.md). The
+# selector name (postal-<tag>._domainkey.theyvoteforyou.org.au) and value are
+# shown in the postal web interface once the domain is added there; set both
+# in this module's call in terraform/main.tf.
+
+variable "postal_dkim_record_name" {
+  description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.theyvoteforyou.org.au"
+  default     = ""
+}
+
+variable "postal_dkim_record_value" {
+  description = "Value of the postal DKIM TXT record (k=rsa; p=...)"
+  default     = ""
+}
+
+resource "cloudflare_record" "postal_domainkey" {
+  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  zone_id = cloudflare_zone.org_au.id
+  name    = var.postal_dkim_record_name
+  type    = "TXT"
+  value   = var.postal_dkim_record_value
+}

--- a/terraform/theyvoteforyou/postal.tf
+++ b/terraform/theyvoteforyou/postal.tf
@@ -6,6 +6,14 @@
 variable "postal_dkim_record_name" {
   description = "Full record name of the postal DKIM TXT record, e.g. postal-abc123._domainkey.theyvoteforyou.org.au"
   default     = ""
+
+  validation {
+    condition = (
+      (var.postal_dkim_record_name == "" && var.postal_dkim_record_value == "") ||
+      (var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "")
+    )
+    error_message = "postal_dkim_record_name and postal_dkim_record_value must either both be set or both be empty."
+  }
 }
 
 variable "postal_dkim_record_value" {
@@ -14,7 +22,7 @@ variable "postal_dkim_record_value" {
 }
 
 resource "cloudflare_record" "postal_domainkey" {
-  count   = var.postal_dkim_record_name == "" ? 0 : 1
+  count   = var.postal_dkim_record_name != "" && var.postal_dkim_record_value != "" ? 1 : 0
   zone_id = cloudflare_zone.org_au.id
   name    = var.postal_dkim_record_name
   type    = "TXT"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,6 +1,9 @@
 
 terraform {
-  required_version = ">= 0.13"
+  # 1.9 is the first release where a variable validation condition may refer
+  # to another variable, which the paired postal_dkim_record_name /
+  # postal_dkim_record_value checks rely on
+  required_version = ">= 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Description

Stacked on #564 (→ #563 → #610). Adds a `postal.tf` to each service module (planningalerts, theyvoteforyou, morph, openaustralia, oaf) containing the postal DKIM TXT record for that sending domain, guarded behind empty-default `postal_dkim_record_name` / `postal_dkim_record_value` variables — the same pattern as the postal module's `return_path_dkim_record` in #610.

Postal generates a random DKIM selector (`postal-<tag>._domainkey.<domain>`) only when each domain is added in its web interface, so the values cannot be known yet. Commented-out TODO stubs in `terraform/main.tf` (one per module call, plus the return-path one on the postal module) show exactly where to paste them. Until then, applying this is a no-op: the guarded resources have `count = 0`.

Each module also carries a variable `validation` block asserting that the name and value are either both set or both empty. Pasting one without the other is the obvious failure mode here — it would otherwise create a TXT record with an empty value, or silently create nothing — so it fails at plan time with a clear message instead.

## Motivation and Context

Phase 3/4 of the Cuttlefish → Postal migration (`docs/postal-migration.md`, added in #610): every sending domain needs a postal DKIM record before its service cuts over. This PR puts the scaffolding in place so that, as each domain is verified in postal, enabling its DKIM record is a two-line uncomment-and-paste in `terraform/main.tf` rather than new resource authoring. All existing cuttlefish DKIM records are untouched.

## How Has This Been Tested?

- [x] Ran automated tests on my own system
- [ ] Checked affected area manually on my own / staging system
- [ ] Confirmed it passed the GitHub actions tests

`terraform fmt -check` and `terraform validate` are clean on all six changed/added files.

Mergeable and appliable immediately: the `count` guard on every new resource evaluates to 0 while both variables are at their empty defaults, so `make tf-plan` should show no changes from this PR. Engineer: please confirm that during review.

Note that the paired-input `validation` blocks reference a second variable, which Terraform only supports from 1.9 onwards. Our `terraform/versions.tf` currently declares `required_version = ">= 0.13"`, so that constraint should be tightened.

The real test happens per-cutover: paste the name and value from the postal UI, `make tf-plan` shows exactly one new TXT record, and postal's built-in DNS check for the domain goes green after apply.

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Description revised with Claude Code (claude-opus-5); original draft by claude-fable-5.
