### PR TITLE
Document and enforce the .j2 template convention

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [Makefile]
 indent_style = tab
 
-[*.json,*.yml,*.json.j2,*.yml.j2]
+[*.{json,yml,json.j2,yml.j2}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [Makefile]
 indent_style = tab
 
-[*.json,*.yml]
+[*.json,*.yml,*.json.j2,*.yml.j2]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,13 @@ jobs:
       - run: make venv
       - run: make yaml-lint
 
+  template-check:
+    name: "Template extension check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make template-check
+
   tf-lint:
     name: "Terraform check format"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
         clean clobber help letsencrypt lint op-check retry roles \
         show-facts show-inventory show-rds-facts show-vars stage_required tf-apply tf-apply-target \
         tf-env-check tf-init tf-plan tf-plan-target tf-secrets \
-        update-github-ssh-keys vagrant venv yaml-lint
+        update-github-ssh-keys vagrant venv yaml-lint template-check
 
 _STAGE := $(if $(filter-out all,$(STAGE)),_$(STAGE),)
 
@@ -325,8 +325,17 @@ yaml-lint: venv
 	.venv/bin/yamllint roles/internal/ roles/*.yml site.yml
 	@echo "PASSED yamllint!"
 
+template-check:
+	@bad=$$(find roles/internal -path '*/templates/*' -type f ! -name '*.j2'); \
+	if [ -n "$$bad" ]; then \
+		echo "ERROR: Jinja2 templates must use the .j2 extension. Rename these, or move static files to the role's files/ dir and use copy:"; \
+		echo "$$bad"; \
+		exit 1; \
+	fi
+	@echo "PASSED template-check!"
+
 ansible-lint: venv roles
 	ANSIBLE_ROLES_PATH=roles:roles/internal:roles/external .venv/bin/ansible-lint roles/internal/ roles/*.yml site.yml
 	@echo "PASSED ansible-lint!"
 
-lint: yaml-lint ansible-lint tf-check-fmt tf-validate
+lint: yaml-lint template-check ansible-lint tf-check-fmt tf-validate

--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ un-rendered template.
 - If a file has no Jinja2 (`{{ ... }}` / `{% ... %}`) it is not a template. Put it in
   the role's `files/` directory and use `copy:` instead.
 
-`make template-check` enforces this - it fails if any file under a role's
-`templates/` directory does not end in `.j2`, and it runs in CI.
+`make template-check` enforces this - it fails if any file under an internal
+role's `templates/` directory does not end in `.j2`, and it runs in CI.
+Third-party roles under `roles/external/` are not checked, as we don't control
+their layout.
 
 ## <a name='Updates'></a>Updates
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ A little note on terminology:
 - "provisioning" - we use this to mean configuring the server with Ansible.
 - "deployment" - we use to mean installing or updating the web application with Capistrano.
 
+## <a name='Templates'></a>Templates
+
+Every file rendered through Ansible's `template:` module **must** use a `.j2`
+extension (for example `general.yml.j2`, `nginx.conf.j2`, `sidekiq.service.j2`).
+This keeps Jinja2 templates visually distinct from finished config files and keeps
+them out of the YAML/JSON linters, which would otherwise try to parse the
+un-rendered template.
+
+- Give the template file its content extension followed by `.j2`
+  (`database.yml` becomes `database.yml.j2`). The `src:` in the task must match; the
+  `dest:` keeps the real filename with no `.j2`. When `dest:` is a directory, name the
+  file explicitly (`dest: /srv/www/production/shared/general.yml`) - Ansible does not
+  strip `.j2` for you.
+- If a file has no Jinja2 (`{{ ... }}` / `{% ... %}`) it is not a template. Put it in
+  the role's `files/` directory and use `copy:` instead.
+
+`make template-check` enforces this - it fails if any file under a role's
+`templates/` directory does not end in `.j2`, and it runs in CI.
+
 ## <a name='Updates'></a>Updates
 
 ### <a name=''></a>2025-05-27

--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -65,8 +65,8 @@ Several services have IP-based deny rules in their nginx configurations:
 
 | Service | Deny Rules | Location |
 |---------|-----------|----------|
-| theyvoteforyou | 563 | `roles/internal/theyvoteforyou/templates/production` |
-| righttoknow | 29 | `roles/internal/righttoknow/templates/nginx/stage` |
+| theyvoteforyou | 563 | `roles/internal/theyvoteforyou/templates/production.j2` |
+| righttoknow | 29 | `roles/internal/righttoknow/templates/nginx/stage.j2` |
 
 These block:
 - Known bot/scraper networks (SEMrush, aggressive crawlers)


### PR DESCRIPTION
## Description

Document and enforce the `.j2` convention:

- README gains a **Templates** section: every file rendered through `template:` must end in `.j2`; files with no Jinja go in the role's `files/` dir via `copy:`.
- New `make template-check` target (wired into `make lint` and added as a CI job) fails if any file under a role's `templates/` dir lacks a `.j2` extension.
- Update the cloudflare proxy migration doc's template path references and extend `.editorconfig` to the new `.yml.j2`/`.json.j2` files.

## Motivation and Context

Ian noted in #581 that giving templates a `.j2` extension resolves several issues. This is the final layer of the conversion — it documents the rule and makes CI enforce it so new templates can't drift back.

Resolves #582.

> Part of the #582 gh-stack (stack #591). Each PR converts one role; the final PR (#590) adds the README convention and the CI `make template-check`. Review/merge bottom-up.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`make yaml-lint`, `make ansible-lint` and `make template-check` all pass locally. A no-op behavioural check (`make check-<svc> --diff` against the hosts) has **not** been run here as it needs the vault password and host access — please confirm the rendered destinations are unchanged before undrafting.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

Also adds a CI check (`make template-check`).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

_Assisted-by: Claude/claude-opus-4-8. AI-assisted