### PR TITLE
Update Ruby version for Right to Know Staging to 3.4.10

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for righttoknow
-ruby_version_staging: 3.2.9
+ruby_version_staging: 3.4.10
 ruby_version_production: 3.2.9
 
 # Keep in step with `BUNDLED WITH` in Alaveteli's Gemfile.lock. An older bundler


### PR DESCRIPTION
## Description
Update the `ruby_version_staging` to 3.4.10 in the defaults configuration for the Right to Know project.

## Motivation and Context

This change is required to ensure compatibility with the latest features and improvements in Ruby 3.4.10.

Related to https://github.com/openaustralia/righttoknow/issues/1045

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):
N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

