### PR TITLE
Run linters on all pull requests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,6 @@
 name: ansible-lint
 on:
   pull_request:
-    branches:
-      - main
 jobs:
   ansible-lint:
     name: Ansible Lint # Naming the build is important to use it as a status check


### PR DESCRIPTION
## Description

Removes the `branches: [main]` filter from the `pull_request` trigger in the lint workflow so the Ansible Lint, Yamllint, and Terraform format-check jobs run on **every** pull request, regardless of the base branch.

## Motivation and Context

The `pull_request` `branches` filter matches on the PR's *base* (target) branch. Now that we use [stacked PRs](https://gh.io/stacks), intermediate PRs target another feature branch rather than `main`, so the linters were being skipped on them (see #584, #585, #586).

Resolves #595

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

<!-- This PR itself targets main, but the lint jobs running here confirm the trigger still fires. A stacked (non-main) PR is the real test of the fix. -->

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
🤖 This PR was prepared with the assistance of Claude Code (Opus 4.8). A human has reviewed the change.
