### PR TITLE
Remove the spent blocked source IP import blocks

### DIFF
--- a/terraform/blocked-source-ips.tf
+++ b/terraform/blocked-source-ips.tf
@@ -8,9 +8,6 @@
 # The grouping of CIDRs across the four rules matches what was created in the console.
 # Each ALB rule condition allows a limited number of values, so ranges were added in
 # batches as they were identified.
-#
-# The `import` blocks below adopt the existing rules into Terraform state rather than
-# creating new ones. They are a no-op once applied and can be deleted after that.
 
 resource "aws_lb_listener_rule" "blocked_source_ips_1" {
   listener_arn = aws_lb_listener.main-https.arn
@@ -108,24 +105,4 @@ resource "aws_lb_listener_rule" "blocked_source_ips_4" {
       ]
     }
   }
-}
-
-import {
-  to = aws_lb_listener_rule.blocked_source_ips_1
-  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/ee1f77e92714910e"
-}
-
-import {
-  to = aws_lb_listener_rule.blocked_source_ips_2
-  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/4fa21e780fccf5a1"
-}
-
-import {
-  to = aws_lb_listener_rule.blocked_source_ips_3
-  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/46780b135a3a4302"
-}
-
-import {
-  to = aws_lb_listener_rule.blocked_source_ips_4
-  id = "arn:aws:elasticloadbalancing:ap-southeast-2:924104513718:listener-rule/app/main/849a14c4221ca5aa/72e3742ac1d27ba5/e7f0ef90383f0369"
 }


### PR DESCRIPTION
## Description

Removes the four `import` blocks from `terraform/blocked-source-ips.tf`, along with the paragraph of the header comment describing them. The rest of the comment stays: it explains why the rules exist and that they should be removed deliberately rather than by accident, which is still true.

This is a zero-diff change. `terraform plan` produces identical output before and after, because an `import` block for a resource already in state is a no-op. The 23-line deletion looks larger than its effect.

The four ALB listener rules blocking abusive source IP ranges are now in Terraform state. They were imported individually before this branch was opened, with `make tf-apply-target RESOURCE=aws_lb_listener_rule.blocked_source_ips_<n>` for each of 1 to 4. Each reported `Apply complete! Resources: 1 imported, 0 added, 0 changed, 0 destroyed.` No live infrastructure was touched at any point; only Terraform's record of it changed. Tags `terraform_20260812021429_aws_lb_listener_rule-blocked_source_ips_1` through `terraform_20260812021604_aws_lb_listener_rule-blocked_source_ips_4` bracket those four runs.

## Motivation and Context

`make tf-plan` was still reporting all four rules as "will be imported", months after #629 was meant to have settled that.

The config was never the problem. It matched live AWS exactly. An `import` block is a plan-time declaration that only takes effect when `terraform apply` runs, and #629 deliberately shipped without an apply, saying so explicitly in its own description. Every apply since it merged on 10 August was scoped with `-target`, at a module or at `aws_db_instance.maindb`, which kept these root-level resources out of the plan entirely. No untargeted `make tf-apply` had been run, because that would also carry the unrelated pending changes.

So the imports simply had not been executed. Running them scoped to the four rules individually got them into state without touching anything else, and this PR clears up the now-spent blocks.

Ordering matters if anyone revisits this pattern: the import blocks could not be removed before the imports landed in state. Doing it the other way round turns "will be imported" into "will be created", and the apply then fails with `PriorityInUse` against the live rules sitting at priorities 1 to 4.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

`make tf-plan-target RESOURCE=aws_lb_listener_rule.blocked_source_ips_<n>` for each of the four rules, before applying, each returning `Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.` with `aws_lb.main` and `aws_lb_listener.main-https` refreshing clean and contributing no diff of their own. That confirmed each apply would be state-only, and that the four hardcoded rule ARNs captured on 10 August still resolved.

After the imports and this change, an untargeted `make tf-plan` shows the four rules only refreshing, with no diff of any kind. That is the actual test that the drift is gone.

`make tf-validate` and `make tf-check-fmt` both pass.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

Housekeeping. It removes configuration that has already done its work, and changes no behaviour.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes for the reviewer

Two unrelated things showed up in the plan while verifying this, both left alone here.

`aws_db_instance.maindb` still wants `engine_version` changed from `8.4.8` to the `8.4` family prefix on every plan, even though #629 applied exactly that fix on 10 August (tag `terraform_20260810131429_aws_db_instance-maindb`). The version-prefix approach does not appear to suppress the perpetual diff on AWS provider 4.62, contrary to what #629 expected. Similarly, `module.righttoknow.aws_instance.staging` wants to swap its `AnsibleGroups` and `PublicHostname` tags for a single `AnsibleGroup`, having drifted back after being applied. Both look worth an issue.

More positively, #627 may now be closable. The six queued destroys it tracks no longer appear in the plan, and the module-targeted applies on 11 August look to have executed them. The remaining `1 to add, 1 to destroy` is entirely the `aws_key_pair.deployer` replacement documented in the README. Worth confirming against the tags before closing it.

The branch name carries no issue number, as with #629. There is no tracked issue for finishing that reconciliation work.

Parts of this contribution were generated or assisted by Claude Code (claude-opus-5). I have reviewed all of it.
