### PR TITLE
Validate RightToKnow certificates via DNS-01 with Cloudflare

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -144,10 +144,18 @@ These block:
 
 | Service | Mode | Challenge Path |
 |---------|------|----------------|
-| righttoknow | webroot | `/usr/share/nginx/html/.well-known/acme-challenge/` |
+| righttoknow | dns-cloudflare (DNS-01) | No HTTP challenge; DNS TXT records via Cloudflare API |
 | theyvoteforyou | nginx plugin | Handled by certbot-nginx |
 | openaustralia | apache plugin | Handled by certbot-apache |
 | planningalerts | apache plugin | Handled by certbot-apache |
+
+righttoknow previously used webroot (HTTP-01 at
+`/usr/share/nginx/html/.well-known/acme-challenge/`), but issuance for the
+proxied hostnames failed in August 2026: Let's Encrypt's validators were
+redirected to HTTPS at the Cloudflare edge and then 403'd. It now uses DNS-01
+via the `certbot_dns_cloudflare` option of the `oaf.certbot` role, which is
+immune to proxy/WAF behaviour entirely. The webroot config is retained as a
+fallback.
 
 ### Cloudflare Behaviour
 

--- a/group_vars/righttoknow.yml
+++ b/group_vars/righttoknow.yml
@@ -5,6 +5,28 @@ site_name: righttoknow.org.au
 cron_enabled: true
 certbot_webserver: nginx
 certbot_webroot: /usr/share/nginx/html
+# righttoknow.org.au and www are proxied through Cloudflare (orange cloud), so
+# HTTP-01 webroot challenges pass through the Cloudflare edge and are subject
+# to its redirects and security rules, which have blocked Let's Encrypt's
+# validators. Validate via DNS-01 with the Cloudflare API instead.
+# certbot_webroot is kept above so nginx still serves
+# /.well-known/acme-challenge/ as a fallback.
+certbot_dns_cloudflare: true
+# A Cloudflare API token scoped to Zone / DNS / Edit for righttoknow.org.au.
+# To rotate: create a token in the Cloudflare dashboard, then run
+#   .venv/bin/ansible-vault encrypt_string --encrypt-vault-id rtk 'THE_TOKEN' \
+#     --name certbot_dns_cloudflare_api_token
+# and replace the value below.
+certbot_dns_cloudflare_api_token: !vault |
+          $ANSIBLE_VAULT;1.2;AES256;rtk
+          36373030633531313031353731656462306434626534616336323062353430333963393630656535
+          3235646233373963666161616263636265333533636336370a653031343664666631333632323834
+          65393533393163666161353837313266653238653737386230353062363764356264633131353238
+          6330383037643631620a386433333837636363633563323438323061663235396363663162656633
+          35613038316134313132346134616665313832643131636463636236356430363037643964303263
+          32636331393462633363336666396636373164303635366362373064653564333763633332643161
+          366231316234343536666436353035653665
+
 backup_gpg_pw: !vault |
           $ANSIBLE_VAULT;1.2;AES256;rtk
           32323937363233343737353934643134346166363339306232613066396233303862313863323364


### PR DESCRIPTION
## Description

Enables the certbot role's new dns-cloudflare mode (#620) for the `righttoknow` group:

- `group_vars/righttoknow.yml`: sets `certbot_dns_cloudflare: true` and adds `certbot_dns_cloudflare_api_token` — a Cloudflare API token scoped to Zone / DNS / Edit for `righttoknow.org.au`, vault-encrypted with the `rtk` vault id. Rotation instructions are in the accompanying comment. `certbot_webroot` is retained so nginx keeps serving the HTTP-01 path as a fallback.
- `docs/cloudflare-proxy-migration.md`: updates the certbot mode table and records why RightToKnow moved to DNS-01.

## Motivation and Context

`make apply-righttoknow STAGE=production` is failing at the certbot webroot task. `righttoknow.org.au` and `www.righttoknow.org.au` are proxied through Cloudflare (orange cloud), so Let's Encrypt's HTTP-01 validators hit the Cloudflare edge, where they were redirected to HTTPS and then 403'd. Grey-clouded `prod.righttoknow.org.au` validated fine against the same origin and webroot, confirming the proxy path as the cause. DNS-01 via the Cloudflare API is immune to proxy and WAF behaviour entirely. #619 fixes the nginx side independently.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`ansible-playbook --syntax-check site.yml` passes. Not yet applied to a live host — suggest verifying on staging (`STAGE=staging`) before production.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Assisted-by: OpenCode/amazon-bedrock/anthropic.claude-fable-5
