### PR TITLE
Add a comment to explain that inline policies don't need a reference to be used [stage 1]

### DIFF
--- a/terraform/logging-and-cloudwatch.tf
+++ b/terraform/logging-and-cloudwatch.tf
@@ -37,6 +37,7 @@ data "aws_iam_policy_document" "logging" {
   }
 }
 
+# Attach inline policy to role to grant logs:* permissions directly (no other reference needed)
 resource "aws_iam_role_policy" "logging" {
   role   = aws_iam_role.logging.name
   name   = "logging"

--- a/terraform/vpn-iam.tf
+++ b/terraform/vpn-iam.tf
@@ -22,6 +22,7 @@ resource "aws_iam_role" "openvpn" {
   }
 }
 
+# Attach inline policy to role to grant permissions directly (no other reference needed)
 resource "aws_iam_role_policy" "openvpn_auth" {
   name = "openvpn-authentication"
   role = aws_iam_role.openvpn.id


### PR DESCRIPTION
## Description

Add a comment to explain that inline policies don't need a reference to be used

Discovered when checking that terraform had good coverage whilst working on:
* https://github.com/openaustralia/infrastructure/issues/558

## Motivation and Context
This change was required to document what blocks don't need to be referenced to be active and useful.

## How Has This Been Tested?
- [x] Checked affected area manually on my own / staging system using `make tf-plan` (no changes proposed aside from deployer key as expected)
Developed and tested on Ubuntu 24.04.4 LTS `x86_64` with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [x] Ran automated tests on my own system (`make lint`)
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (inline comment)
- [x] I have updated the documentation accordingly.
