### PR TITLE
Clarify op signin requirements [stage 1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Operator credentials (AWS, Google) aren't stored in this repo or 1Password — e
 - **1Password CLI (`op`)** — required to read the shared Ansible Vault passphrases and the RDS admin password.
   - Install: `brew install --cask 1password-cli` on macOS, or the [official package](https://developer.1password.com/docs/cli/get-started) on Linux.
   - The CLI normally inherits a session from the 1Password desktop app. If you're running headless, sign in once with `op signin --account oaforgau`.
+    - Note: enable App > Developer > Settings > "Integrate with 1Password CLI", otherwise you need to run `eval $(op signin --account oaforgau)` instead.
   - Ask an existing admin to add you to the **DevOps** vault.
 - **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state. Configure with whichever AWS auth method we're currently using (`aws configure sso`, `aws configure`, etc.).
 - **Google Cloud SDK (`gcloud`)** — required for Terraform's Google provider. After install, run `gcloud auth application-default login`.


### PR DESCRIPTION
## Description

Documented what you need to do so the advice to use `op signin --account oaforgau` works, as well as what to do if you don't want to or can't run the desktop app (eg headless server)

## Motivation and Context

Required for login to 1passsword advice to work.
Found whilst working on:
* https://github.com/openaustralia/infrastructure/issues/558

## How Has This Been Tested?

Tested using `make tf-plan` and `make lint` (worked as expected)
 
- [x] Checked affected area manually on my own / staging system
Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
