### PR TITLE
Split tf-plan-target/tf-apply-target's TARGET into MODULE and RESOURCE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ make letsencrypt                       # force-renew all registered LetsEncrypt 
 
 # Terraform (tf-plan/tf-apply/tf-*-target depend on tf-secrets+tf-env-check; tf-validate/tf-check-fmt need neither)
 make tf-plan / make tf-apply           # plan/apply the whole terraform/ config
-make tf-plan-target TARGET=<module>    # scope to one module, e.g. TARGET=planningalerts
+make tf-plan-target MODULE=<module>    # scope to one module, e.g. MODULE=planningalerts
+make tf-plan-target RESOURCE=<type>.<name> # scope to one resource, e.g. RESOURCE=aws_db_instance.maindb
 make tf-validate                       # tf-check-fmt + terraform validate (no 1Password/AWS access needed)
 
 make vagrant                           # install the vagrant plugin/dev certs/requirements needed before `vagrant up`

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,10 @@ help:
 	@echo "  tf-init                             Run terraform init in the terraform directory"
 	@echo "  tf-plan                             Run terraform plan in the terraform directory"
 	@echo "  tf-apply                            Run terraform apply in the terraform directory"
-	@echo "  tf-plan-target TARGET=<module>       Run terraform plan scoped to a single module"
-	@echo "  tf-apply-target TARGET=<module>      Run terraform apply scoped to a single module"
+	@echo "  tf-plan-target MODULE=<module>       Run terraform plan scoped to a single module"
+	@echo "  tf-apply-target MODULE=<module>      Run terraform apply scoped to a single module"
+	@echo "  tf-plan-target RESOURCE=<type>.<name>  Run terraform plan scoped to a single resource"
+	@echo "  tf-apply-target RESOURCE=<type>.<name> Run terraform apply scoped to a single resource"
 	@echo "  update-github-ssh-keys              Update SSH keys on all servers from GitHub"
 	@echo "  vagrant                             Install vagrant plugins and ensure requirements are present"
 	@echo ""
@@ -91,7 +93,9 @@ help:
 	@echo "  SKIP_TAGS      Skip plays/tasks with these tags (optional, space or comma separated)"
 	@echo "  STAGE          Target stage: staging, production or all (required by check-righttoknow/apply-righttoknow only)"
 	@echo "  TAGS           Only run plays/tasks tagged with these (optional, space or comma separated)"
-	@echo "  TARGET         Terraform module name (required by tf-plan-target/tf-apply-target, will list options if not supplied)"
+	@echo "  MODULE         Terraform module name for tf-plan-target/tf-apply-target (lists options if not supplied)"
+	@echo "  RESOURCE       Terraform resource address <type>.<name> for tf-plan-target/tf-apply-target, instead of MODULE"
+	@echo "                 Find it in plan output ('  # <type>.<name> will be ...') or a 'resource \"<type>\" \"<name>\" {' block"
 
 setup:
 	sudo apt install parallel jq direnv
@@ -270,19 +274,31 @@ tf-check-fmt:
 	@echo "PASSED tf-check-fmt!"
 
 check-target:
-ifndef TARGET
-	@echo "ERROR: TARGET is not set! Available targets are:"
-	@ls -1 terraform/ | grep -E '^[a-z]' | grep -v '\.tf$$' | sed 's/^/  /'
+ifdef MODULE
+ifdef RESOURCE
+	@echo "ERROR: Set only one of MODULE or RESOURCE, not both!"
 	@exit 1
 endif
+endif
+ifndef MODULE
+ifndef RESOURCE
+	@echo "ERROR: MODULE or RESOURCE must be set! Available modules are:"
+	@ls -1 terraform/ | grep -E '^[a-z]' | grep -v '\.tf$$' | sed 's/^/  /'
+	@echo "Or set RESOURCE=<type>.<name> for a single resource, e.g. RESOURCE=aws_db_instance.maindb"
+	@echo "  Find <type>.<name> in plan output ('  # <type>.<name> will be ...') or a 'resource \"<type>\" \"<name>\" {' block in a .tf file"
+	@exit 1
+endif
+endif
+
+TF_TARGET := $(if $(MODULE),module.$(MODULE),$(RESOURCE))
 
 tf-plan-target: check-target tf-secrets tf-env-check .make/terraform
-	terraform -chdir=terraform plan -target=module.$(TARGET)
+	terraform -chdir=terraform plan -target=$(TF_TARGET)
 
 tf-apply-target: check-target tf-secrets tf-env-check .make/terraform
-	bin/tag-provisioning --wip terraform "$(TARGET)" "" ""
-	terraform -chdir=terraform apply -target=module.$(TARGET)
-	bin/tag-provisioning terraform "$(TARGET)" "" ""
+	bin/tag-provisioning --wip terraform "$(TF_TARGET)" "" ""
+	terraform -chdir=terraform apply -target=$(TF_TARGET)
+	bin/tag-provisioning terraform "$(TF_TARGET)" "" ""
 
 stage_required:
 ifndef STAGE


### PR DESCRIPTION
## Description

Split `tf-plan-target`/`tf-apply-target`'s `TARGET` variable into two, each with a specific meaning:

- `MODULE=<module>` keeps today's behaviour (prefixed with `module.`), e.g. `MODULE=righttoknow`.
- `RESOURCE=<type>.<name>` targets a single resource address directly, e.g. `RESOURCE=aws_db_instance.maindb`.

`check-target` now errors if both or neither are set, with a hint on where to find a resource's `<type>.<name>` address (plan output or a `resource "<type>" "<name>" {` block). `make help` and AGENTS.md's command reference are updated to match.

This was used to update the `aws_db_instance.maindb ` resource.

This is a step in the process of validating the change to SSM as part of implementing:
* https://github.com/openaustralia/infrastructure/issues/558

## Motivation and Context

`TARGET` previously always meant a module name, prefixed with `module.`. There was no way to scope a plan/apply to an individual resource that isn't inside any module — e.g. `aws_db_instance.maindb`, which came up while working through the `feature/558-add-ssm-instance-policy-to-righttoknow-staging` plan drift on #576.

```
Terraform will perform the following actions:

  # aws_db_instance.maindb will be updated in-place
  ~ resource "aws_db_instance" "maindb" {
      ~ allow_major_version_upgrade           = true -> false
      ~ apply_immediately                     = true -> false
        id                                    = "maindb"
        name                                  = null
        tags                                  = {}
        # (63 unchanged attributes hidden)
    }
```

Stacked on top of #631 (bump `engine_version` to 8.4.8) rather than `main`, since it was developed alongside that work, and was part of handling existing plan drift before introducing intentional changes.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system (dry-run of `check-target`/`tf-plan-target`/`tf-apply-target` with `MODULE` set, `RESOURCE` set, both set, and neither set; confirmed `make help` renders cleanly)

Checked RESOURCE by planning and applying a single update:
```
ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-plan-target RESOURCE=aws_db_instance.maindb
terraform -chdir=terraform plan -target=aws_db_instance.maindb
...

Terraform will perform the following actions:

  # aws_db_instance.maindb will be updated in-place
  ~ resource "aws_db_instance" "maindb" {
      ~ allow_major_version_upgrade           = true -> false
      ~ apply_immediately                     = true -> false
        id                                    = "maindb"
        name                                  = null
        tags                                  = {}
        # (63 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

──────────────────────────────────────────────────────
Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.

ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-apply-target RESOURCE=aws_db_instance.maindb
bin/tag-provisioning --wip terraform "aws_db_instance.maindb" "" ""
...
terraform -chdir=terraform apply -target=aws_db_instance.maindb
...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_db_instance.maindb will be updated in-place
  ~ resource "aws_db_instance" "maindb" {
      ~ allow_major_version_upgrade           = true -> false
      ~ apply_immediately                     = true -> false
        id                                    = "maindb"
        name                                  = null
        tags                                  = {}
        # (63 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_db_instance.maindb: Modifying... [id=maindb]
...
aws_db_instance.maindb: Modifications complete after 1m21s [id=maindb]
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command to verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

...
bin/tag-provisioning terraform "aws_db_instance.maindb" "" ""
...

ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-plan
terraform -chdir=terraform plan
... <refreshing state> ...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

Terraform will perform the following actions:

(aws_db_instance.maindb is no longer listed as needing to be changed, but the remaining entries are still present as expected)

  # aws_iam_instance_profile.cloudwatch_logging_and_ssm will be destroyed
  # (because aws_iam_instance_profile.cloudwatch_logging_and_ssm is not in configuration)
  - resource "aws_iam_instance_profile" "cloudwatch_logging_and_ssm" {
      - arn         = "arn:aws:iam::924104513718:instance-profile/cloudwatch-logging-and-ssm" -> null
      - create_date = "2026-07-17T14:59:01Z" -> null
...
```

Checked MODULE by planning and applying a module update (reverting a change I was testing for a future PR):
```
ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-plan-target MODULE=righttoknow
terraform -chdir=terraform plan -target=module.righttoknow
...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.righttoknow.aws_instance.staging will be updated in-place
  ~ resource "aws_instance" "staging" {
      ~ iam_instance_profile                 = "cloudwatch-logging-and-ssm" -> "logging"
        id                                   = "i-04885b2749bc99213"
      ~ tags                                 = {
          - "AnsibleGroup" = "righttoknow_staging" -> null
            "Environment"  = "staging"
            "Name"         = "righttoknow-staging"
            "Purpose"      = "Ubuntu 22.04 Staging Server"
        }
      ~ tags_all                             = {
          - "AnsibleGroup" = "righttoknow_staging" -> null
            # (3 unchanged elements hidden)
        }
        # (35 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

──────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.

ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-apply-target MODULE=righttoknow
bin/tag-provisioning --wip terraform "module.righttoknow" "" ""
...
terraform -chdir=terraform apply -target=module.righttoknow
...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.righttoknow.aws_instance.staging will be updated in-place
  ~ resource "aws_instance" "staging" {
      ~ iam_instance_profile                 = "cloudwatch-logging-and-ssm" -> "logging"
        id                                   = "i-04885b2749bc99213"
      ~ tags                                 = {
          - "AnsibleGroup" = "righttoknow_staging" -> null
            "Environment"  = "staging"
            "Name"         = "righttoknow-staging"
            "Purpose"      = "Ubuntu 22.04 Staging Server"
        }
      ~ tags_all                             = {
          - "AnsibleGroup" = "righttoknow_staging" -> null
            # (3 unchanged elements hidden)
        }
        # (35 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.righttoknow.aws_instance.staging: Modifying... [id=i-04885b2749bc99213]
module.righttoknow.aws_instance.staging: Still modifying... [id=i-04885b2749bc99213, 00m10s elapsed]
module.righttoknow.aws_instance.staging: Modifications complete after 12s [id=i-04885b2749bc99213]
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command to verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

...
bin/tag-provisioning terraform "module.righttoknow" "" ""
...

ianh@ben:.../infrastructure (feature/tf-apply-targ)$ make tf-plan-target MODULE=righttoknow
terraform -chdir=terraform plan -target=module.righttoknow
...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

```

Checked it detects both set and outputs a reasonable message:
```
$ make tf-plan-target MODULE=righttoknow RESOURCE=aaa.bbb
ERROR: Set only one of MODULE or RESOURCE, not both!
make: *** [Makefile:280: check-target] Error 1
```

Checked if neither is set it outputs useful help:
```
ianh@ben:.../infrastructure (feature/tf-apply-targ)$->(2) make tf-plan-target
ERROR: MODULE or RESOURCE must be set! Available modules are:
  activestorage-s3
  aws-certificate
  campaign-monitor
  cuttlefish
  docs-internal
  metabase
  morph
  oaf
  openaustralia
  planningalerts
  prepkey.sh
  proxy
  raisely
  righttoknow
  secrets.auto.tfvars
  secrets.auto.tfvars.tmpl
  social
  theyvoteforyou
  vpn-user-data.sh
Or set RESOURCE=<type>.<name> for a single resource, e.g. RESOURCE=aws_db_instance.maindb
  Find <type>.<name> in plan output ('  # <type>.<name> will be ...') or a 'resource "<type>" "<name>" {' block in a .tf file
make: *** [Makefile:289: check-target] Error 1
```

Checked make [help] is helpful:
```
Available targets
...
  tf-plan-target MODULE=<module>       Run terraform plan scoped to a single module
  tf-apply-target MODULE=<module>      Run terraform apply scoped to a single module
  tf-plan-target RESOURCE=<type>.<name>  Run terraform plan scoped to a single resource
  tf-apply-target RESOURCE=<type>.<name> Run terraform apply scoped to a single resource
...

Extra vars:
...
  MODULE         Terraform module name for tf-plan-target/tf-apply-target (lists options if not supplied)
  RESOURCE       Terraform resource address <type>.<name> for tf-plan-target/tf-apply-target, instead of MODULE
                 Find it in plan output ('  # <type>.<name> will be ...') or a 'resource "<type>" "<name>" {' block

```


- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

This PR description was drafted with Claude Code (claude-sonnet-5) assistance, reviewed by @ianheggie-oaf before submission.
