### PR TITLE
Get aws login working and documented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "Available targets"
 	@echo "  help                                Output this help text"
 	@echo "  all                                 Run full site.yml playbook against all hosts"
-	@echo "  requirements                        Install requirements: venv, roles, collections, terraform.pem"
+	@echo "  requirements                        Install requirements: venv, roles, collections, terraform.pem and check required commands"
 	@echo "  op-check                            Fail if not signed into the OAF 1Password account"
 	@echo "  aws-check                           Fail if aws-cli or the Session Manager plugin aren't installed and recent enough"
 	@echo "  terraform.pem                       Materialise terraform.pem from 1Password"
@@ -96,7 +96,7 @@ help:
 setup:
 	sudo apt install parallel jq direnv
 
-requirements: op-check terraform.pem .make/roles venv
+requirements: op-check terraform.pem .make/roles venv aws-check
 
 # Fail if the operator can't read the OAF 1Password account. 1Password
 # is the sole source for the Ansible Vault passphrases, the RDS admin

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ aws-check:
 	else \
 	  echo "ERROR: session-manager-plugin not found." >&2; \
 	  echo "  Install: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" >&2; \
+	  echo "For MacOS users, install using brew: brew install session-manager-plugin" >&2; \
 	  exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all ansible-lint apply-metabase apply-oaf requirements apply-openaustralia \
         apply-planningalerts apply-righttoknow  apply-theyvoteforyou \
+        aws-check \
         check-host check-metabase check-oaf check-openaustralia check-planningalerts check-righttoknow \
         check-theyvoteforyou check-target \
         scan-oaf scan-openaustralia scan-planningalerts \
@@ -35,6 +36,7 @@ help:
 	@echo "  all                                 Run full site.yml playbook against all hosts"
 	@echo "  requirements                        Install requirements: venv, roles, collections, terraform.pem"
 	@echo "  op-check                            Fail if not signed into the OAF 1Password account"
+	@echo "  aws-check                           Fail if aws-cli or the Session Manager plugin aren't installed"
 	@echo "  terraform.pem                       Materialise terraform.pem from 1Password"
 	@echo "  tf-secrets                          Render terraform/secrets.auto.tfvars from 1Password via op inject"
 	@echo "  tf-env-check                        Warn (non-fatal) if AWS or gcloud credentials aren't reachable"
@@ -109,6 +111,29 @@ op-check:
 	else \
 	  echo "ERROR: OAF 1Password not reachable (account=$$(cat bin/.op-account))." >&2; \
 	  echo "  Install the 1Password CLI and sign in: op signin --account $$(cat bin/.op-account)" >&2; \
+	  exit 1; \
+	fi
+
+# Fail if aws-cli or the Session Manager plugin aren't on PATH. The plugin is
+# needed for `aws ssm start-session` and the SSH-over-SSM ProxyCommand
+# Capistrano will use once a host is SSM-managed:
+#   ssh -o ProxyCommand="aws ssm start-session --target %h \
+#     --document-name AWS-StartSSHSession --parameters 'portNumber=%p'" ...
+# Checked in this order (aws first, plugin second) since the plugin is useless
+# without the CLI, and reporting the more fundamental problem first is clearer.
+aws-check:
+	@if command -v aws >/dev/null 2>&1; then \
+	  echo "OK: aws CLI found ($$(aws --version 2>&1))"; \
+	else \
+	  echo "ERROR: aws CLI not found." >&2; \
+	  echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2; \
+	  exit 1; \
+	fi
+	@if command -v session-manager-plugin >/dev/null 2>&1; then \
+	  echo "OK: session-manager-plugin found ($$(session-manager-plugin --version 2>&1))"; \
+	else \
+	  echo "ERROR: session-manager-plugin not found." >&2; \
+	  echo "  Install: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" >&2; \
 	  exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "  all                                 Run full site.yml playbook against all hosts"
 	@echo "  requirements                        Install requirements: venv, roles, collections, terraform.pem"
 	@echo "  op-check                            Fail if not signed into the OAF 1Password account"
-	@echo "  aws-check                           Fail if aws-cli or the Session Manager plugin aren't installed"
+	@echo "  aws-check                           Fail if aws-cli or the Session Manager plugin aren't installed and recent enough"
 	@echo "  terraform.pem                       Materialise terraform.pem from 1Password"
 	@echo "  tf-secrets                          Render terraform/secrets.auto.tfvars from 1Password via op inject"
 	@echo "  tf-env-check                        Warn (non-fatal) if AWS or gcloud credentials aren't reachable"
@@ -123,7 +123,12 @@ op-check:
 # without the CLI, and reporting the more fundamental problem first is clearer.
 aws-check:
 	@if command -v aws >/dev/null 2>&1; then \
-	  echo "OK: aws CLI found ($$(aws --version 2>&1))"; \
+      if aws --version 2>&1 | grep -qE 'aws-cli/2\.(3[2-9]|[4-9][0-9]|[1-9][0-9][0-9])'; then \
+	    echo "OK: recent aws CLI found ($$(aws --version 2>&1))"; \
+	  else \
+        echo "ERROR: Require aws CLI version 2.32.0 or higher to support 'aws login' (currently $$(aws --version 2>&1))" >&2; \
+        exit 1; \
+	  fi \
 	else \
 	  echo "ERROR: aws CLI not found." >&2; \
 	  echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2; \

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Operator credentials (AWS, Google) aren't stored in this repo or 1Password — e
   - The CLI normally inherits a session from the 1Password desktop app. If you're running headless, sign in once with `op signin --account oaforgau`.
     - Note: enable App > Developer > Settings > "Integrate with 1Password CLI", otherwise you need to run `eval $(op signin --account oaforgau)` instead.
   - Ask an existing admin to add you to the **DevOps** vault.
-- **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state. Configure with whichever AWS auth method we're currently using (`aws configure sso`, `aws configure`, etc.).
+- **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state. Configure with whichever AWS auth method we're currently using (`aws sso login`, `aws login`, etc.).
 - **Google Cloud SDK (`gcloud`)** — required for Terraform's Google provider. After install, run `gcloud auth application-default login`.
 - **Cloudflare and Linode API tokens** — no per-operator setup. These are shared service tokens stored in the **DevOps** 1Password vault (item _Terraform DB Passwords_); `make tf-secrets` renders them into `terraform/secrets.auto.tfvars` and the providers read them from there. You no longer need to export `CLOUDFLARE_API_TOKEN` or `LINODE_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If it makes sense we might move cuttlefish and morph.io to AWS as well.
 - In order to run Capistrano, you'll need a version of Ruby installed; even better, install [rbenv](https://rbenv.org/) so that you're able to manage multiple versions of Ruby.
 - For deploying code onto dev/test/prod machines, you'll need [capistrano](http://capistranorb.com/)
 - For a few things, including major PlanningAlerts deployments, you'll need [Terraform](https://developer.hashicorp.com/terraform/install). Terraform reads its AWS and Google credentials from your own CLI tooling — see [CLI tools for credentials](#cli-tools-for-credentials) below. The shared secrets — the RDS admin password and the Cloudflare and Linode API tokens — are rendered into `terraform/secrets.auto.tfvars` from 1Password by `make tf-secrets`.
+- For AWS's SSM Session Manager access (replacing SSH), you'll need the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html). Run `make aws-check` to confirm it and the AWS CLI are both installed.
 - `jq` must be installed for `terraform/prepkey.sh`
 - The key found by the `terraform/prepkey.sh` script should be
   - registered as an ssh key in your GitHub account,

--- a/README.md
+++ b/README.md
@@ -266,20 +266,24 @@ Operator credentials (AWS, Google) aren't stored in this repo or 1Password — e
     - Terraform doesn't understand its `login_session` credentials directly yet, so bridge them by editing
       `~/.aws/config`:
       ```ini
-      [profile signin]
+      [profile oaf]
       login_session = arn:aws:iam::924104513718:user/<your-user>
       region = ap-southeast-2
 
-      [default]
-      # Bridges `aws login` to tools that don't understand `login_session` yet (e.g. Terraform).
-      # Following the linked docs as written names this profile `process` instead of `default` —
-      # do that and you'll need AWS_PROFILE=process set whenever provisioning from this repo or
-      # deploying from the app repos.
-      credential_process = aws configure export-credentials --profile signin --format process
+      [profile oaf-legacy]
+      # Bridges `aws login` to tools that don't understand `login_session` yet (e.g. Terraform, Ansible).
+      credential_process = aws configure export-credentials --profile oaf --format process
       region = ap-southeast-2
       ```
-      Then `aws login --profile signin` to authenticate — `terraform`, `ansible`, and `cap` all pick it up via `default`
-      automatically.
+      Then `aws login --profile oaf` to authenticate. `terraform` (via each provider's `profile = "oaf-legacy"`) and
+      the `aws_ec2` Ansible inventory (via `aws_profile: oaf-legacy` in `inventory/aws_ec2.yml`) pick this up
+      explicitly. `cap` has no AWS touchpoint yet, and there's nowhere else with a per-tool profile setting, so for
+      that — and any ad hoc `aws`/`cap` commands — set `export AWS_PROFILE=oaf-legacy` in your `.envrc`. If you'd
+      rather everything default to `oaf-legacy` without setting `AWS_PROFILE`, you can instead duplicate the
+      `[profile oaf-legacy]` block above as `[default]` in `~/.aws/config`.
+    - The `oaf` profile's `login_session` ARN has the OAF account ID (`924104513718`) baked in, so if you ever sign
+      in to a different AWS account, `aws login --profile oaf` will notice the mismatch and ask you to confirm before
+      overwriting it — a safety net against authenticating against the wrong account.
   - We no longer recommend:
     - `aws sso login` as it has a more complicated setup,
     - `aws configure`, or AWS vars in dotenv's `.envrc` file as these long-lived credentials do not use MFA and are

--- a/README.md
+++ b/README.md
@@ -215,27 +215,37 @@ If it makes sense we might move cuttlefish and morph.io to AWS as well.
 
 ### <a name='Prerequisites'></a>Prerequisites
 
-- For starting local VMs for testing you will need [Vagrant](https://www.vagrantup.com/) and a supported provider - our instructions assume [VirtualBox](https://developer.hashicorp.com/vagrant/docs/providers/virtualbox).
+- For starting local VMs for testing you will need [Vagrant](https://www.vagrantup.com/) and a supported provider - our
+  instructions assume [VirtualBox](https://developer.hashicorp.com/vagrant/docs/providers/virtualbox).
 - In order to run Ansible, you'll need Python < 3.12 installed
-  - 3.12 dropped some deprecated language features which cause [Ansible 2.9 and 2.10 to no longer work](https://github.com/ansible/ansible/issues/81946).
-  - Secrets: Ansible passphrases are read from the OAF 1Password account. See [Add the Ansible Vault password](#add-the-ansible-vault-password) below.
-- In order to run Capistrano, you'll need a version of Ruby installed; even better, install [rbenv](https://rbenv.org/) so that you're able to manage multiple versions of Ruby.
+    - 3.12 dropped some deprecated language features which
+      cause [Ansible 2.9 and 2.10 to no longer work](https://github.com/ansible/ansible/issues/81946).
+    - Secrets: Ansible passphrases are read from the OAF 1Password account.
+      See [Add the Ansible Vault password](#add-the-ansible-vault-password) below.
+- In order to run Capistrano, you'll need a version of Ruby installed; even better, install [rbenv](https://rbenv.org/)
+  so that you're able to manage multiple versions of Ruby.
 - For deploying code onto dev/test/prod machines, you'll need [capistrano](http://capistranorb.com/)
-- For a few things, including major PlanningAlerts deployments, you'll need [Terraform](https://developer.hashicorp.com/terraform/install). Terraform reads its AWS and Google credentials from your own CLI tooling — see [CLI tools for credentials](#cli-tools-for-credentials) below. The shared secrets — the RDS admin password and the Cloudflare and Linode API tokens — are rendered into `terraform/secrets.auto.tfvars` from 1Password by `make tf-secrets`.
-- For AWS's SSM Session Manager access (replacing SSH), you'll need the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html). Run `make aws-check` to confirm it and the AWS CLI are both installed.
+- For a few things, including major PlanningAlerts deployments, you'll
+  need [Terraform](https://developer.hashicorp.com/terraform/install). Terraform reads its AWS and Google credentials
+  from your own CLI tooling — see [CLI tools for credentials](#cli-tools-for-credentials) below. The shared secrets —
+  the RDS admin password and the Cloudflare and Linode API tokens — are rendered into `terraform/secrets.auto.tfvars`
+  from 1Password by `make tf-secrets`.
+- For AWS's SSM Session Manager access (replacing SSH), you'll need
+  the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html).
+  Run `make aws-check` to confirm it and the AWS CLI are both installed.
 - `jq` must be installed for `terraform/prepkey.sh`
 - The key found by the `terraform/prepkey.sh` script should be
-  - registered as an ssh key in your GitHub account,
-  - used by ssh for the hostnames in `inventory/ec2-hosts`
-    - add entries to your `~/.ssh/config` if not using the default `~/.ssh/id_{ed25519,rsa}.pub` files
+    - registered as an ssh key in your GitHub account,
+    - used by ssh for the hostnames in `inventory/ec2-hosts`
+        - add entries to your `~/.ssh/config` if not using the default `~/.ssh/id_{ed25519,rsa}.pub` files
 - The `terraform/prepkey.sh` looks for public keys from
-  - First GitHub key if `$GITHUB_USER` is set
-  - `${SSH_PUBLIC_KEY_FILE:-}` if set
-  - `~/.ssh/id_{ed25519,rsa}*oaf*.pub`
-  - `~/.ssh/id_{ed25519,rsa}*OAF*.pub`
-  - `~/.ssh/id_{ed25519,rsa}*open*au*.pub`
-  - `~/.ssh/id_{ed25519,rsa}*OPEN*AU*.pub`
-  - `~/.ssh/id_{ed25519,rsa}.pub`
+    - First GitHub key if `$GITHUB_USER` is set
+    - `${SSH_PUBLIC_KEY_FILE:-}` if set
+    - `~/.ssh/id_{ed25519,rsa}*oaf*.pub`
+    - `~/.ssh/id_{ed25519,rsa}*OAF*.pub`
+    - `~/.ssh/id_{ed25519,rsa}*open*au*.pub`
+    - `~/.ssh/id_{ed25519,rsa}*OPEN*AU*.pub`
+    - `~/.ssh/id_{ed25519,rsa}.pub`
 - Note the ansible `internal/deploy-user` role replaces the authorized list from the keys registered for `github_users`
   when run by anyone so mismatches will cause connection problems!
 
@@ -244,13 +254,41 @@ If it makes sense we might move cuttlefish and morph.io to AWS as well.
 Operator credentials (AWS, Google) aren't stored in this repo or 1Password — each tool reads from your own CLI configuration. The Cloudflare and Linode provider tokens are the exception: they're shared service tokens kept in the **DevOps** 1Password vault and rendered by `make tf-secrets`. Install and configure the ones you need:
 
 - **1Password CLI (`op`)** — required to read the shared Ansible Vault passphrases and the RDS admin password.
-  - Install: `brew install --cask 1password-cli` on macOS, or the [official package](https://developer.1password.com/docs/cli/get-started) on Linux.
-  - The CLI normally inherits a session from the 1Password desktop app. If you're running headless, sign in once with `op signin --account oaforgau`.
-    - Note: enable App > Developer > Settings > "Integrate with 1Password CLI", otherwise you need to run `eval $(op signin --account oaforgau)` instead.
-  - Ask an existing admin to add you to the **DevOps** vault.
-- **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state. Configure with whichever AWS auth method we're currently using (`aws sso login`, `aws login`, etc.).
-- **Google Cloud SDK (`gcloud`)** — required for Terraform's Google provider. After install, run `gcloud auth application-default login`.
-- **Cloudflare and Linode API tokens** — no per-operator setup. These are shared service tokens stored in the **DevOps** 1Password vault (item _Terraform DB Passwords_); `make tf-secrets` renders them into `terraform/secrets.auto.tfvars` and the providers read them from there. You no longer need to export `CLOUDFLARE_API_TOKEN` or `LINODE_TOKEN`.
+    - Install: `brew install --cask 1password-cli` on macOS, or
+      the [official package](https://developer.1password.com/docs/cli/get-started) on Linux.
+    - The CLI normally inherits a session from the 1Password desktop app. If you're running headless, sign in once with
+      `op signin --account oaforgau`.
+      - Note: enable App > Developer > Settings > "Integrate with 1Password CLI", otherwise you need to run `eval $(op signin --account oaforgau)` instead.
+    - Ask an existing admin to add you to the **DevOps** vault.
+- **AWS CLI (`aws`)** — required for Terraform's AWS provider and for reading S3-backed Terraform state.
+    - We recommend you sign in with [`aws login`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html)
+      which uses a browser-based authentication flow (supporting MFA) to provide temporary credentials.
+    - Terraform doesn't understand its `login_session` credentials directly yet, so bridge them by editing
+      `~/.aws/config`:
+      ```ini
+      [profile signin]
+      login_session = arn:aws:iam::924104513718:user/<your-user>
+      region = ap-southeast-2
+
+      [default]
+      # Bridges `aws login` to tools that don't understand `login_session` yet (e.g. Terraform).
+      # Following the linked docs as written names this profile `process` instead of `default` —
+      # do that and you'll need AWS_PROFILE=process set whenever provisioning from this repo or
+      # deploying from the app repos.
+      credential_process = aws configure export-credentials --profile signin --format process
+      region = ap-southeast-2
+      ```
+      Then `aws login --profile signin` to authenticate — `terraform`, `ansible`, and `cap` all pick it up via `default`
+      automatically.
+  - We no longer recommend:
+    - `aws sso login` as it has a more complicated setup,
+    - `aws configure`, or AWS vars in dotenv's `.envrc` file as these long-lived credentials do not use MFA and are
+      stored on the local file system in plain text.
+- **Google Cloud SDK (`gcloud`)** — required for Terraform's Google provider. After installation, run
+  `gcloud auth application-default login`.
+- **Cloudflare and Linode API tokens** — no per-operator setup. These are shared service tokens stored in the **DevOps**
+  1Password vault (item _Terraform DB Passwords_); `make tf-secrets` renders them into `terraform/secrets.auto.tfvars`
+  and the providers read them from there. You no longer need to export `CLOUDFLARE_API_TOKEN` or `LINODE_TOKEN`.
 
 Run `make tf-env-check` to verify each of these is reachable from your shell before running Terraform.
 

--- a/inventory/aws_ec2.yml
+++ b/inventory/aws_ec2.yml
@@ -1,4 +1,5 @@
 plugin: aws_ec2
+aws_profile: oaf-legacy
 regions:
   - ap-southeast-2
 keyed_groups:

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,21 +1,24 @@
 # Provider credentials:
-#   AWS         — `~/.aws/credentials`, AWS_PROFILE, AWS SSO, instance profile, or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars
+#   AWS         — the `oaf-legacy` profile (see README "CLI tools for credentials")
 #   Google      — `gcloud auth application-default login`
 #   Cloudflare  — var.cloudflare_api_token, rendered into secrets.auto.tfvars from 1Password by `make tf-secrets`
 #   Linode      — var.linode_api_token, rendered into secrets.auto.tfvars from 1Password by `make tf-secrets`
 
 provider "aws" {
-  region = var.ec2_region
+  profile = "oaf-legacy"
+  region  = var.ec2_region
 }
 
 provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
+  alias   = "us-east-1"
+  profile = "oaf-legacy"
+  region  = "us-east-1"
 }
 
 provider "aws" {
-  alias  = "ap-southeast-1"
-  region = "ap-southeast-1"
+  alias   = "ap-southeast-1"
+  profile = "oaf-legacy"
+  region  = "ap-southeast-1"
 }
 
 provider "cloudflare" {


### PR DESCRIPTION
## Description

Use `aws login` which opens a browser session to authenticate with aws console login credentials including MFA where configured.
This replaces `aws configure` and/or env variables with long lived access keys. Instead temporary credentials (typically 12 hours) are generated.
Using `aws sso login` is also deprecated because it is more complicated to setup per user.

Related changes:
1. Checks that aws is recent enough to support aws login command
2. Checks that the `session-manager-plugin` is installed so SSM sessions are available where SSM is configured on the server, eg:
```
aws ssm start-session --target i-04885b2749bc99213
```
3. Split the AWS profile in two: `oaf` (the `aws login`/`login_session` profile) and `oaf-legacy` (a `credential_process` bridge for tools that don't understand `login_session` yet). Terraform's `aws` provider blocks and the (not-yet-used) `aws_ec2` Ansible inventory plugin now explicitly reference `oaf-legacy` rather than relying on `default`.
4. Documented how to setup `~/.aws/config` so terraform can recognise the new credentials process

## Motivation and Context

* To enable the use of MFA for authentication
* To reduce the number of different credentials and IAM users needed
* Making sure the required tools are installed to support:
  * https://github.com/openaustralia/infrastructure/issues/558
   
* IAM Users no longer need to have long lived access keys. It is suggested they be disabled first to confirm nothing breaks and later removed.

## How Has This Been Tested?

Checked it detected my old aws version (`make aws-check` prints a messages and exits with status 1)

- [x] Checked affected area manually on my own / staging system
Developed and tested on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0, make 4.3

- [x] Ran automated tests on my own system 
  - `make lint`,
  - `make aws-check`
  -  `make requirements`
  -  `make`
  - `make check-righttoknow STAGE=staging` # for ansible
  - `make tf-plan` for terraform
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

