### PR TITLE
DRY instance profiles using reusable service-instance-role module for per-service IAM roles

### DIFF
--- a/terraform/service-instance-role/main.tf
+++ b/terraform/service-instance-role/main.tf
@@ -1,0 +1,60 @@
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = var.service_name
+  description        = "EC2 instances for ${var.service_name}: CloudWatch Logs and SSM Session Manager access"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_logging" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch_logging" {
+  role   = aws_iam_role.this.name
+  name   = "cloudwatch-logging"
+  policy = data.aws_iam_policy_document.cloudwatch_logging.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "extra" {
+  count  = var.extra_policy_json == null ? 0 : 1
+  role   = aws_iam_role.this.name
+  name   = "${var.service_name}-extra"
+  policy = var.extra_policy_json
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${var.service_name}-instance-profile"
+  role = aws_iam_role.this.name
+}

--- a/terraform/service-instance-role/outputs.tf
+++ b/terraform/service-instance-role/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_profile" {
+  value = aws_iam_instance_profile.this
+}
+
+output "role" {
+  value = aws_iam_role.this
+}

--- a/terraform/service-instance-role/variables.tf
+++ b/terraform/service-instance-role/variables.tf
@@ -1,0 +1,10 @@
+variable "service_name" {
+  description = "Used as the IAM role name and to derive the instance profile name (\"<service_name>-instance-profile\")"
+  type        = string
+}
+
+variable "extra_policy_json" {
+  description = "Extra inline policy document JSON to attach on top of the CloudWatch Logs/SSM baseline (e.g. from aws_iam_policy_document), or null for none"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

- New generic Terraform module `terraform/service-instance-role/` (`service_name` + optional
  `extra_policy_json`) granting the standard CloudWatch Logs + SSM Session Manager baseline any EC2 service
  role needs, plus one optional extra inline policy.
- Not wired up to anything yet in this PR - planningalerts and righttoknow (later in this stack) are the
  first consumers, each getting their own dedicated role instead of bolting extra permissions onto the shared
  `cloudwatch_logging_and_ssm` role, which has its own "create a new role rather than edit this one in place"
  convention (`terraform/cloudwatch-logging-and-ssm-instance-profile.tf`).

## Motivation

Part of https://github.com/openaustralia/infrastructure/issues/312 (the Cloudflare WAF migration epic), via
the branch stack progressing https://github.com/openaustralia/oaf-internal/issues/266 (Cloudflare Tunnel
migration for PlanningAlerts) - both the planningalerts and righttoknow-staging tunnel work (#646 and #645)
need a dedicated IAM role scoped to just their own SSM parameters (tunnel tokens), and this module is what
makes that a few lines per service instead of duplicated boilerplate each time.

## AI involvement

Drafted with Claude Code (claude-sonnet-5) - see the `Assisted-by` trailer on the commit for the full
disclosure trailer.

## Test plan

- [x] `make tf-check-fmt` passes. CI (`gh pr checks`) is green.
- [ ] `make tf-validate` currently fails from this branch onward - not this branch's own fault, see
      note below.
- [ ] Confirmed working in practice via the two downstream PRs later in this stack (#645, #646), which both
      consume it.

Note: `make tf-validate`/`tf-plan`/`tf-apply` fail repo-wide from this branch onward because it's
stacked on top of #650, which has an unrelated regression (breaks the `cloudflare` provider
resolution for the whole repo - see that PR's "Known issue found via testing"). Confirmed this
branch's own diff isn't the cause: the failure reproduces identically on #650 itself, which this
branch doesn't touch.

---

Retargeted base from `feature/ansible-via-ssm-for-staging-righttoknow` to `feature/remove-make-check-oaf-apply-oaf` to reflect where this branch actually sits in the stack.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


