### PR TITLE
Serve ACME challenges on RightToKnow HTTPS vhosts

### DIFF
--- a/roles/internal/righttoknow/templates/nginx/stage.j2
+++ b/roles/internal/righttoknow/templates/nginx/stage.j2
@@ -71,7 +71,18 @@ server {
 server {
   listen 443 ssl http2;
   server_name {{ domain }};
-  rewrite ^/(.*) https://www.{{ domain }}/$1 permanent;
+
+  # Let's Encrypt HTTP-01 challenges can arrive over HTTPS (the validator
+  # follows redirects), so they must be exempt from the redirect below.
+  {% if certbot_webroot is defined %}
+  location ^~ /.well-known/acme-challenge/ {
+    root {{ certbot_webroot }};
+  }
+  {% endif %}
+
+  location / {
+    rewrite ^/(.*) https://www.{{ domain }}/$1 permanent;
+  }
 
   ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
@@ -96,6 +107,17 @@ server {
   ssl_prefer_server_ciphers on;
   ssl_session_cache  builtin:1000  shared:SSL:10m;
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';
+
+  # Let's Encrypt HTTP-01 challenges can arrive over HTTPS (the validator
+  # follows redirects), so they must bypass the deny list in `location /`
+  # below — Let's Encrypt validates from cloud provider IP ranges that
+  # overlap with it.
+  {% if certbot_webroot is defined %}
+  location ^~ /.well-known/acme-challenge/ {
+    auth_basic off;
+    root {{ certbot_webroot }};
+  }
+  {% endif %}
 
   # If you need to access the "emergency user" and password_protect is enabled
   # then you probably have to disable it temporarily


### PR DESCRIPTION
## Description

Adds the webroot-backed `^~ /.well-known/acme-challenge/` location to both HTTPS (`:443`) server blocks in the RightToKnow nginx template, mirroring the existing exemptions in the HTTP (`:8000`) blocks:

- The apex server-level `rewrite` is moved into `location /` so the ACME location can take effect.
- On `www`, the ACME location sits outside `location /`, so challenge requests bypass the deny list there.
- `auth_basic off;` in the ACME location so staging's password protection can't 401 challenges.

## Motivation and Context

Certificate issuance for `righttoknow.org.au` and `www.righttoknow.org.au` is failing (`make apply-righttoknow STAGE=production`, `oaf.certbot` webroot task). Let's Encrypt validators follow redirects, so HTTP-01 challenges can arrive over HTTPS. The 443 vhosts had no ACME exemption, so challenges fell into `location /` where they hit the apex redirect or the deny list — which includes cloud provider ranges Let's Encrypt validates from (e.g. `18.97.9.0/24`) — and returned 403.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Rendered `stage.j2` locally with production and staging contexts (with and without `certbot_webroot` defined): 5 ACME locations when defined (3 HTTP + 2 new HTTPS), 0 otherwise. `ansible-playbook --syntax-check site.yml` passes.

**This was applied to RTK Production to bypass a certbot error.**

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: OpenCode/amazon-bedrock/anthropic.claude-fable-5
