### PR TITLE
Bugfix/562 stop add comment prompt on apply [stage 1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,9 @@ tf-plan-target: check-target tf-secrets tf-env-check .make/terraform
 	terraform -chdir=terraform plan -target=module.$(TARGET)
 
 tf-apply-target: check-target tf-secrets tf-env-check .make/terraform
+	bin/tag-provisioning --wip terraform "$(TARGET)" "" ""
 	terraform -chdir=terraform apply -target=module.$(TARGET)
+	bin/tag-provisioning terraform "$(TARGET)" "" ""
 
 stage_required:
 ifndef STAGE

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
       - [Deploying OpenAustralia to your local development server](#deploying-openaustralia-to-your-local-development-server)
       - [Deploying OpenAustralia to production](#deploying-openaustralia-to-production)
   - [Backups](#backups)
+  - [Git Tags](#gittags)
   - [Mail Catching](#mail-catching)
     - [`log_not_sendmail`](#log_not_sendmail)
 
@@ -77,7 +78,7 @@ we ended up (from memory) rebuilding the server once again by hand as a giant
 monolithic server.
 
 In the years since then, things have become a little more complicated. We had
-a second small VM running on Octopus which runs oaf.org.au, CiviCRM and
+a second small VM running on Octopus which runs oaf.org.au, CiviCRM, and
 elasticsearch. All of these had to run on a separate VM because they required
 a more recent version of the operating system.
 
@@ -89,7 +90,7 @@ undermining the email reputation of kedumba. So, we hosted it elsewhere.
 
 Fast forward to early 2018. After many years of support Andrew Snow decided
 to close Octopus computing. We had a couple of months to find a new hosting
-provider, migrate all our services and shut down everything on Octopus.
+provider, migrate all our services, and shut down everything on Octopus.
 
 So, we picked up the work that we started in 2015 with, at a high level,
 a very similar approach.
@@ -101,7 +102,7 @@ a very similar approach.
 - Make it easy for different servers / services to be maintained by different
   people.
 - Centralise the databases - a central database is easier to backup, easier
-  to scale and easier to manage.
+  to scale, and easier to manage.
 - Use AWS but don't lock ourselves in. Make the architecture transferrable to
   any hosting provider.
 - Spend a bit more money on hosting if it means less maintenance.
@@ -111,7 +112,7 @@ a very similar approach.
 To get a completely working server and service up and running requires a number
 of different tools. We use different tools for different things.
 
-- Terraform: To spin up servers, manage DNS and IP addresses and setting up any
+- Terraform: To spin up servers, manage DNS and IP addresses, and setting up any
   related AWS infrastructure
 - Ansible: To configure individual servers - install packages, create directory
   structures, install SSL certificates, configure cron jobs, create databases,
@@ -246,7 +247,7 @@ Run `make requirements` to install the requirements for python and ansible.
 **Capistrano (in project repos)**
 
 - In order to run Capistrano, you'll need a version of Ruby installed;
-  - Consider installing [mise](https://mise.jdx.dev/) so that you're able to install and swap between multiple versions of Ruby, python and php.
+  - Consider installing [mise](https://mise.jdx.dev/) so that you're able to install and swap between multiple versions of Ruby, python, and php.
 - For deploying code onto dev/test/prod machines, you'll need to install [capistrano](http://capistranorb.com/) using `bundle install`
 
 **Terraform**
@@ -593,6 +594,25 @@ Data directories of servers are backed up to S3 using Duply.
 Using the `data_directory` profile as an example, to run a backup manually you'd log in as root and run `duply data_directory backup`.
 
 To restore the latest backup to `/mnt/restore` you'd run `duply data_directory restore /mnt/restore`.
+
+## <a name='gittags'></a>Git Tags
+
+The make `apply-*` and `tf-apply*` targets create a git tag before and after the command to actually change the
+infrastructure is called so it is clear what has and hasn't been fully actioned. A `wip-*` tag that sticks around
+indicates a failed provisioning command.
+
+The `bin/tag-provisioning` command is called to tag the latest commit. Specifically it:
+
+1. creates a git tag with `wip-` prefix to indicate that changes to infrastructure had been started and pushes it to GitHub;
+2. runs the requested command;
+3. creates the git tag without the `wip-` prefix and pushes it to GitHub;
+4. removes the wip git tag locally and on GitHub, so it is clear the command succeeded.
+
+Terraform tags (from `make tf-apply`) will start with `[wip-]terraform` and then have the timestamp, eg
+`terraform_20260717125154`.
+
+Ansible tags (from `make apply-*`) will start with the service being targetted, and then have the timestamp, followed
+by the `STAGE`, `TAGS`, and `SKIP_TAGS` values, if set.
 
 ## <a name='MailCatching'></a>Mail Catching
 

--- a/bin/tag-provisioning
+++ b/bin/tag-provisioning
@@ -40,6 +40,19 @@ build_tag() {
   echo "$tag"
 }
 
+build_description() {
+  local desc=""
+  if [ "$1" = "true" ]; then
+    desc="Provisioning ${TARGET}"
+  else
+    desc="Provisioned ${TARGET}"
+  fi
+  [ -n "$STAGE" ] && [ "$STAGE" != "all" ] && desc="${desc} $(sanitize "$STAGE")"
+  [ -n "$TAGS" ] && desc="${desc} for $(sanitize "$TAGS")"
+  [ -n "$SKIP_TAGS" ] && desc="${desc} not for $(sanitize "$SKIP_TAGS")"
+  echo "$desc"
+}
+
 if $WIP; then
   TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
   if [ -f "$WIP_FILE" ]; then
@@ -59,9 +72,10 @@ WIP_TAG="wip-$TAG"
 if $WIP; then
   TAG="$WIP_TAG"
 fi
+DESC=$(build_description "$WIP")
 
-echo "Tagging: $TAG"
-git tag "$TAG"
+echo "Tagging: $TAG - $DESC"
+git tag -m "$DESC" "$TAG"
 if $HAS_REMOTE; then
   git push origin "$TAG"
 fi


### PR DESCRIPTION
## Description

1. Adds a comment when tagging so the user is not prompted to provide a comment.
2. Tags targetted terraform command to be consistent with other calls to terraform and ansible
3. Makes commas in README lists consistent (Oxford style)

## Motivation and Context
Saves developers time and provides consistent comments.

Fixes:
* https://github.com/openaustralia/infrastructure/issues/562

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Tested via:
```
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ bin/tag-provisioning --wip righttoknow staging "" ""
Tagging: wip-righttoknow_20260717123713_staging - Provisioning righttoknow staging
Enumerating objects: 12, done.
Counting objects: 100% (12/12), done.
Delta compression using up to 12 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 1.11 KiB | 1.11 MiB/s, done.
Total 8 (delta 5), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (5/5), completed with 4 local objects.
To github.com:openaustralia/infrastructure.git
 * [new tag]           wip-righttoknow_20260717123713_staging -> wip-righttoknow_20260717123713_staging
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ git log
commit 41e8121a2b3569b31cbe26f362bf10a799f08075 (HEAD -> bugfix/562-stop-add-comment-prompt-on-apply, tag: wip-righttoknow_20260717123713_staging)
Author: Ian Heggie (OAF) <ian@oaf.org.au>
Date:   Fri Jul 17 22:36:37 2026 +1000

    Provide a description for tag in bin/tag-provisioning so user is not prompted for it

...

ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ bin/tag-provisioning righttoknow staging "" ""
Tagging: righttoknow_20260717123713_staging - Provisioned righttoknow staging
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 194 bytes | 194.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/infrastructure.git
 * [new tag]           righttoknow_20260717123713_staging -> righttoknow_20260717123713_staging
Removing: wip-righttoknow_20260717123713_staging
Deleted tag 'wip-righttoknow_20260717123713_staging' (was 49ac7533)

Checked commit log to confirm relationship and that the tag had author tagged
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ gitk --all &

ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ bin/tag-provisioning righttoknow staging "dns,ruby" "rbenv"
Error: Missing tmp/wip-tag-timestamp with timestamp! Call with --wip before the actual provisioning command so attempts are tagged!
[2]+  Done                    gitk --all
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$->(1) bin/tag-provisioning --wip righttoknow staging "dns,ruby" "rbenv"
Tagging: wip-righttoknow_20260717123927_staging-dns-ruby-not-rbenv - Provisioning righttoknow staging for dns-ruby not for rbenv
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 228 bytes | 228.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/infrastructure.git
 * [new tag]           wip-righttoknow_20260717123927_staging-dns-ruby-not-rbenv -> wip-righttoknow_20260717123927_staging-dns-ruby-not-rbenv
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ bin/tag-provisioning righttoknow staging "dns,ruby" "rbenv"
Tagging: righttoknow_20260717123927_staging-dns-ruby-not-rbenv - Provisioned righttoknow staging for dns-ruby not for rbenv
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 225 bytes | 225.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/infrastructure.git
 * [new tag]           righttoknow_20260717123927_staging-dns-ruby-not-rbenv -> righttoknow_20260717123927_staging-dns-ruby-not-rbenv
Removing: wip-righttoknow_20260717123927_staging-dns-ruby-not-rbenv
Deleted tag 'wip-righttoknow_20260717123927_staging-dns-ruby-not-rbenv' (was 6505b35a)
```

Cleaned up afterwards:
```
git tag -d righttoknow_20260717123927_staging-dns-ruby-not-rbenv
git tag -d righttoknow_20260717123713_staging
git push origin --delete righttoknow_20260717123927_staging-dns-ruby-not-rbenv
git push origin --delete righttoknow_20260717123713_staging
```

ALSO tested by planning and then applying change:

```
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ make tf-plan
terraform -chdir=terraform init
Initializing the backend...
...
Terraform will perform the following actions:

  # aws_key_pair.deployer must be replaced
...(details of change)...

Plan: 1 to add, 0 to change, 1 to destroy.

ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ make tf-apply
bin/tag-provisioning --wip terraform "" "" ""
Tagging: wip-terraform_20260717125154 - Provisioning terraform
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 189 bytes | 189.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/infrastructure.git
 * [new tag]           wip-terraform_20260717125154 -> wip-terraform_20260717125154
terraform -chdir=terraform apply
...
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_key_pair.deployer must be replaced
-/+ resource "aws_key_pair" "deployer" {
      ~ arn             = "arn:aws:ec2:ap-southeast-2:924104513718:key-pair/deployer_key" -> (known after apply)
      ~ fingerprint     = "91:5a:ae:25:3b:f0:33:21:26:c8:ad:21:1c:b3:e7:41" -> (known after apply)
      ~ id              = "deployer_key" -> (known after apply)
      + key_name_prefix = (known after apply)
      ~ key_pair_id     = "key-04e75d0685319f2ff" -> (known after apply)
      ~ key_type        = "rsa" -> (known after apply)
      ~ public_key      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDMRQzXCnjHRLZS98M1DWY5BS3wg3m9IdHs043ItRQeBWKSsGNdTyV3O+LHs2CI8nLY3TVNVtAm+Q7cR4gqQGZB8av8azqP1D5D0TgI3zlAr+zyZZN/0w2ALaJB1gRaU+++asaOPxvs89Lk+kJHIRxcn+2OxEIEJ6zrRMpW68JUjp0/lXk6W6dJLeKkpVIgXY6AZ4R93E2ylK5BQJTOEm7p33t6wJUckrGwp5h+fhkET3Kp2f8BMZTH8TXU7ilTeovbspeDzkr9I4I+57n6DVuUNNLnIASg7SsGL4wVW3C0Lsr/zmABbqrTun2fxT/04i/iYkaMlmm4V0fzSSEMQzfx" -> "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBQLU40rC9Ywf0RWernB3KFUc4FceE5yPuh9tIl3cjhM ian@oaf.org.au" # forces replacement
      - tags            = {} -> null
      ~ tags_all        = {} -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_key_pair.deployer: Destroying... [id=deployer_key]
aws_key_pair.deployer: Destruction complete after 0s
aws_key_pair.deployer: Creating...
aws_key_pair.deployer: Creation complete after 0s [id=deployer_key]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

Outputs:

planningalerts_activestorage_s3_access_key_id = "AKIA5OKHL3C3OEAQPIOE"
planningalerts_activestorage_s3_secret_access_key = <sensitive>
planningalerts_sitemaps_access_key_id = "AKIA5OKHL3C3CGUSBVVS"
planningalerts_sitemaps_secret_access_key = <sensitive>
vpn_server_ip = "52.64.33.12"
vpn_server_private_ip = "172.31.38.143"
vpn_users_group_name = "vpn-users"
bin/tag-provisioning terraform "" "" ""
Tagging: terraform_20260717125154 - Provisioned terraform
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 185 bytes | 185.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:openaustralia/infrastructure.git
 * [new tag]           terraform_20260717125154 -> terraform_20260717125154
Removing: wip-terraform_20260717125154
Deleted tag 'wip-terraform_20260717125154' (was 3c2e7a7e)
ianh@ben:.../infrastructure (bugfix/562-stop-add-c)$ 
```
After this, the commit had been tagged:
```
commit a32ff7c2db9e20288c5dc2d9452183ba5f89f633 (HEAD -> bugfix/562-stop-add-comment-prompt-on-apply, tag: terraform_20260717125154, origin/bugfix/562-stop-add-comment-prompt-on-apply)
Author: Ian Heggie (OAF) <ian@oaf.org.au>
Date:   Fri Jul 17 22:36:37 2026 +1000

    Provide a description for tag in bin/tag-provisioning so user is not prompted for it

...    
```

Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [x] Ran automated tests on my own system (`make lint`)
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality) (tagging targeted terraform)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.