### PR TITLE
WIP: Add SSM instance policy to righttoknow staging and production servers to validate changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,13 @@ If it makes sense we might move cuttlefish and morph.io to AWS as well.
     - `~/.ssh/id_{ed25519,rsa}.pub`
 - Note the ansible `internal/deploy-user` role replaces the authorized list from the keys registered for `github_users`
   when run by anyone so mismatches will cause connection problems!
+- See the following section for cli tools prerequisites.
 
 #### <a name='CLItoolsforcredentials'></a>CLI tools for credentials
 
-Operator credentials (AWS, Google) aren't stored in this repo or 1Password — each tool reads from your own CLI configuration. The Cloudflare and Linode provider tokens are the exception: they're shared service tokens kept in the **DevOps** 1Password vault and rendered by `make tf-secrets`. Install and configure the ones you need:
+Operator credentials (AWS, Google) aren't stored in this repo or 1Password — each tool reads from your own CLI
+configuration. The Cloudflare and Linode provider tokens are the exception: they're shared service tokens kept in the *
+*DevOps** 1Password vault and rendered by `make tf-secrets`. Install and configure the ones you need:
 
 - **1Password CLI (`op`)** — required to read the shared Ansible Vault passphrases and the RDS admin password.
     - Install: `brew install --cask 1password-cli` on macOS, or
@@ -261,6 +264,9 @@ Operator credentials (AWS, Google) aren't stored in this repo or 1Password — e
       - Note: enable App > Developer > Settings > "Integrate with 1Password CLI", otherwise you need to run `eval $(op signin --account oaforgau)` instead.
     - Ask an existing admin to add you to the **DevOps** vault.
 - **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state.
+  Install using the official
+  [Installing or updating to the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+  instructions.
     - We recommend you sign in with [`aws login`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html)
       which uses a browser-based authentication flow (supporting MFA) to provide temporary credentials.
     - Terraform doesn't understand its `login_session` credentials directly yet, so bridge them by editing

--- a/terraform/cloudwatch-logging-and-ssm-instance-profile.tf
+++ b/terraform/cloudwatch-logging-and-ssm-instance-profile.tf
@@ -1,0 +1,64 @@
+# Role + instance profile granting EC2 instances CloudWatch Logs write access
+# and SSM Session Manager access. Same permissions as aws_iam_role.logging in
+# logging-and-cloudwatch.tf, plus AmazonSSMManagedInstanceCore.
+#
+# If this role's contents need to change in future, create a new role with a
+# new name reflecting the new contents rather than editing this one in place —
+# don't let the name silently go stale for whatever's already using it.
+
+data "aws_iam_policy_document" "cloudwatch_logging_and_ssm_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_logging_and_ssm" {
+  name               = "cloudwatch-logging-and-ssm"
+  description        = "Allows EC2 instances to send logs to CloudWatch and be managed via SSM Session Manager"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_logging_and_ssm_assume_role.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_logging" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# Attach inline policy directly to role to grant logs:* permissions (no other reference needed)
+resource "aws_iam_role_policy" "cloudwatch_logging" {
+  role   = aws_iam_role.cloudwatch_logging_and_ssm.name
+  name   = "cloudwatch-logging"
+  policy = data.aws_iam_policy_document.cloudwatch_logging.json
+}
+
+# Also attach AWS maintained policy
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.cloudwatch_logging_and_ssm.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Attach this to
+resource "aws_iam_instance_profile" "cloudwatch_logging_and_ssm" {
+  name = "cloudwatch-logging-and-ssm"
+  role = aws_iam_role.cloudwatch_logging_and_ssm.name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,7 +51,7 @@ module "righttoknow" {
   security_group_webserver      = aws_security_group.webserver
   security_group_service        = aws_security_group.righttoknow
   security_group_incoming_email = aws_security_group.incoming_email
-  instance_profile              = aws_iam_instance_profile.logging
+  instance_profile              = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   cloudflare_account_id         = var.cloudflare_account_id
   # This has been upgraded in place to Ubuntu 18.04
   ami           = var.ubuntu_16_ami

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -25,7 +25,10 @@ resource "aws_instance" "production" {
   ]
 
   availability_zone    = aws_ebs_volume.production_data.availability_zone
-  iam_instance_profile = var.instance_profile.name
+  # FIXME: pinned to the old profile while we test cloudwatch_logging_and_ssm on
+  # staging. Revert to the following (commented out) line once tested.
+  #  iam_instance_profile = var.instance_profile.name
+  iam_instance_profile = "logging"
 
   # Disable termination to protect production
   disable_api_termination = true

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "production" {
     var.security_group_incoming_email.id,
   ]
 
-  availability_zone    = aws_ebs_volume.production_data.availability_zone
+  availability_zone = aws_ebs_volume.production_data.availability_zone
   # FIXME: pinned to the old profile while we test cloudwatch_logging_and_ssm on
   # staging. Revert to the following (commented out) line once tested.
   #  iam_instance_profile = var.instance_profile.name

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -24,11 +24,7 @@ resource "aws_instance" "production" {
     var.security_group_incoming_email.id,
   ]
 
-  availability_zone = aws_ebs_volume.production_data.availability_zone
-  # FIXME: pinned to the old profile while we test cloudwatch_logging_and_ssm on
-  # staging. Revert to the following (commented out) line once tested.
-  #  iam_instance_profile = var.instance_profile.name
-  iam_instance_profile = "logging"
+  iam_instance_profile = var.instance_profile.name
 
   # Disable termination to protect production
   disable_api_termination = true

--- a/terraform/righttoknow/production.tf
+++ b/terraform/righttoknow/production.tf
@@ -24,6 +24,7 @@ resource "aws_instance" "production" {
     var.security_group_incoming_email.id,
   ]
 
+  availability_zone    = aws_ebs_volume.production_data.availability_zone
   iam_instance_profile = var.instance_profile.name
 
   # Disable termination to protect production


### PR DESCRIPTION
## Description

Add SSM instance policy to righttoknow staging and production server  (updated from just staging after initial testing)

This is based on the following which must be approved and merged first!
* https://github.com/openaustralia/infrastructure/pull/575
* https://github.com/openaustralia/infrastructure/pull/577
* https://github.com/openaustralia/infrastructure/pull/578
* https://github.com/openaustralia/infrastructure/pull/579

## Motivation and Context

This is a step in the process of validating the change to SSM as part of implementing:
* https://github.com/openaustralia/infrastructure/issues/558

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
  - ran `make tf-plan` and reviewed output
  - applied changes with `make tf-apply-target MODULE=righttoknow` and checked:
    - can still SSH
    - can SSM from AWS console to both servers

Note - systems require a reboot to pick up new policy.

Tested in production: select instance > Connect > SSM Session Manager
```
$ sudo -i -u deploy
deploy@ip-172-31-38-219:~$ alias
alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
alias be='bundle exec'
alias cdp='cd /srv/www/production/current; export RAILS_ENV=production; env | egrep RAILS_ENV'
alias egrep='egrep --color=auto'
alias fgrep='fgrep --color=auto'
alias grep='grep --color=auto'
alias l='ls -CF'
alias la='ls -A'
alias ll='ls -alF'
alias ls='ls --color=auto'
alias r='bundle exec rails'
alias rk='bundle exec rake'
deploy@ip-172-31-38-219:~$ cdp
RAILS_ENV=production
deploy@ip-172-31-38-219:/srv/www/production/current$ r c
Loading production environment (Rails 8.0.1)
alaveteli(prod)> User.count
=> 10111
alaveteli(prod)>

deploy@ip-172-31-38-219:/srv/www/production/current$
```

Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [ ] Ran automated tests on my own system `make lint`
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) (No, functionality was added but not removed)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
