### PR TITLE
Cut OpenAustralia mail over from cuttlefish to postal

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -47,6 +47,15 @@ morph_api_key: !vault |
           37623834323437363632616438633663666564313730363362653064363539306634386663396638
           3166633336663738350a313937326333383535316666656335653137366330626337633138323937
           34333461663732616665663737623565383231663263646566393630616336313165
+# TODO(before merge): create an SMTP credential on the openaustralia mail
+# server in the postal web interface (roles/internal/postal/README.md), set
+# postal_username to it and vault the password:
+#   .venv/bin/ansible-vault encrypt_string --encrypt-vault-id default --name postal_password SECRET
+# postal_username:
+# postal_password: !vault |
+
+# The cuttlefish credentials are kept until decommission so this can be
+# rolled back by reverting the msmtprc template (docs/postal-migration.md)
 cuttlefish_username: php_14
 cuttlefish_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256

--- a/roles/internal/openaustralia/templates/msmtprc.j2
+++ b/roles/internal/openaustralia/templates/msmtprc.j2
@@ -29,17 +29,16 @@
 
     account default : catch_email
 {% else %}
-    account cuttlefish
+    account postal
     tls on
-    # For some reason we're not able to correctly verify the certs
-    # TODO: Figure out what's going on and fix this
-    #tls_trust_file /etc/ssl/certs/ca-certificates.crt
-    tls_certcheck off
-    host cuttlefish.oaf.org.au
+    # Postal has a valid Let's Encrypt certificate, so unlike cuttlefish we
+    # can verify it properly
+    tls_trust_file /etc/ssl/certs/ca-certificates.crt
+    host postal.oaf.org.au
     port 2525
     auth on
-    user {{ cuttlefish_username }}
-    password {{ cuttlefish_password }}
+    user {{ postal_username }}
+    password {{ postal_password }}
 
-    account default : cuttlefish
+    account default : postal
 {% endif %}


### PR DESCRIPTION
## Description

Stacked on #565 (→ #564 → #563 → #610). **Draft — this is the actual OpenAustralia cutover** (service 5 in the migration order in `docs/postal-migration.md`) and must not merge until the postal server is live, the `openaustralia.org` domain is verified there, and the earlier services (TVFY, morph, WordPress) have cut over.

Changes:

- `roles/internal/openaustralia/templates/msmtprc.j2`: the relay account becomes `postal` (host `postal.oaf.org.au`, port 2525 unchanged) and TLS certificate verification is turned **on** — postal has a valid Let's Encrypt certificate, resolving the long-standing `tls_certcheck off` TODO we had against cuttlefish. The `catch_all_mail` branch used by staging is untouched.
- `group_vars/openaustralia.yml`: commented `postal_username` / `postal_password` stubs with vaulting instructions; the cuttlefish credentials deliberately stay until decommission.

**Merge gate:** the two variables above must be filled in and vaulted before this merges. `msmtprc.j2` references them unconditionally in the non-`catch_all_mail` branch, so with them commented out *any* `apply-openaustralia` run fails on the msmtp template task, not just a cutover run.

## Motivation and Context

OpenAustralia's Perl/PHP app shells out to `/usr/sbin/sendmail`, which is msmtp relaying to cuttlefish — so its cutover is entirely a config change in this repo. Rollback is reverting this commit and re-running the msmtp tag (cuttlefish keeps running and its credentials remain vaulted here).

## How Has This Been Tested?

- [ ] Ran automated tests on my own system
- [ ] Checked affected area manually on my own / staging system
- [ ] Confirmed it passed the GitHub actions tests

`ansible-playbook --syntax-check` passes.

Engineer, before merge: create the SMTP credential on the `openaustralia` mail server in postal, fill in and vault the two vars (instructions in the group_vars comment), and confirm the `openaustralia.org` domain shows green DNS checks in postal.

Engineer, at cutover: `make check-openaustralia` then `make apply-openaustralia`; on the box send a test (`echo test | sendmail <you>@oaf.org.au`) and confirm spf, dkim and dmarc pass in the received headers and that the message appears in postal's log. Then watch the next daily alertmailer cron run, and the Suped DMARC dashboard for openaustralia.org over the following days.

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Description revised with Claude Code (claude-opus-5); original draft by claude-fable-5.
