### PR TITLE
Provision the Postal server, firewall and DNS in Terraform

### DIFF
--- a/docs/postal-migration.md
+++ b/docs/postal-migration.md
@@ -1,0 +1,76 @@
+# Cuttlefish to Postal migration
+
+We are replacing [cuttlefish](https://cuttlefish.oaf.org.au), our
+transactional mail server (a hand-provisioned Ubuntu 14.04 Linode that is
+not managed by ansible), with [Postal](https://postalserver.io) v3 on a new
+ansible-managed Linode at postal.oaf.org.au.
+
+Cuttlefish currently relays mail for:
+
+- Planning Alerts (also uses cuttlefish-specific headers and its delivery
+  event webhook for bounce handling)
+- They Vote For You
+- OpenAustralia.org.au (via msmtp, configured by this repo)
+- morph.io (the app and its Discourse forum, configured by the morph repo)
+- oaf.org.au (the WordPress.com site)
+
+Right to Know does not use cuttlefish (it runs its own postfix).
+
+## How the migration works
+
+Cuttlefish keeps running untouched until every service has moved. All DNS
+changes are additive while the two servers coexist (each sending domain
+gains a Postal DKIM record and `include:spf.postal.oaf.org.au` alongside
+its cuttlefish records). Each service then cuts over individually by
+swapping SMTP host and credentials, so rollback for any service is just
+restoring the old credential - no DNS involved.
+
+Services move in ascending order of volume/risk, which also warms up the
+new IP's sending reputation before the biggest sender moves:
+
+1. They Vote For You staging (free rehearsal, same config shape as
+   production)
+2. They Vote For You production
+3. morph.io (morph repo PR: `provisioning/group_vars/production.yml` plus
+   the morph-app and discourse templates; morph's alert emails also rely on
+   cuttlefish's CSS inlining which Postal doesn't do, so that PR needs
+   premailer or accepts plainer styling)
+4. oaf.org.au WordPress (manual: find the SMTP plugin settings in wp-admin
+   first, then swap host/credentials)
+5. OpenAustralia (this repo: msmtprc template + group_vars; also turn
+   certificate checking back on since postal has a valid certificate)
+6. Planning Alerts last, 2-3 weeks after the others: it is the highest
+   volume sender and needs app changes first (X-Postal-Tag headers, a new
+   /postal/event webhook controller for bounce handling, MessageHeld Slack
+   notifications). Those ship in their own planningalerts PR before the
+   credential swap.
+
+Per-cutover verification: send a test mail to a Gmail-hosted address and
+check spf/dkim/dmarc all pass with the postal DKIM selector, check the
+message log in the Postal UI, and watch the domain's sending source shift
+from the cuttlefish IP to the postal IP in the Suped DMARC dashboard over
+the following days.
+
+## Decommissioning cuttlefish
+
+Only after all services have moved and 2-4 weeks of watching the cuttlefish
+UI for stragglers (it was historically open to the civic tech community):
+
+1. Remove cuttlefish credentials/config from the app repos, the
+   /cuttlefish/event webhook from planningalerts, and the `cuttlefish_*`
+   vars from group_vars/openaustralia.yml.
+2. Terraform: remove `ip4:<cuttlefish>` from the `_spf1.oaf.org.au` record,
+   `a:cuttlefish.oaf.org.au` from the planningalerts SPF, every
+   `*.cuttlefish._domainkey.*` TXT record, the `email.morph.io` /
+   `email2.morph.io` / `email2.planningalerts.org.au` CNAMEs, and finally
+   the `cuttlefish` module itself.
+3. Take a final Linode snapshot and database dump first - the delivery
+   history is worth keeping.
+
+## Where things live
+
+- Server + firewall + per-server DNS: `terraform/postal/`
+- Provisioning: `roles/internal/postal/` (see its README for the
+  application setup runbook, upgrades, backup/restore)
+- Secrets: `group_vars/postal.yml` (ansible-vault)
+- Per-service DNS: each service's own `dns.tf` (added at cutover time)

--- a/docs/postal-migration.md
+++ b/docs/postal-migration.md
@@ -69,6 +69,9 @@ UI for stragglers (it was historically open to the civic tech community):
 
 ## Where things live
 
+Some of these arrive after the terraform foundation, so they may not exist
+yet depending on how far through the migration we are:
+
 - Server + firewall + per-server DNS: `terraform/postal/`
 - Provisioning: `roles/internal/postal/` (see its README for the
   application setup runbook, upgrades, backup/restore)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,13 @@ module "cuttlefish" {
   zone_id = cloudflare_zone.oaf_org_au.id
 }
 
+# Replacement for cuttlefish (see docs/postal-migration.md)
+module "postal" {
+  source         = "./postal"
+  zone_id        = cloudflare_zone.oaf_org_au.id
+  authorized_key = data.external.id_rsa.result["id_rsa"]
+}
+
 module "docs-internal" {
   source  = "./docs-internal"
   zone_id = cloudflare_zone.oaf_org_au.id

--- a/terraform/postal/dns.tf
+++ b/terraform/postal/dns.tf
@@ -1,0 +1,103 @@
+# DNS for the Postal mail server (https://docs.postalserver.io/getting-started/dns-configuration)
+#
+# These are the per-server records. Each sending domain (planningalerts.org.au,
+# theyvoteforyou.org.au, etc.) additionally needs its own SPF include and a
+# per-domain DKIM record, which live in that service's own dns.tf.
+
+# A records
+
+resource "cloudflare_record" "a" {
+  zone_id = var.zone_id
+  name    = "postal.oaf.org.au"
+  type    = "A"
+  value   = linode_instance.main.ip_address
+}
+
+resource "cloudflare_record" "rp_a" {
+  zone_id = var.zone_id
+  name    = "rp.postal.oaf.org.au"
+  type    = "A"
+  value   = linode_instance.main.ip_address
+}
+
+# Exists so click/open tracking could be turned on later. We deliberately
+# leave tracking disabled in Postal itself.
+resource "cloudflare_record" "track_a" {
+  zone_id = var.zone_id
+  name    = "track.postal.oaf.org.au"
+  type    = "A"
+  value   = linode_instance.main.ip_address
+}
+
+# AAAA records
+
+resource "cloudflare_record" "aaaa" {
+  zone_id = var.zone_id
+  name    = "postal.oaf.org.au"
+  type    = "AAAA"
+  value   = cidrhost(linode_instance.main.ipv6, 0)
+}
+
+resource "cloudflare_record" "rp_aaaa" {
+  zone_id = var.zone_id
+  name    = "rp.postal.oaf.org.au"
+  type    = "AAAA"
+  value   = cidrhost(linode_instance.main.ipv6, 0)
+}
+
+# MX records
+
+# The return-path domain is the default MAIL FROM / bounce domain for all
+# mail Postal sends, so remote MTAs deliver bounces here on port 25
+resource "cloudflare_record" "rp_mx" {
+  zone_id  = var.zone_id
+  name     = "rp.postal.oaf.org.au"
+  type     = "MX"
+  priority = 10
+  value    = "postal.oaf.org.au"
+}
+
+# Inbound mail routed to Postal "routes" (forwarding to HTTP endpoints etc.)
+resource "cloudflare_record" "routes_mx" {
+  zone_id  = var.zone_id
+  name     = "routes.postal.oaf.org.au"
+  type     = "MX"
+  priority = 10
+  value    = "postal.oaf.org.au"
+}
+
+# TXT records
+
+resource "cloudflare_record" "spf" {
+  zone_id = var.zone_id
+  name    = "postal.oaf.org.au"
+  type    = "TXT"
+  value   = "v=spf1 a -all"
+}
+
+# The include referenced by every sending domain's SPF record. Future IP
+# changes only need this one record updated.
+resource "cloudflare_record" "spf_include" {
+  zone_id = var.zone_id
+  name    = "spf.postal.oaf.org.au"
+  type    = "TXT"
+  value   = "v=spf1 ip4:${linode_instance.main.ip_address} ip6:${cidrhost(linode_instance.main.ipv6, 0)} -all"
+}
+
+resource "cloudflare_record" "rp_spf" {
+  zone_id = var.zone_id
+  name    = "rp.postal.oaf.org.au"
+  type    = "TXT"
+  value   = "v=spf1 a mx include:spf.postal.oaf.org.au -all"
+}
+
+# DKIM for the return-path domain, signed with the installation's signing.key.
+# The value is the p= record printed by `postal default-dkim-record`, only
+# known once the signing key exists, hence the empty-string guard.
+resource "cloudflare_record" "rp_dkim" {
+  count   = var.return_path_dkim_record == "" ? 0 : 1
+  zone_id = var.zone_id
+  name    = "postal._domainkey.rp.postal.oaf.org.au"
+  type    = "TXT"
+  value   = var.return_path_dkim_record
+}

--- a/terraform/postal/main.tf
+++ b/terraform/postal/main.tf
@@ -1,0 +1,95 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.4.0"
+    }
+    linode = {
+      source  = "linode/linode"
+      version = "~> 2.5.2"
+    }
+  }
+}
+
+resource "linode_instance" "main" {
+  region = "ap-southeast"
+  # Postal's documented minimum (4GB / 2 cores). Resizing to g6-standard-4
+  # later is a quick reboot because resize_disk is false.
+  type             = "g6-standard-2"
+  label            = "postal"
+  image            = "linode/ubuntu22.04"
+  authorized_keys  = [var.authorized_key]
+  booted           = true
+  backups_enabled  = true
+  watchdog_enabled = true
+  resize_disk      = false
+}
+
+# Forward and reverse DNS must match (FCrDNS) or major mail receivers
+# will junk or reject what we send
+resource "linode_rdns" "ipv4" {
+  address = linode_instance.main.ip_address
+  rdns    = "postal.oaf.org.au"
+}
+
+resource "linode_rdns" "ipv6" {
+  address = cidrhost(linode_instance.main.ipv6, 0)
+  rdns    = "postal.oaf.org.au"
+}
+
+# Provider-level firewall, the Linode equivalent of the AWS security groups
+# used elsewhere in this repo. 2525 is the legacy Cuttlefish submission port
+# that clients keep using; an iptables rule on the host redirects it to 25.
+resource "linode_firewall" "main" {
+  label = "postal"
+
+  inbound {
+    label    = "ssh"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "22"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "smtp"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "25"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "smtp-legacy-submission"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "2525"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "http"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "80"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound {
+    label    = "https"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "443"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound_policy  = "DROP"
+  outbound_policy = "ACCEPT"
+
+  linodes = [linode_instance.main.id]
+}

--- a/terraform/postal/outputs.tf
+++ b/terraform/postal/outputs.tf
@@ -1,0 +1,7 @@
+output "ipv4_address" {
+  value = linode_instance.main.ip_address
+}
+
+output "ipv6_address" {
+  value = cidrhost(linode_instance.main.ipv6, 0)
+}

--- a/terraform/postal/variables.tf
+++ b/terraform/postal/variables.tf
@@ -1,0 +1,12 @@
+variable "zone_id" {
+  description = "Cloudflare zone id for oaf.org.au"
+}
+
+variable "authorized_key" {
+  description = "SSH public key installed for root on first boot"
+}
+
+variable "return_path_dkim_record" {
+  description = "Output of `postal default-dkim-record` (the k=rsa; p=... value). Leave empty until the server's signing key exists."
+  default     = ""
+}


### PR DESCRIPTION
## Description

Bottom of the Cuttlefish → Postal stack. Provisions the infrastructure the Postal server needs, and nothing else: the Linode instance, its firewall, its reverse DNS, and the per-server DNS records. No Ansible, no service cutover, nothing that touches cuttlefish. Split out of #563 so the Terraform foundation can be planned, reviewed and applied on its own before any provisioning lands.

**`terraform/postal/`** (mirrors the structure of the existing `terraform/cuttlefish/` module):

- `linode_instance` in `ap-southeast` (Sydney), Ubuntu 22.04, `g6-standard-2` — Postal's documented minimum of 4GB and 2 cores. `resize_disk = false` so bumping to `g6-standard-4` later is just a reboot. Backups and watchdog on.
- `linode_rdns` for both IPv4 and IPv6 pointing at `postal.oaf.org.au`. Forward and reverse DNS have to match or the major receivers junk or reject what we send.
- `linode_firewall` with a default-DROP inbound policy allowing 22, 25, 80, 443 and 2525. This is the provider-level equivalent of the AWS security groups used elsewhere in the repo, and is something cuttlefish never had. 2525 is the legacy submission port that client apps keep using.
- Cloudflare records in the `oaf.org.au` zone, following https://docs.postalserver.io/getting-started/dns-configuration: A/AAAA for the host, the `spf.postal` include that every sending domain will reference, the `rp.postal` return-path domain (A, AAAA, MX and SPF), the `routes.postal` MX, and a `track.postal` A record. Tracking stays switched off in Postal itself; the record just keeps the option open without another DNS change later.
- The return-path DKIM record is guarded behind an empty-default `return_path_dkim_record` variable, because its value only exists once the server's signing key does. At the default it has `count = 0`, so it is a no-op until filled in.

**`terraform/main.tf`**: wires the module up with the `oaf.org.au` zone id and the shared `data.external.id_rsa` key, so the box is reachable by Ansible as root on first boot.

**`docs/postal-migration.md`**: the plan for the whole migration — what currently relays through cuttlefish, why the coexistence approach means per-service rollback never involves DNS, the cutover order (lowest volume first, so the new IP warms up before Planning Alerts moves), per-cutover verification, and the decommissioning checklist. This is forward-looking: the `roles/internal/postal/` and `group_vars/postal.yml` paths it references arrive in #563.

## Motivation and Context

Cuttlefish is a hand-provisioned Ubuntu 14.04 Linode that is not managed by Ansible and is no longer actively maintained upstream. Postal is a maintained, Docker-based alternative with per-service mail servers, webhooks, suppression lists and message logs. This PR is the foundation that lets the five services currently relaying through cuttlefish (Planning Alerts, They Vote for You, OpenAustralia.org.au, morph.io and the oaf.org.au WordPress site) migrate one at a time with near-instant rollback.

Everything here is additive. No cuttlefish resource is modified or destroyed.

## How Has This Been Tested?

- [x] Ran automated tests on my own system
- [ ] Checked affected area manually on my own / staging system
- [ ] Confirmed it passed the GitHub actions tests

`terraform fmt -check -recursive terraform/` and `terraform validate` both pass on this branch on its own, which matters because this branch is a new stack base that has to stand up without the four PRs above it.

Record names and the return-path DKIM selector were checked against the upstream Postal DNS documentation rather than written from memory.

Not applied anywhere yet. Before merge, please run `make tf-plan` and confirm it shows only new resources (one Linode instance, two rDNS entries, one firewall, and the `postal.oaf.org.au` records) and no changes to any cuttlefish resource. The `rp_dkim` record should not appear at all, since its variable is empty.

After apply, the follow-up on this PR is step 5 of `roles/internal/postal/README.md`: run `postal default-dkim-record` on the box and set `return_path_dkim_record`.

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Description drafted with Claude Code (claude-opus-5).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
