### PR TITLE
Infrastructure upgrades required for Alaveteli 0.46.7.0

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -8,4 +8,4 @@ ruby_version_production: 3.2.9
 # 0.45.8.0's 2.6.2 lockfile), so this does not have to be exact - but matching it
 # avoids the version-mismatch warning and keeps a rebuilt server consistent with
 # the one we have.
-bundler_version: 2.6.2
+bundler_version: 2.7.2

--- a/roles/internal/righttoknow/tasks/cron.yml
+++ b/roles/internal/righttoknow/tasks/cron.yml
@@ -300,6 +300,35 @@
     state: "{{ cron_enabled | ternary('present', 'absent')}}"
   with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
 
+# Daily purge of profile content for limited user profiles (added in 0.46)
+- name: Add alaveteli crontab - users-purge-limited
+  cron:
+    user: deploy
+    name: "users-purge-limited"
+    minute: "50"
+    hour: "2"
+    job: "/bin/bash -l -c 'cd /srv/www/{{ item }}/current && RAILS_ENV=production run-with-lockfile -n ../users-purge-limited.lock \"bin/rails --quiet users:purge_limited\" || echo \"stalled?\"'"
+    cron_file: "{{ item }}"
+    state: "{{ cron_enabled | ternary('present', 'absent')}}"
+  with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
+
+# Daily destruction of users deemed unused for two years (added in 0.46).
+# Shipped disabled: last_sign_in_at is nil for every account that predates the
+# 0.46 upgrade, so the first run would sweep up a large number of accounts.
+# Enable only after the dry-run count on staging has been reviewed and signed
+# off on openaustralia/righttoknow#1031.
+- name: Add alaveteli crontab - users-destroy-unused
+  cron:
+    user: deploy
+    name: "users-destroy-unused"
+    minute: "53"
+    hour: "2"
+    job: "/bin/bash -l -c 'cd /srv/www/{{ item }}/current && RAILS_ENV=production run-with-lockfile -n ../users-destroy-unused.lock \"bin/rails --quiet users:destroy_unused\" || echo \"stalled?\"'"
+    cron_file: "{{ item }}"
+    state: "{{ cron_enabled | ternary('present', 'absent')}}"
+    disabled: true
+  with_items: "{{ ['staging'] if 'righttoknow_staging' in group_names else ( ['production'] if 'righttoknow_production' in group_names else [] ) }}"
+
 # Daily public body export (added)
 - name: Add alaveteli crontab - public-body-export
   cron:

--- a/roles/internal/righttoknow/templates/general.yml.j2
+++ b/roles/internal/righttoknow/templates/general.yml.j2
@@ -456,7 +456,7 @@ SECRET_KEY_BASE: '{{ alaveteli_secret_key_base }}'
 # checks in a few obvious places. Typically, you do not want to run your site
 # in read-only mode.
 #
-# READ_ONLY - String (default: nil)
+# READ_ONLY - String (default: '')
 #
 # Examples:
 #
@@ -465,6 +465,29 @@ SECRET_KEY_BASE: '{{ alaveteli_secret_key_base }}'
 #
 # ---
 READ_ONLY: ''
+
+# READ_ONLY_FEATURES - Array of strings (default: [])
+#
+# Granular read-only control for specific features. This allows you to disable
+# specific functionality without putting the entire site in read-only mode.
+#
+# Available features:
+#   'annotations'     - Blocks annotations on requests
+#   'classifications' - Blocks request status classifications
+#   'followups'       - Blocks followup messages on requests
+#   'requests'        - Blocks new FOI requests
+#   'signups'         - Blocks new user registration
+#
+# Examples:
+#
+# Block only new requests:
+#   READ_ONLY_FEATURES: ['requests']
+#
+# Block new requests and annotations:
+#   READ_ONLY_FEATURES: ['requests', 'annotations']
+#
+# ---
+READ_ONLY_FEATURES: []
 
 # Is this a staging or development site? If not, it's a live production site.
 # This setting controls whether or not the rails-post-deploy script will create
@@ -1290,6 +1313,27 @@ SURVEY_URL: ''
 #
 # ---
 USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 30
+
+# If ENABLE_PUBLIC_ANNOTATIONS is set to true, comments (annotations) will
+# be allowed on all requests regardless of who made the request.
+#
+# If set to false, comments will only be allowed by the requester or admin
+# users.
+#
+# ENABLE_PUBLIC_ANNOTATIONS - Boolean (default: true)
+#
+# ---
+ENABLE_PUBLIC_ANNOTATIONS: true
+
+# If ENABLE_USER_TO_USER_MESSAGING is set to true, Alaveteli will allow users
+# to send messages to each other through the site.
+#
+# If set to false, user-to-user messaging functionality will be disabled.
+#
+# ENABLE_USER_TO_USER_MESSAGING- Boolean (default: true)
+#
+# ---
+ENABLE_USER_TO_USER_MESSAGING: true
 
 # Background jobs are processed by Rails' ActiveJob using Sidekiq. There are
 # various ways to run Sidekiq depending to server resources and technical


### PR DESCRIPTION
## Description

Infrastructure changes required for Alaveteli 0.46.7.0 (openaustralia/alaveteli#55):

- `bundler_version` 2.6.2 → 2.7.2, matching `BUNDLED WITH` in the 0.46.7.0 `Gemfile.lock`. Must be applied before the first Capistrano deploy of the new code.
- `general.yml.j2`: adds the three settings introduced in 0.46.0.0 — `READ_ONLY_FEATURES: []`, `ENABLE_PUBLIC_ANNOTATIONS: true`, `ENABLE_USER_TO_USER_MESSAGING: true` — all at upstream defaults, which preserve current behaviour. Comment blocks mirror `config/general.yml-example` at the tag.
- `tasks/cron.yml`: adds the two cron jobs from the regenerated 0.46 crontab. `users-purge-limited` (02:50) is active. `users-destroy-unused` (02:53) ships `disabled: true`: `last_sign_in_at` is nil for every account predating the upgrade, so its first run would sweep all "unused" accounts older than two years. It gets enabled in a follow-up once the dry-run count on staging is reviewed and signed off on openaustralia/righttoknow#1031.

No Ruby change (3.2.9 remains supported), no package changes, `sidekiq.yml` unchanged between the tags.

## Motivation and Context

Final stage of the staged upgrade tracked in openaustralia/righttoknow#1005; this jump is openaustralia/righttoknow#1031, which carries the staging deploy runbook.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

yamllint reports no new issues on the changed files (the line-length warnings are pre-existing across the whole cron file). The three new `general.yml` keys were exercised locally via the Docker dev stack running 0.46.7.0 with default values. Run `make check-righttoknow STAGE=staging` before applying.

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My code follows the code style of this project.

---
Prepared with AI assistance (Claude Code, claude-fable-5).
