### PR TITLE
Drop obsolete nginx ssl directive for RTK

### DIFF
--- a/roles/internal/righttoknow/files/nginx/nginx.conf
+++ b/roles/internal/righttoknow/files/nginx/nginx.conf
@@ -39,7 +39,7 @@ http {
 	# SSL Settings
 	##
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_prefer_server_ciphers on;
 
 	##

--- a/roles/internal/righttoknow/templates/nginx/default.j2
+++ b/roles/internal/righttoknow/templates/nginx/default.j2
@@ -15,11 +15,10 @@ server {
   server_name _;
   rewrite ^/(.*) https://www.{{ righttoknow_domain }}/$1 permanent;
 
-  ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ righttoknow_domain }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ righttoknow_domain }}/privkey.pem;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers on;
   ssl_session_cache  builtin:1000  shared:SSL:10m;
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';

--- a/roles/internal/righttoknow/templates/nginx/stage.j2
+++ b/roles/internal/righttoknow/templates/nginx/stage.j2
@@ -84,11 +84,10 @@ server {
     rewrite ^/(.*) https://www.{{ domain }}/$1 permanent;
   }
 
-  ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers on;
   ssl_session_cache  builtin:1000  shared:SSL:10m;
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';
@@ -99,11 +98,10 @@ server {
   listen 443 ssl http2;
   server_name www.{{ domain }};
 
-  ssl on;
   ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.2 TLSv1.3;
   ssl_prefer_server_ciphers on;
   ssl_session_cache  builtin:1000  shared:SSL:10m;
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two related nginx changes for Right to Know, covering the three HTTPS server blocks (`templates/nginx/default.j2`, `templates/nginx/stage.j2`) and the http-level defaults in `files/nginx/nginx.conf`:

- Removes the standalone `ssl on;` directive from all three server blocks. Each already carries `listen 443 ssl http2`, so it was redundant; nginx deprecated it in 1.15.0 and removed it in 1.25.1, where it becomes a config load failure. Clearing it now means a later distro nginx bump cannot take the site down on reload.
- Narrows `ssl_protocols TLSv1 TLSv1.1 TLSv1.2` to `ssl_protocols TLSv1.2 TLSv1.3` in the server blocks and the http-level default, so a future server block without its own override inherits the modern list. TLS 1.0/1.1 are deprecated by RFC 8996. The hosts run nginx 1.18 with OpenSSL 3.0 (confirmed `nginx/1.18.0` on both live hosts, read-only check), which accepts and can negotiate TLSv1.3.

Deliberately deferred: the `http2` flag on the `listen` lines stays. The replacement `http2 on;` directive only exists from nginx 1.25.1, so switching now would break the currently shipped nginx. That follows once the fleet crosses 1.25.1.

Context for reviewers: righttoknow.org.au and www are Cloudflare-proxied, so for public traffic `ssl_protocols` here governs the Cloudflare-to-origin hop; the unproxied prod./staging. hostnames are reached directly. Upstream's `nginx-ssl.conf.example` carries the same `ssl on;` line, so this is shared debt rather than something RTK introduced. The theyvoteforyou role has the same `ssl on;` in three templates, which deserves its own follow-up.

## Motivation and Context

Item 7 of #653: forward compatibility with nginx >= 1.25.1 plus TLS hardening. Part of openaustralia/infrastructure#653.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`make yaml-lint`, `make template-check` and `ansible-lint` (CI config) pass, byte-identical to a pre-edit baseline. nginx cannot be syntax-checked locally because the rendered config and certificates only exist on the hosts; an `nginx -t` on staging after `STAGE=staging make apply-righttoknow` is the real test.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: this change was written by Claude Code (model `claude-opus-5`) as part of an orchestrated run coordinated by OpenCode (model `anthropic.claude-fable-5`), reviewed and committed by a human. See the `Assisted-by:` commit trailer.
