### PR TITLE
Add security changes manually added to AWS so it will be explicit when we remove them [stage 1]

### DIFF
--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -74,9 +74,17 @@ resource "aws_security_group" "webserver" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  # Ignore ingress changes while testing VPN
-  lifecycle {
-    ignore_changes = [ingress]
+  # Open VPN changes
+  ingress {
+    cidr_blocks      = ["10.8.0.0/24"]
+    description      = "SSH from VPN clients only"
+    from_port        = 22
+    # ipv6_cidr_blocks = []
+    # prefix_list_ids  = []
+    protocol         = "tcp"
+    # security_groups  = []
+    self             = false
+    to_port          = 22
   }
 }
 
@@ -184,8 +192,16 @@ resource "aws_security_group" "planningalerts" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  # Ignore ingress changes while testing VPN
-  lifecycle {
-    ignore_changes = [ingress]
+  # Open VPN changes
+  ingress {
+    cidr_blocks      = ["10.8.0.0/24"]
+    description      = "SSH from VPN clients only"
+    from_port        = 22
+    # ipv6_cidr_blocks = []
+    # prefix_list_ids  = []
+    protocol         = "tcp"
+    # security_groups  = []
+    self             = false
+    to_port          = 22
   }
 }

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -76,15 +76,15 @@ resource "aws_security_group" "webserver" {
 
   # Open VPN changes
   ingress {
-    cidr_blocks      = ["10.8.0.0/24"]
-    description      = "SSH from VPN clients only"
-    from_port        = 22
+    cidr_blocks = ["10.8.0.0/24"]
+    description = "SSH from VPN clients only"
+    from_port   = 22
     # ipv6_cidr_blocks = []
     # prefix_list_ids  = []
-    protocol         = "tcp"
+    protocol = "tcp"
     # security_groups  = []
-    self             = false
-    to_port          = 22
+    self    = false
+    to_port = 22
   }
 }
 
@@ -194,14 +194,14 @@ resource "aws_security_group" "planningalerts" {
 
   # Open VPN changes
   ingress {
-    cidr_blocks      = ["10.8.0.0/24"]
-    description      = "SSH from VPN clients only"
-    from_port        = 22
+    cidr_blocks = ["10.8.0.0/24"]
+    description = "SSH from VPN clients only"
+    from_port   = 22
     # ipv6_cidr_blocks = []
     # prefix_list_ids  = []
-    protocol         = "tcp"
+    protocol = "tcp"
     # security_groups  = []
-    self             = false
-    to_port          = 22
+    self    = false
+    to_port = 22
   }
 }


### PR DESCRIPTION
## Description

Config for Security rules was ignoring differences in ingress rules.
This PR fixes that and aligns the configuration with the current AWS state.

## Motivation and Context

I need to be able to remove ingress rules, and the ignore_changes was stopping that.
related to  [Move to SSM](https://github.com/openaustralia/infrastructure/issues/558):
* https://github.com/openaustralia/infrastructure/issues/558

## How Has This Been Tested?
- [x] Checked affected area manually on my own / staging system
  - using `make tf-plan` after removing and ignore_changes and then added missing config so `tf-plan` stopped planning changes.
  - Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3
- [x] Ran automated tests on my own system
  - `make lint`
  - `make tf-plan`
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

