### PR TITLE
Infrastructure cutover for Alaveteli 0.45.8.0 on production

### DIFF
--- a/group_vars/righttoknow.yml
+++ b/group_vars/righttoknow.yml
@@ -141,10 +141,19 @@ stripe_webhook_secret_production: !vault |
 stripe_prices_test:
   price_1ScdLJDXjniQjO8YsjtZ6QYq: pro
   price_1TthbLDXjniQjO8YclWV5JEQ: pro-annual-billing
-# production uses the same account in LIVE mode. Rendered into production's
-# general.yml now, but inert until production moves to 0.45.x - 0.44.3.0 has no
-# STRIPE_PRICES setting and ignores the key. RTK-pro is a legacy plan ID and so
-# carries the STRIPE_NAMESPACE prefix, per upstream guidance on historical IDs.
+# production uses the same account in LIVE mode.
+#
+# Both entries must be real Stripe Price IDs. AlaveteliPro::Price.retrieve does
+# `stripe_prices.key(param)`, mapping the value (the URL slug in plan_path) back
+# to the key, then passes that key to Stripe::Price.retrieve. So the key is the
+# object ID and the value is the slug - a namespaced plan ID like `RTK-pro` does
+# not belong here, despite what infrastructure#581's description claims.
+#
+# Existing subscriptions created against the old `RTK-pro` plan are unaffected
+# by not being listed: AlaveteliPro::Subscription#price wraps the subscription's
+# own price object from Stripe rather than looking it up here. Adding RTK-pro
+# would be actively wrong - AlaveteliPro::Price.list iterates this whole hash to
+# build the pricing page, so it would show as an extra legacy-priced tier.
 stripe_prices_live:
   price_1Ty5E7DXjniQjO8YnPyv0BUZ: pro
   price_1TthX2DXjniQjO8YeJfDzO35: pro-annual-billing

--- a/roles/internal/righttoknow/templates/general.yml.j2
+++ b/roles/internal/righttoknow/templates/general.yml.j2
@@ -1183,12 +1183,11 @@ STRIPE_NAMESPACE: 'RTK'
 # Maps Stripe Price IDs to Alaveteli Pro URL slugs. Alaveteli 0.45.0.0 migrated
 # Stripe from Plans to Prices and made this key required for Pro pricing.
 #
-# Emitted for both stages. Production still runs 0.44.3.0, where this key is
-# inert: it is absent from that version's DEFAULTS, and Alaveteli's config
-# loader ignores keys it does not know. Emitting it now keeps the template free
-# of version conditionals and means production is already configured when it
-# moves to 0.45.x, rather than silently falling back to the { pro: 'pro' }
-# default on a live billing path.
+# Emitted unconditionally for both stages. It was first emitted for production
+# while that stage was still on 0.44.3.0, where the key was inert - absent from
+# that version's DEFAULTS, and Alaveteli's config loader ignores keys it does not
+# know - so that the live billing path was already configured at the 0.45 cutover
+# rather than silently falling back to the { pro: 'pro' } default.
 #
 # The hash KEY is the Stripe Price ID; the VALUE is the URL slug used in
 # plan_path. Values come from the stripe_prices_test / stripe_prices_live

--- a/roles/internal/righttoknow/templates/sidekiq.yml.j2
+++ b/roles/internal/righttoknow/templates/sidekiq.yml.j2
@@ -7,12 +7,8 @@ production:
 :queues:
   - default
   - xapian
-{% if stage == 'staging' %}
   - low
-{% endif %}
 
 :limits:
   xapian: 1
-{% if stage == 'staging' %}
   low: 1
-{% endif %}


### PR DESCRIPTION
## Description

RTK Issue: https://github.com/openaustralia/righttoknow/issues/999

The infrastructure side of moving Right to Know **production** to Alaveteli 0.45.8.0. This is
the only unchecked item on the cutover checklist in #581, plus two comment corrections in the
files that checklist points at.

**1. Make the `low` Sidekiq queue unconditional.** 0.45.x enqueues `FoiAttachmentMaskJob` to
`low`. A queue absent from `sidekiq.yml` is not an error - the jobs accumulate in Redis, no
worker collects them, nothing fails, and the only symptom is attachment masking quietly
stopping. `#581` added the queue for staging only, because production was still on 0.44.3.0.

**2. Correct the `STRIPE_PRICES` comments.** One of them records reasoning that is wrong, not
just stale - see below. Comments only; no rendered output changes.

## Motivation and Context

Production runs 0.44.3.0; staging has run 0.45.8.0 since 28 July. This PR is the first of three
for the production cutover, alongside `openaustralia/alaveteli` (`staging` -> `production`) and
`openaustralia/righttoknow` (`staging` -> `production`).

**This one is deliberately merged and applied ahead of the deploy window.** An extra queue in
`sidekiq.yml` is inert on 0.44.3.0, so there is no reason to carry it into the outage, and
applying early leaves time to notice if the sidekiq restart misbehaves. The "Apply sidekiq
config" task already carries `notify: restart sidekiq` and the handler does a `daemon_reload`
plus restart, so no manual intervention is needed.

### The comment that was wrong, not just stale

`group_vars/righttoknow.yml` said `RTK-pro is a legacy plan ID and so carries the
STRIPE_NAMESPACE prefix, per upstream guidance on historical IDs`. Two problems:

- The value it describes was replaced in de520e470 ("Update stripe_prices_live to a price where
  GST = exclusive"). The live monthly entry has been `price_1Ty5E7DXjniQjO8YnPyv0BUZ` since then.
- The reasoning behind it - stated in #581's description as "`AlaveteliPro::Price.retrieve`
  passes the hash key to Stripe **raw**, so `RTK-pro` must be the literal object ID" - is
  contradicted by the code. `retrieve` does `stripe_prices.key(param)`, which maps the **value**
  (the URL slug used in `plan_path`) back to the **key**, and passes that key to
  `Stripe::Price.retrieve`. So the key is the Price ID and the value is the slug. The current
  config is correct; #581's justification for the old value was not.

Left alone, someone would eventually "restore" `RTK-pro` on #581's stated logic. The replacement
comment says what the hash actually is and why the legacy ID must not be added back.

### Existing Pro subscribers are not affected by the cutover

The obvious follow-up question is what happens to subscriptions created against the old
`RTK-pro` plan when `STRIPE_PRICES` goes live without it. Traced at the 0.45.8.0 tag, every
caller of `plan_path`:

| Caller | Argument | Legacy-price exposure |
| --- | --- | --- |
| `subscriptions_controller.rb:65` (`create` error path) | `@price` from `load_price` | none - always from `Price.retrieve`, so in the hash |
| `subscriptions_controller.rb:92` (`authorise`, `invoice_open?`) | `@subscription.price` | none - `#authorise` is only reachable from the redirect `create` issues, so the subscription was just created against a configured price |
| `subscriptions_controller.rb:120` (`authorise` rescue) | literal `'pro'` | none - a String; `to_param` is never called on a Price |
| `plans/_pricing_tiers.html.erb`, `plans/index.html.erb` | prices from `Price.list` | none - sourced from the hash |

And the two pages an existing subscriber actually uses:

- **Account / billing** (`subscriptions#index` -> `_subscription.html.erb`) reads
  `product.name`, `unit_amount_with_tax` and `billing_frequency`.
  `AlaveteliPro::Subscription#price` wraps `items.first.price` - the subscription's own price
  object from Stripe - so nothing consults `STRIPE_PRICES`.
- **Cancel** (`subscriptions#destroy`) sets `cancel_at_period_end` and redirects to
  `subscriptions_path`. No `plan_path`.

So nothing needs adding to `stripe_prices_live`, and adding `RTK-pro` would be actively harmful:
`AlaveteliPro::Price.list` iterates the whole hash to build the pricing page, so it would appear
as a third, legacy-priced tier to new visitors. Migrating those subscriptions onto the new Price
in Stripe is out of scope here - they bill correctly as they are, and it is a pricing decision
rather than a technical one.

### On the `tax_behavior` mismatch #581 flagged

#581's description recommends normalising inconsistent `tax_behavior` between the monthly and
annual live prices (`inclusive` vs `exclusive`). That describes the pre-swap pair. de520e470
replaced the monthly entry specifically to fix it, so the two IDs production is configured with
are both GST-exclusive. #581's body was never revised after that commit - which is part of why
these comments are being corrected here. Still worth a glance in the dashboard at cutover, but
there is no known inconsistency to fix.

### Note on `sidekiq.yml.j2`

With the conditionals gone the file contains no Jinja. It stays a `.j2` template rendered by the
`template:` module rather than moving to `files/` + `copy:`, because `make yaml-lint` parses
anything under `templates/` without a `.j2` extension and `make template-check` enforces the
extension. `1e7b9dc1` moved it here for exactly that reason. The now-unused `stage` var on the
task is left in place - the next release may well reintroduce a stage-specific queue.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`make yaml-lint` and `make template-check` both pass (the remaining warnings are pre-existing,
in `cloudflare_realip`, `openaustralia` and `site.yml`). The rendered `sidekiq.yml` was parsed as
YAML and gives `queues: [default, xapian, low]`, `limits: {xapian: 1, low: 1}` - identical to
what staging renders today, which is byte-identical to upstream's `config/sidekiq.yml-example` at
0.45.8.0.

**Not yet run against the hosts.** `make check-righttoknow STAGE=production` and
`apply-righttoknow` come next, before the deploy window, and this stays in draft until then.

## Screenshots (if appropriate):

Nil required.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI use: planned and drafted with Claude Code (Opus 5), including the `plan_path` trace above.
Reviewed by me before opening.
