### PR TITLE
Don't install boto3 on Python older than 3.7

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -99,7 +99,11 @@
     - name: Install boto3 which is required for EC2 stuff (Python 3)
       tags: python
       pip: name=boto3
-      when: ansible_python_version is version('3', '>=')
+      # Not 3.0: pip 8.x on Ubuntu 16.04 ignores Requires-Python, so it happily
+      # installs py3.8+ only wheels (urllib3 2.x) that fail to even parse on
+      # python3.5. That shadows the distro urllib3 and breaks every module
+      # importing ansible.module_utils.urls, apt included.
+      when: ansible_python_version is version('3.7', '>=')
 
 - hosts: ec2
   name: "Gather RDS facts"


### PR DESCRIPTION
## Description

Gates the `Install boto3 which is required for EC2 stuff (Python 3)` task on Python 3.7 or newer, instead of on Python 3 or newer.

Stock pip on Ubuntu 16.04 is 8.1.1, which predates `Requires-Python` and ignores it. On `au.proxy.oaf.org.au` (xenial, Python 3.5.2) `pip install boto3` therefore pulled down boto3 1.43.52 along with urllib3 2.7.0, which needs Python 3.8+ and uses f-strings. That urllib3 landed in `/usr/local/lib/python3.5/dist-packages`, which precedes `/usr/lib/python3/dist-packages` on `sys.path`, so it shadowed the working distro `python3-urllib3 1.13.1`. ansible-core imports urllib3 at module scope in `module_utils/urls.py`, so every `apt`, `uri` and `get_url` task against that host then died with a `SyntaxError`, including the `Install python packages` task immediately above this one. The playbook had broken its own target.

I have already removed the poisoned pip chain from `au.proxy.oaf.org.au`, so the host itself is recovered. This change is what stops the next run from reinstalling boto3 and poisoning it again.

## Motivation and Context

Resolves #615.

`make check-proxy` has been failing at the third task with an opaque `MODULE FAILURE`, which made the whole `proxy` host unmanageable by Ansible. It also masked everything behind it, so no one had seen the rest of the run in a while.

`proxy` does not need boto3. The only consumers are the `Gather RDS facts` tasks, gated on `db_name` and `planningalerts_db_name`, and both variables are defined solely in `group_vars/requires_mysql.yml` and `group_vars/requires_postgresql.yml`. `proxy` is in neither group, so both tasks skip. The check run reaching `ok=63` with boto3 absent from the host confirms this empirically rather than just by reading the conditionals.

Related to #528, which would remove the problem entirely by getting this box off 16.04, and to #436, which is the same over-broad `hosts: all` pattern in the same play. This change is a mitigation for as long as a 16.04 host exists, not a substitute for #528.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Ran `.venv/bin/ansible-playbook -i ./inventory/ec2-hosts site.yml -l proxy --check --diff` against production before and after.

Before, on the poisoned host: `ok=3 changed=0 failed=1`, dying at `TASK [Install python packages]`.

After removing the pip chain and applying this guard: `ok=63 changed=6 failed=1`, with `TASK [Install boto3 which is required for EC2 stuff (Python 3)]` correctly reporting `skipping: [au.proxy.oaf.org.au]`. Confirmed on the host that `/usr/local/lib/python3.5/dist-packages` is empty and `import urllib3` now resolves to 1.13.1 from the distro path.

`ansible-playbook --syntax-check` passes. `ansible-lint site.yml` reports one `internal-error`, which I confirmed is pre-existing by stashing this change and getting identical output on `main`.

The remaining `failed=1` is a pre-existing `--check`-only artifact in the `proxy` role, unrelated to this change: `get_url` reports changed without downloading under check mode, so the chained `unarchive` has no source file. tinyproxy 1.10.0 is built and the service has been running since 2026-06-15. I have not touched it here.

I have not run this against any other host. Every other host in the fleet is on 20.04 or 22.04, where `ansible_python_version` is well above 3.7, so the conditional evaluates the same as before and behaviour is unchanged.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

### Not in scope, flagged for follow-up

Two pre-existing problems became visible once the run got far enough to reveal them. Happy to raise issues for both if useful.

The `geerlingguy.swap` role guard never skips. `when: swap_file_size_mb is defined` is always true, because the role's own `defaults/main.yml` sets `swap_file_size_mb: '512'` and role defaults are in scope when the guard is evaluated. So the role runs on every host, including `proxy`, which defines neither that variable nor `swap_file_state`. A live run against `proxy` would add a `/swapfile` fstab entry and set swappiness on a box with 466 MB RAM and no swap.

Anyone running this live against `proxy` should know the `proxy` role will re-download, `./configure` and `make && make install` tinyproxy whenever `/tmp` has been cleared, then fire `notify: restart tinyproxy`. That is a C compile on a 466 MB t3.nano with zero swap, followed by a restart of the proxy morph.io scrapers depend on.

Separately, `vpn.oaf.org.au` no longer resolves in DNS despite being listed in the `[ec2]` inventory group. The `[openvpn]` group reaches the same box by IP, which is up.

---

Investigated and implemented with the help of Claude Code (claude-opus-5). I reviewed the diagnosis, the change and the production cleanup before this PR was opened.
