### PR TITLE
Wire up Alaveteli's Varnish cache invalidation

### DIFF
--- a/roles/internal/righttoknow/files/default.vcl
+++ b/roles/internal/righttoknow/files/default.vcl
@@ -58,12 +58,13 @@ sub vcl_recv {
        req.method != "POST" &&
        req.method != "PUT" &&
        req.method != "PURGE" &&
+       req.method != "BAN" &&
        req.method != "DELETE" ) {
         # We don't allow any other methods.
         return (synth(405, "Method Not Allowed"));
     }
 
-    if (req.method != "GET" && req.method != "HEAD" && req.method != "PURGE") {
+    if (req.method != "GET" && req.method != "HEAD" && req.method != "PURGE" && req.method != "BAN") {
         /* We only deal with GET and HEAD by default, the rest get passed direct to backend */
         return (pass);
     }
@@ -94,6 +95,11 @@ sub vcl_recv {
          return (synth(405, "Not allowed."));
       }
 
+      # Alaveteli's NotifyCacheJob sends its requests through Varnish as an
+      # HTTP proxy, so the request line carries an absolute URI. Strip the
+      # scheme and host so the ban pattern matches the path stored in x-url.
+      set req.url = regsub(req.url, "^https?://[^/]+", "");
+
       # For an explanation of the following roundabout way of defining
       # ban lists, see
       # http://kristianlyng.wordpress.com/2010/07/28/smart-bans-with-varnish/
@@ -101,6 +107,22 @@ sub vcl_recv {
       # TODO: in Varnish 2.x, the following would be
       # purge("obj.http.x-url ~ " req.url);
       ban("obj.http.x-url ~ " + req.url);
+      return (synth(200, "Banned"));
+    }
+
+    # Handle BAN requests. Alaveteli sends these (instead of PURGE) for the
+    # pattern entries in its cached_urls lists, with the pattern in the
+    # X-Invalidate-Pattern header.
+    if (req.method == "BAN") {
+      if (!client.ip ~ purge) {
+         return (synth(405, "Not allowed."));
+      }
+
+      if (!req.http.X-Invalidate-Pattern) {
+         return (synth(400, "X-Invalidate-Pattern header required"));
+      }
+
+      ban("obj.http.x-url ~ " + req.http.X-Invalidate-Pattern);
       return (synth(200, "Banned"));
     }
     return (hash);

--- a/roles/internal/righttoknow/files/varnish.service
+++ b/roles/internal/righttoknow/files/varnish.service
@@ -6,7 +6,7 @@ Documentation=https://www.varnish-cache.org/docs/4.1/ man:varnishd
 Type=simple
 LimitNOFILE=131072
 LimitMEMLOCK=82000
-ExecStart=/usr/sbin/varnishd -j unix,user=vcache -F -a :80 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
+ExecStart=/usr/sbin/varnishd -j unix,user=vcache -F -a :80 -a 127.0.0.1:6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
 ExecReload=/usr/share/varnish/reload-vcl
 ProtectSystem=full
 ProtectHome=true

--- a/roles/internal/righttoknow/tasks/main.yml
+++ b/roles/internal/righttoknow/tasks/main.yml
@@ -431,7 +431,9 @@
     enable_alaveteli_pro: true
     enable_pro_pricing: true
     pro_referral_coupon: "{{ pro_referral_coupon_production }}"
-  notify: nginx restart
+  notify:
+    - nginx restart
+    - restart sidekiq
   when: "'righttoknow_production' in group_names"
 
 - name: Apply Alaveteli config (staging)
@@ -456,7 +458,9 @@
     enable_alaveteli_pro: true
     enable_pro_pricing: true
     pro_referral_coupon: "{{ pro_referral_coupon_staging }}"
-  notify: nginx restart
+  notify:
+    - nginx restart
+    - restart sidekiq
   when: "'righttoknow_staging' in group_names"
 
 - name: Apply Alaveteli Storage Config

--- a/roles/internal/righttoknow/templates/general.yml.j2
+++ b/roles/internal/righttoknow/templates/general.yml.j2
@@ -615,6 +615,21 @@ EXCEPTION_NOTIFICATIONS_TO:
 # ---
 MAX_REQUESTS_PER_USER_PER_DAY: 6
 
+# If you're running behind Varnish set this to work out where to send purge
+# requests. Otherwise, don't set it.
+#
+# VARNISH_HOSTS - Array of Strings (default: nil)
+#
+# Examples:
+#
+#   VARNISH_HOSTS:
+#     - host1
+#     - host2
+#
+# ---
+VARNISH_HOSTS:
+  - 127.0.0.1
+
 # Adding a value here will enable Google Analytics on all non-admin pages for
 # non-admin users.
 #


### PR DESCRIPTION
## Description

Wires up Alaveteli's Varnish cache invalidation on the Right to Know servers, which was never configured, so cache entries only ever expired on their TTL. Four changes in `roles/internal/righttoknow/`:

- **`files/varnish.service`** — add a second listen address, `-a 127.0.0.1:6081`. Alaveteli proxies its cache invalidation requests through port 6081 (Varnish's stock listen port); binding it to loopback only makes the purge port exist without exposing it.
- **`files/default.vcl`** — add a `BAN` branch alongside the existing `PURGE` handling, gated on the same `acl purge` and honouring the `X-Invalidate-Pattern` header Alaveteli sends for the pattern entries in its `cached_urls` lists (previously a `BAN` hit the method allowlist and got a 405). Also normalise absolute-form request URIs in the `PURGE` branch — Alaveteli's `NotifyCacheJob` sends via HTTP proxy form, and the ban pattern has to match the path stored in `x-url`.
- **`templates/general.yml.j2`** — set `VARNISH_HOSTS` (previously one of the few upstream keys the template omitted). With it unset, `NotifyCacheJob`'s `around_enqueue` guard meant the job was never even enqueued.
- **`tasks/main.yml`** — notify `restart sidekiq` from the two "Apply Alaveteli config" tasks, so `general.yml` changes reach the process that performs `NotifyCacheJob` (previously only nginx was restarted).

## Motivation and Context

Alaveteli marks pages cacheable for anonymous visitors on purpose and expects to evict them itself when content changes. With the invalidation half missing, applying a censor rule or hiding a request left the pre-redaction page being served to anonymous visitors until the TTL expired — up to an hour for request pages and up to 24 hours for details pages.

Resolves openaustralia/oaf-internal#348

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system (`make lint` — yamllint, template-check, ansible-lint, tf-check-fmt, tf-validate all pass)
- [x] Confirmed it passed the GitHub actions tests

Staging verification happens as part of the rollout below, after merge.

## Rollout (after merge)

Staging first, production only once staging verifies clean:

- [x] `STAGE=staging make check-righttoknow` — review dry-run diff
- [x] `STAGE=staging make apply-righttoknow` — handlers restart Varnish + Sidekiq
- [x] Restart staging Passenger so the web app picks up `VARNISH_HOSTS` (alaveteli init script — touches `tmp/restart.txt`)
- [ ] Verify on staging:
  - [ ] Anonymous fetch of a request page carries `Cache-Control: max-age=3600, public`
  - [ ] Apply a censor rule in admin → anonymous re-fetch shows the redaction immediately (no TTL wait); same check on `/request/<title>/details` (24h window)
  - [ ] Manual `curl -X PURGE -x 127.0.0.1:6081 http://<domain>/<path>` evicts a cached page (confirms proxy-form absolute URIs match after the `regsub`)
  - [ ] Manual `BAN` with `X-Invalidate-Pattern` returns 200 and evicts matching entries
  - [ ] Sidekiq log shows `NotifyCacheJob` debug lines (2xx), no "Unable to" warnings
- [ ] `STAGE=production make check-righttoknow` → `STAGE=production make apply-righttoknow`
- [ ] Restart production Passenger; repeat the censor-rule spot-check
- [ ] Report back on openaustralia/oaf-internal#348 and close

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI assistance

This change was developed with material AI assistance from Claude Code (model `anthropic.claude-fable-5`): analysis, the config/VCL changes, and this PR description. Reviewed and committed by a human.
