### PR TITLE
upgrade mysql to 8.4

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -104,14 +104,20 @@ resource "aws_db_instance" "postgresql" {
   deletion_protection    = true
 }
 
-# New maindb MySQL 8.0 instance
+# maindb MySQL 8.4 instance
 resource "aws_db_instance" "maindb" {
   allocated_storage = 50
 
   # Using general purpose SSD
   storage_type   = "gp2"
   engine         = "mysql"
-  engine_version = "8.0.44"
+  engine_version = "8.4.6"
+
+  # Required by AWS to perform a major version upgrade (8.0 -> 8.4) in place.
+  # TODO: Remove this (or set back to false) once the upgrade has completed,
+  # so an accidental engine_version bump in future can't trigger a surprise
+  # major version upgrade.
+  allow_major_version_upgrade = true
 
   instance_class      = "db.t3.small"
   identifier          = "maindb"
@@ -139,7 +145,7 @@ resource "aws_db_instance" "maindb" {
   apply_immediately          = false
   skip_final_snapshot        = true
   vpc_security_group_ids     = [aws_security_group.main_database.id]
-  parameter_group_name       = "default.mysql8.0"
+  parameter_group_name       = "default.mysql8.4"
   deletion_protection        = false
   copy_tags_to_snapshot      = true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

part of:
 - https://github.com/openaustralia/openaustralia/issues/884

## Description

It's time to upgrade to mysql 8.4


## Motivation and Context
Because Amazon makes us, and Amazon is right to do so.


## How Has This Been Tested?

By the time this merges, the apps that need this database have been tested in docker and CI to work with mysql 8.4

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
