### PR TITLE
Change heredocs containing JSON to data statements that are validated and then exported as json

### DIFF
--- a/terraform/backups-orpington.tf
+++ b/terraform/backups-orpington.tf
@@ -9,33 +9,38 @@ resource "aws_iam_user" "oaf-backups-orpington" {
   name = "oaf-backups-orpington"
 }
 
+data "aws_iam_policy_document" "oaf-backups-orpington" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::oaf-backups-orpington",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::oaf-backups-orpington/*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "oaf-backups-orpington" {
   name   = "oaf-backups-orpington"
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": "arn:aws:s3:::oaf-backups-orpington"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": "arn:aws:s3:::oaf-backups-orpington/*"
-        }
-    ]
-}
-EOF
-
+  policy = data.aws_iam_policy_document.oaf-backups-orpington.json
 }
 
 resource "aws_iam_user_policy_attachment" "oaf-backups-orpington" {

--- a/terraform/backups.tf
+++ b/terraform/backups.tf
@@ -2,40 +2,50 @@ resource "aws_iam_user" "oaf-backups" {
   name = "oaf-backups"
 }
 
+data "aws_iam_policy_document" "oaf-backups" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::oaf-backups",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::oaf-backups/*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "oaf-backups" {
   name   = "S3BucketAccessTo_oaf-backups"
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListAllMyBuckets"
-            ],
-            "Resource": "arn:aws:s3:::*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": "arn:aws:s3:::oaf-backups"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": "arn:aws:s3:::oaf-backups/*"
-        }
-    ]
-}
-EOF
-
+  policy = data.aws_iam_policy_document.oaf-backups.json
 }
 
 resource "aws_iam_user_policy_attachment" "oaf-backups" {

--- a/terraform/elasticsearch-snapshots.tf
+++ b/terraform/elasticsearch-snapshots.tf
@@ -6,26 +6,24 @@ resource "aws_iam_user" "oaf-elasticsearch-snapshots" {
   name = "oaf-elasticsearch-snapshots"
 }
 
+data "aws_iam_policy_document" "oaf-elasticsearch-snapshots" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.oaf-elasticsearch-snapshots.id}",
+      "arn:aws:s3:::${aws_s3_bucket.oaf-elasticsearch-snapshots.id}/*",
+    ]
+  }
+}
+
 resource "aws_iam_policy" "oaf-elasticsearch-snapshots" {
   name   = "S3BucketAccessTo_oaf-elasticsearch-snapshots"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:*"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.oaf-elasticsearch-snapshots.id}",
-        "arn:aws:s3:::${aws_s3_bucket.oaf-elasticsearch-snapshots.id}/*"
-      ]
-    }
-  ]
-}
-EOF
-
+  policy = data.aws_iam_policy_document.oaf-elasticsearch-snapshots.json
 }
 
 resource "aws_iam_user_policy_attachment" "oaf-elasticsearch-snapshots" {

--- a/terraform/logging-and-cloudwatch.tf
+++ b/terraform/logging-and-cloudwatch.tf
@@ -1,45 +1,46 @@
+data "aws_iam_policy_document" "logging_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "logging" {
   # TODO: Don't know yet if this is a sensible name or not
   name               = "logging"
   description        = "Allows EC2 instances to send logs"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+  assume_role_policy = data.aws_iam_policy_document.logging_assume_role.json
 }
-EOF
 
+data "aws_iam_policy_document" "logging" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "logging" {
   role   = aws_iam_role.logging.name
   name   = "logging"
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:DescribeLogStreams",
-                "logs:PutLogEvents"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-
+  policy = data.aws_iam_policy_document.logging.json
 }
 
 resource "aws_iam_instance_profile" "logging" {


### PR DESCRIPTION
## Description

Noticed code smell: some here-docs with JSON in them, which doesn't get validated till applied.
Replaced with data statments which validate content as per 
[Data Source: aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)

NOTE: Version is supplied automatically (which is fine since there is only one valid value) and thus doesn't need to be set.

## Motivation and Context
Change is required to improve code quality as per my PD.

Noticed whilst working on:
* https://github.com/openaustralia/infrastructure/issues/558

## How Has This Been Tested?

Testing environment: on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

Ran `make tf-plan` and made sure there where no proposed changes

- [x] Checked github actions passed

## Screenshots (if appropriate):

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project. (Instead it changes the style for the better)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
