### PR TITLE
Update the remaining servers to use the cloudwatch_logging_and_ssm instance profile

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,7 @@ module "docs-internal" {
 
 module "planningalerts" {
   source           = "./planningalerts"
-  instance_profile = aws_iam_instance_profile.logging
+  instance_profile = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   # Not sure if it's better to pass this in or whether this module should just make its own version of it
   security_group_incoming_email = aws_security_group.incoming_email
   deployer_key                  = aws_key_pair.deployer
@@ -42,7 +42,7 @@ module "theyvoteforyou" {
   deployer_key           = aws_key_pair.deployer
   security_group         = aws_security_group.webserver
   security_group_service = aws_security_group.theyvoteforyou
-  instance_profile       = aws_iam_instance_profile.logging
+  instance_profile       = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   cloudflare_account_id  = var.cloudflare_account_id
 }
 
@@ -66,7 +66,7 @@ module "morph" {
 module "metabase" {
   source                   = "./metabase"
   security_group_behind_lb = aws_security_group.planningalerts
-  instance_profile         = aws_iam_instance_profile.logging
+  instance_profile         = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   ami                      = var.ubuntu_22_ami
   zone_id                  = cloudflare_zone.oaf_org_au.id
   load_balancer            = aws_lb.main
@@ -78,7 +78,7 @@ module "openaustralia" {
   source                   = "./openaustralia"
   security_group_webserver = aws_security_group.webserver
   security_group_service   = aws_security_group.openaustralia
-  instance_profile         = aws_iam_instance_profile.logging
+  instance_profile         = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   ami                      = var.ubuntu_16_ami
   ubuntu_22_ami            = var.ubuntu_22_ami
   ubuntu_24_ami            = var.ubuntu_24_ami
@@ -109,7 +109,7 @@ module "raisely" {
 module "proxy" {
   source           = "./proxy"
   ami              = var.ubuntu_16_ami
-  instance_profile = aws_iam_instance_profile.logging
+  instance_profile = aws_iam_instance_profile.cloudwatch_logging_and_ssm
   zone_id          = cloudflare_zone.oaf_org_au.id
 }
 


### PR DESCRIPTION
## Description

Switch the remaining EC2 modules that take an `instance_profile` (planningalerts, theyvoteforyou, metabase, openaustralia, proxy) from `aws_iam_instance_profile.logging` to `aws_iam_instance_profile.cloudwatch_logging_and_ssm`, the same profile validated on righttoknow staging and production in #576. `cuttlefish`, `docs-internal`, `morph`, `oaf`, `campaign-monitor`, `raisely` and `social` don't take an `instance_profile` at all, so nothing to change there.

This is a step in the process of  SSM rollout, stacked on top of PR #576, providing an alternative to ssh for manual access, requiring MFA and convenient on mobiles and tablets.
*  https://github.com/openaustralia/infrastructure/issues/558

## Motivation and Context

#576 validated `cloudwatch_logging_and_ssm` on righttoknow (staging and production): SSH and SSM Session Manager both work, and a production Rails console session was confirmed working over SSM. This PR extends the same profile to every other server so SSM access works fleet-wide, per:
* https://github.com/openaustralia/infrastructure/issues/558

## Installation

NOTE - This is based on output from `make tf-plan` to get the resources to be updated whilst ignoring changes from hotfix #629 (yet to be merged at this time)

Recommenced installation approach:

1. Check planned changes only change:
```
~ iam_instance_profile                 = "logging" -> "cloudwatch-logging-and-ssm"
```
When you run:
```
make tf-plan-target RESOURCE=module.metabase.aws_instance.main
make tf-plan-target RESOURCE=module.openaustralia.aws_instance.main
make tf-plan-target RESOURCE=module.openaustralia.aws_instance.production
make tf-plan-target RESOURCE=module.proxy.aws_instance.main
make tf-plan-target RESOURCE=module.theyvoteforyou.aws_instance.main
make tf-plan-target RESOURCE=module.planningalerts.module.blue.aws_instance.main
```

2. Apply changes if they are as expected:
```
make tf-apply-target RESOURCE=module.metabase.aws_instance.main
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
make tf-apply-target RESOURCE=module.openaustralia.aws_instance.main
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
make tf-apply-target RESOURCE=module.openaustralia.aws_instance.production
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
make tf-apply-target RESOURCE=module.proxy.aws_instance.main
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
make tf-apply-target RESOURCE=module.theyvoteforyou.aws_instance.main
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
make tf-apply-target RESOURCE=module.planningalerts.module.blue.aws_instance.main
# Reboot instance and confirm you can connect via SSM on EC2 web dashboard
```

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system 
  * ran `make tf-plan` and checked expected Plan matched what I had already tested in
    * https://github.com/openaustralia/infrastructure/pull/576
  
- [ ] Ran automated tests on my own system `make lint`
- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) (No, functionality was added but not removed)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

This PR description was drafted with Claude Code (claude-sonnet-5) assistance, reviewed by @ianheggie-oaf before submission.
