### PR TITLE
Record emergency AWS changes in terraform

### DIFF
--- a/terraform/blocked-source-ips.tf
+++ b/terraform/blocked-source-ips.tf
@@ -1,0 +1,131 @@
+# Source IP ranges blocked at the load balancer with a 403.
+#
+# These rules were added directly in the AWS console as an emergency response and
+# are recorded here so they're explicit, reviewable, and removed deliberately rather
+# than by accident. They sit at priorities 1-4, ahead of every routing rule on the
+# HTTPS listener, so blocked traffic never reaches an application.
+#
+# The grouping of CIDRs across the four rules matches what was created in the console.
+# Each ALB rule condition allows a limited number of values, so ranges were added in
+# batches as they were identified.
+#
+# The `import` blocks below adopt the existing rules into Terraform state rather than
+# creating new ones. They are a no-op once applied and can be deleted after that.
+
+resource "aws_lb_listener_rule" "blocked_source_ips_1" {
+  listener_arn = aws_lb_listener.main-https.arn
+  priority     = 1
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    source_ip {
+      values = [
+        "43.173.176.0/22",
+        "43.173.180.0/23",
+        "43.173.182.0/24",
+      ]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "blocked_source_ips_2" {
+  listener_arn = aws_lb_listener.main-https.arn
+  priority     = 2
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    source_ip {
+      values = [
+        "43.172.194.0/23",
+        "43.172.196.0/23",
+        "43.172.198.0/24",
+      ]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "blocked_source_ips_3" {
+  listener_arn = aws_lb_listener.main-https.arn
+  priority     = 3
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    source_ip {
+      values = [
+        "43.173.173.0/24",
+        "43.173.174.0/23",
+        "155.117.163.0/24",
+      ]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "blocked_source_ips_4" {
+  listener_arn = aws_lb_listener.main-https.arn
+  priority     = 4
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    source_ip {
+      values = [
+        "167.148.117.0/24",
+      ]
+    }
+  }
+}
+
+import {
+  to = aws_lb_listener_rule.blocked_source_ips_1
+  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/ee1f77e92714910e"
+}
+
+import {
+  to = aws_lb_listener_rule.blocked_source_ips_2
+  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/4fa21e780fccf5a1"
+}
+
+import {
+  to = aws_lb_listener_rule.blocked_source_ips_3
+  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/46780b135a3a4302"
+}
+
+import {
+  to = aws_lb_listener_rule.blocked_source_ips_4
+  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/e7f0ef90383f0369"
+}

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -57,9 +57,11 @@ resource "aws_db_instance" "maindb" {
   allocated_storage = 50
 
   # Using general purpose SSD
-  storage_type   = "gp2"
-  engine         = "mysql"
-  engine_version = "8.4.6"
+  storage_type = "gp2"
+  engine       = "mysql"
+  # Track the 8.4 family rather than a pinned patch: auto_minor_version_upgrade is on
+  # below, so AWS moves the patch version on its own and a pinned value drifts.
+  engine_version = "8.4"
 
   # Required by AWS to perform a major version upgrade (8.0 -> 8.4) in place.
   allow_major_version_upgrade = false

--- a/terraform/metabase/main.tf
+++ b/terraform/metabase/main.tf
@@ -75,7 +75,7 @@ resource "aws_lb_listener_certificate" "main" {
 
 resource "aws_lb_listener_rule" "main" {
   listener_arn = var.listener_https.arn
-  priority     = 6
+  priority     = 13
 
   action {
     type             = "forward"

--- a/terraform/planningalerts/load-balancer.tf
+++ b/terraform/planningalerts/load-balancer.tf
@@ -24,7 +24,8 @@ resource "aws_lb_listener_rule" "redirect-http-to-https" {
 
 resource "aws_lb_listener_rule" "redirect-https-to-canonical" {
   listener_arn = var.listener_https.arn
-  priority     = 1
+  # Priorities 1-4 are the blocked source IP rules, see terraform/blocked-source-ips.tf
+  priority = 10
 
   action {
     type = "redirect"
@@ -44,7 +45,7 @@ resource "aws_lb_listener_rule" "redirect-https-to-canonical" {
 
 resource "aws_lb_listener_rule" "main-https-redirect-sitemaps" {
   listener_arn = var.listener_https.arn
-  priority     = 2
+  priority     = 11
 
   action {
     type = "redirect"
@@ -75,7 +76,7 @@ resource "aws_lb_listener_rule" "main-https-redirect-sitemaps" {
 
 resource "aws_lb_listener_rule" "forward" {
   listener_arn = var.listener_https.arn
-  priority     = 5
+  priority     = 12
 
   action {
     type = "forward"

--- a/terraform/righttoknow/staging.tf
+++ b/terraform/righttoknow/staging.tf
@@ -7,9 +7,10 @@ resource "aws_instance" "staging" {
   key_name      = "terraform"
 
   tags = {
-    Name        = "righttoknow-staging"
-    Environment = "staging"
-    Purpose     = "Ubuntu 22.04 Staging Server"
+    Name         = "righttoknow-staging"
+    Environment  = "staging"
+    Purpose      = "Ubuntu 22.04 Staging Server"
+    AnsibleGroup = "righttoknow_staging"
   }
 
   # Increase root volume size to 20GB to allow for more packages and data


### PR DESCRIPTION
## Description

Records in Terraform a set of changes that were made directly in the AWS console during an emergency, so that config and live infrastructure describe the same thing again.

The console changes were four ALB listener rules that block ten source IP ranges with a `403 Forbidden`, sitting at priorities 1-4 on the HTTPS listener. Those are added here in `terraform/blocked-source-ips.tf`, with `import` blocks so Terraform adopts the existing rules rather than creating duplicates.

Inserting them pushed every managed listener rule down, so four priorities are corrected to match live: `redirect-https-to-canonical` 1 to 10, `main-https-redirect-sitemaps` 2 to 11, `forward` 5 to 12, and metabase's `main` 6 to 13.

Two smaller pieces of drift are also picked up. `maindb` is running MySQL 8.4.8 while config pinned 8.4.6, because `auto_minor_version_upgrade` is enabled and AWS moves the patch version by itself; config now tracks the `8.4` family instead, which is the AWS provider's [documented way](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version) to handle exactly this and stops it re-drifting at every patch. The RightToKnow staging instance had also gained an `AnsibleGroup` tag out of band, which is now in config.

## Motivation and Context

Terraform was out of sync with production after emergency console work, which means a plan could not be trusted and the next apply risked reverting the IP blocks.

A full sweep was run to find everything, not just the known changes: a `terraform plan -refresh-only` for attribute drift on managed resources, a normal plan for what Terraform would revert, and a read-only comparison of live AWS and Cloudflare API listings against state to catch resources that exist but were never in Terraform at all.

Most of the estate came back clean. All 14 security groups match state with no rule drift, all 173 Terraform-managed DNS records match Cloudflare exactly with nothing deleted, and EC2 instances, target groups, ACM certificates and the `us-east-1`/`ap-southeast-1` regions are all as described. The blast radius really was just the load balancer.

Two unrelated findings came out of the sweep and are deliberately **not** changed here, to keep this reviewable:

- #627 — the plan carries six destroys queued by earlier cleanup commits (23a8b8fc, b5cda440) that were committed but never applied. Worth reading before anyone applies this branch, since the same apply executes them.
- #628 — eight Cloudflare DNS records and three idle Elastic IPs exist in production but are not managed by Terraform.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Verified with a read-only `terraform plan` against production. Every difference attributable to the console changes is gone, and the four blocking rules now show as `will be imported` with no accompanying diff, which confirms the config matches the live rules exactly.

`make tf-check-fmt` and `make tf-validate` both pass locally.

No `terraform apply` has been run. State does not yet contain the imports, so applying this branch is still to be done deliberately.

Remaining plan output is expected and unrelated: the `aws_key_pair.deployer` replacement documented in README, plus the six destroys tracked in #627.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Notes for the reviewer

The branch name has no issue number, which departs from Conventional Branch. There was no tracked issue for this reconciliation work; #627 and #628 are follow-ups filed from it rather than its parent. Happy to renumber if you would prefer an issue raised retrospectively.

Worth a look while you are in here: `terraform/security-groups.tf` declares the VPN SSH rule as an inline `ingress` block on the `webserver` and `planningalerts` groups, while `terraform/vpn-security-groups.tf` declares the same rule again as standalone `aws_security_group_rule` resources. Terraform treats inline blocks as authoritative for the whole group, so the two representations can fight each other. It is pre-existing and did not cause drift here, so it is left alone, but it is a trap for later.

Assisted-by: Claude Code/claude-opus-5
