### PR TITLE
Make terraform checks recursive and verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ tf-validate: tf-check-fmt .make/terraform
 	terraform -chdir=terraform validate
 	@echo "PASSED tf-validate!"
 tf-check-fmt:
-	terraform -chdir=terraform fmt -check
+	terraform -chdir=terraform fmt -check -recursive -diff
 	@echo "PASSED tf-check-fmt!"
 
 check-target:

--- a/terraform/docs-internal/dns.tf
+++ b/terraform/docs-internal/dns.tf
@@ -23,12 +23,12 @@ resource "cloudflare_record" "acme_challenge" {
   zone_id = var.zone_id
   name    = "_acme-challenge.handbook.oaf.org.au"
   type    = "TXT"
-    value   = "xGOXm9GVbIeebdkTXhFElSIJFKfvQNAu0VPCc3RxM60"
-  }
+  value   = "xGOXm9GVbIeebdkTXhFElSIJFKfvQNAu0VPCc3RxM60"
+}
 
-  resource "cloudflare_record" "custom_hostname" {
-    zone_id = var.zone_id
-    name    = "_cf-custom-hostname.handbook.oaf.org.au"
-    type    = "TXT"
-    value   = "7d3c04c3-2a65-4d09-99dd-ac61add178f8"
-  }
+resource "cloudflare_record" "custom_hostname" {
+  zone_id = var.zone_id
+  name    = "_cf-custom-hostname.handbook.oaf.org.au"
+  type    = "TXT"
+  value   = "7d3c04c3-2a65-4d09-99dd-ac61add178f8"
+}

--- a/terraform/planningalerts/google-api-keys.tf
+++ b/terraform/planningalerts/google-api-keys.tf
@@ -64,7 +64,7 @@ resource "google_apikeys_key" "google_maps_key" {
 resource "google_apikeys_key" "google_maps_server_key" {
   display_name = "PlanningAlerts Server-Side API Key (google_maps_server_key)"
   name         = "e401e298-4aa7-4ee8-a53e-06b6da107b2a"
-  
+
   restrictions {
     server_key_restrictions {
       allowed_ips = concat(module.blue.public_ips, module.green.public_ips)


### PR DESCRIPTION
## Description

Noticed that terraform link didn't recursively check, and when it reports an error, it just listed the filename

## Motivation and Context

Improves code standards, and confirms quality.
Found whilst working on:
* https://github.com/openaustralia/infrastructure/issues/558

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- [x] Checked affected area manually on my own / staging system
Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3
- [x] Ran automated tests on my own system: `make lint` and `make tf-plan` (no changes)
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
