### PR TITLE
Bootstrap ~/.aws/config oaf/oaf-legacy profiles from aws-check; sync docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,11 @@ it.
   Ruby/Python/PHP versions.
 - Ansible Vault passphrases and AWS/Terraform state creds come from the OAF 1Password account (id in
   `bin/.op-account`; sign in with `op signin --account "$(cat bin/.op-account)"`), fetched via
-  `bin/ansible-vault-client`. AWS and Google credentials are your own CLI config — whatever gets `aws sts
-  get-caller-identity`/`gcloud auth application-default print-access-token` working (`aws configure`,
-  `aws configure sso`, `AWS_PROFILE`, `gcloud auth application-default login`) — no specific profile is required
-  today; not stored here.
+  `bin/ansible-vault-client`. AWS and Google credentials are your own CLI config, not stored here: `aws login`
+  (browser-based, MFA) against the `oaf` profile, with Terraform/Ansible reading through `oaf-legacy`, which
+  bridges to that session via `credential_process` — see README "CLI tools for credentials" for the `~/.aws/config`
+  setup. `aws sso login`/`aws configure` are no longer recommended (no MFA, long-lived creds on disk). Google via
+  `gcloud auth application-default login`.
 - `make requirements` — sets up the Python venv, installs ansible-galaxy roles/collections, checks 1Password.
 - `make tf-secrets` — renders `terraform/secrets.auto.tfvars` from 1Password (RDS admin password, Cloudflare/Linode
   API tokens) before any `tf-*` target.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "  all                                 Run full site.yml playbook against all hosts"
 	@echo "  requirements                        Install requirements: venv, roles, collections, terraform.pem and check required commands"
 	@echo "  op-check                            Fail if not signed into the OAF 1Password account"
-	@echo "  aws-check                           Fail if aws-cli or the Session Manager plugin aren't installed and recent enough"
+	@echo "  aws-check                           Fail if aws-cli/Session Manager plugin missing; bootstrap ~/.aws/config oaf/oaf-legacy profiles"
 	@echo "  terraform.pem                       Materialise terraform.pem from 1Password"
 	@echo "  tf-secrets                          Render terraform/secrets.auto.tfvars from 1Password via op inject"
 	@echo "  tf-env-check                        Warn (non-fatal) if AWS or gcloud credentials aren't reachable"
@@ -125,6 +125,11 @@ op-check:
 #     --document-name AWS-StartSSHSession --parameters 'portNumber=%p'" ...
 # Checked in this order (aws first, plugin second) since the plugin is useless
 # without the CLI, and reporting the more fundamental problem first is clearer.
+# Also bootstraps ~/.aws/config: both [profile oaf-legacy] and [profile oaf] are only ever written
+# to if missing, never overwritten - so if either was customised for some unexpected reason, that
+# customisation is left alone. [profile oaf]'s login_session ARN is operator-specific, so its
+# bootstrapped value is a placeholder you're expected to edit with your own username; see README
+# "CLI tools for credentials".
 aws-check:
 	@if command -v aws >/dev/null 2>&1; then \
       if aws --version 2>&1 | grep -qE 'aws-cli/2\.(3[2-9]|[4-9][0-9]|[1-9][0-9][0-9])'; then \
@@ -145,6 +150,21 @@ aws-check:
 	  echo "  Install: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" >&2; \
 	  echo "For MacOS users, install using brew: brew install session-manager-plugin" >&2; \
 	  exit 1; \
+	fi
+	@if aws configure get login_session --profile oaf >/dev/null 2>&1; then \
+	  echo "OK: [profile oaf] already has a login_session set"; \
+	else \
+	  aws configure set region ap-southeast-2 --profile oaf; \
+	  aws configure set login_session "arn:aws:iam::924104513718:user/REPLACE_ME" --profile oaf; \
+	  echo "WARN: [profile oaf] had no login_session - added a placeholder in ~/.aws/config." >&2; \
+	  echo "  Edit it with your own IAM username, then run: aws login --profile oaf" >&2; \
+	fi
+	@if aws configure get credential_process --profile oaf-legacy >/dev/null 2>&1; then \
+	  echo "OK: [profile oaf-legacy] already configured"; \
+	else \
+	  aws configure set region ap-southeast-2 --profile oaf-legacy; \
+	  aws configure set credential_process "aws configure export-credentials --profile oaf --format process" --profile oaf-legacy; \
+	  echo "OK: [profile oaf-legacy] configured in ~/.aws/config (bridges 'aws login --profile oaf' for Terraform/Ansible)"; \
 	fi
 
 # Materialise terraform.pem from 1Password. The script is idempotent

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ configuration. The Cloudflare and Linode provider tokens are the exception: they
   Install using the official
   [Installing or updating to the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   instructions.
-    - We recommend you sign in with [`aws login`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html)
+    - We recommend you sign in with [`aws login --profile oaf`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html)
       which uses a browser-based authentication flow (supporting MFA) to provide temporary credentials.
     - Terraform doesn't understand its `login_session` credentials directly yet, so bridge them by editing
       `~/.aws/config`:
@@ -290,7 +290,7 @@ configuration. The Cloudflare and Linode provider tokens are the exception: they
     - The `oaf` profile's `login_session` ARN has the OAF account ID (`924104513718`) baked in, so if you ever sign
       in to a different AWS account, `aws login --profile oaf` will notice the mismatch and ask you to confirm before
       overwriting it — a safety net against authenticating against the wrong account.
-  - We no longer recommend:
+  - We no longer support (because we use oaf-legacy profile):
     - `aws sso login` as it has a more complicated setup,
     - `aws configure`, or AWS vars in dotenv's `.envrc` file as these long-lived credentials do not use MFA and are
       stored on the local file system in plain text.


### PR DESCRIPTION
## Description

`aws-check` now bootstraps `~/.aws/config`'s `[profile oaf]` and `[profile oaf-legacy]` if either is missing, checked in that order (`oaf-legacy`'s `credential_process` depends on `oaf`). Neither is touched if already present, so any existing customisation is left alone; `oaf`'s bootstrapped `login_session` is a placeholder (`user/REPLACE_ME`) since the real ARN is operator-specific.

Also brings AGENTS.md's AWS setup guidance in line with README's already-documented `aws login --profile oaf` approach, plus a couple of small README wording tweaks.

## Motivation and Context

Manually editing `~/.aws/config` by hand from the README instructions is easy to get wrong. Automating the generic part (`oaf-legacy`) and bootstrapping a fail-fast placeholder for the operator-specific part (`oaf`) reduces onboarding friction without risking an operator's existing config: `aws login --profile oaf` itself catches an unedited placeholder and asks for confirmation before overwriting it, since the ARN won't match.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system — backed up and deleted my own `oaf`/`oaf-legacy` profiles, ran `make aws-check`, confirmed both were bootstrapped correctly (placeholder for `oaf`, real values for `oaf-legacy`), then ran `aws login --profile oaf` and confirmed it prompted about the ARN mismatch as expected. Re-ran `make aws-check` afterwards and confirmed both now report "already configured".
- [ ] Ran automated tests on my own system `make lint`
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

This PR description was drafted with Claude Code (claude-sonnet-5) assistance, reviewed by @ianheggie-oaf before submission.
