### PR TITLE
Sync general.yml keys with upstream examples

### DIFF
--- a/roles/internal/righttoknow/templates/general.yml.j2
+++ b/roles/internal/righttoknow/templates/general.yml.j2
@@ -466,6 +466,29 @@ SECRET_KEY_BASE: '{{ alaveteli_secret_key_base }}'
 # ---
 READ_ONLY: ''
 
+# READ_ONLY_FEATURES - Array of strings (default: [])
+#
+# Granular read-only control for specific features. This allows you to disable
+# specific functionality without putting the entire site in read-only mode.
+#
+# Available features:
+#   'annotations'     - Blocks annotations on requests
+#   'classifications' - Blocks request status classifications
+#   'followups'       - Blocks followup messages on requests
+#   'requests'        - Blocks new FOI requests
+#   'signups'         - Blocks new user registration
+#
+# Examples:
+#
+# Block only new requests:
+#   READ_ONLY_FEATURES: ['requests']
+#
+# Block new requests and annotations:
+#   READ_ONLY_FEATURES: ['requests', 'annotations']
+#
+# ---
+READ_ONLY_FEATURES: []
+
 # Is this a staging or development site? If not, it's a live production site.
 # This setting controls whether or not the rails-post-deploy script will create
 # the file config/rails_env.rb file to force Rails into production environment.
@@ -941,6 +964,13 @@ BLOCK_SPAM_ABOUT_ME_TEXT: true
 # ---
 BLOCK_SPAM_COMMENTS: true
 
+# Prevent users submitting user to user messages that appear to be spam.
+#
+# BLOCK_SPAM_USER_MESSAGES - Boolean (default: false)
+#
+# ---
+BLOCK_SPAM_USER_MESSAGES: true
+
 # Prevent user signups from spam email domains or names which appear to be spam.
 #
 # BLOCK_SPAM_SIGNUPS - Boolean (default: false)
@@ -1291,18 +1321,23 @@ SURVEY_URL: ''
 # ---
 USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 30
 
-# Background jobs are processed by Rails' ActiveJob using Sidekiq. There are
-# various ways to run Sidekiq depending to server resources and technical
-# knowledge in order to run and maintain a Redis server.
+# If ENABLE_PUBLIC_ANNOTATIONS is set to true, comments (annotations) will
+# be allowed on all requests regardless of who made the request.
 #
-# Can either be set to:
-# - 'inline' to process jobs within the web application process, this was the
-#   default option up until Alaveteli 0.42 and doesn't require Redis to be.
-#   installed. Due to issues with requests with web requests timing out this has
-#   been superseded by the other options.
-# - 'server' to process job by a server running as a system daemon.
+# If set to false, comments will only be allowed by the requester or admin
+# users.
 #
-# BACKGROUND_JOBS – String (default: 'server')
+# ENABLE_PUBLIC_ANNOTATIONS - Boolean (default: true)
 #
 # ---
-BACKGROUND_JOBS: 'server'
+ENABLE_PUBLIC_ANNOTATIONS: true
+
+# If ENABLE_USER_TO_USER_MESSAGING is set to true, Alaveteli will allow users
+# to send messages to each other through the site.
+#
+# If set to false, user-to-user messaging functionality will be disabled.
+#
+# ENABLE_USER_TO_USER_MESSAGING - Boolean (default: true)
+#
+# ---
+ENABLE_USER_TO_USER_MESSAGING: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Brings `roles/internal/righttoknow/templates/general.yml.j2` back in step with upstream Alaveteli's `general.yml-example`, comment blocks included:

- Adds `BLOCK_SPAM_USER_MESSAGES: true`. **This is a behaviour change and the one thing in this PR that needs a deliberate call**: upstream defaults it to false, the key already exists in the deployed 0.45.8, and every other `BLOCK_SPAM_*` toggle in this template is explicitly true, so it was set true to match. Flip to `false` before merging if the current behaviour should be kept instead.
- Adds three settings that arrive with 0.46.7.0, each set to the upstream default so behaviour is unchanged: `READ_ONLY_FEATURES: []` (granular read-only control, useful during a spam wave), `ENABLE_PUBLIC_ANNOTATIONS: true` and `ENABLE_USER_TO_USER_MESSAGING: true` (both moderation levers worth pinning explicitly rather than trusting a default upstream could change). Alaveteli ignores unknown `general.yml` keys, so these are safe to deploy ahead of the upgrade.
- Removes the dead `BACKGROUND_JOBS: 'server'` key and its comment block. Alaveteli removed the setting; nothing reads it.

Placement note: `BLOCK_SPAM_USER_MESSAGES` sits after `BLOCK_SPAM_COMMENTS`, matching where upstream puts it in both 0.45.8 and 0.46.7.

## Motivation and Context

Items 8, 9 and part of 12 of #653. Of 112 top-level keys in upstream's 0.45.8 example, `BLOCK_SPAM_USER_MESSAGES` was one of only two absent from this template with no recorded reason. Part of openaustralia/infrastructure#653.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

`make yaml-lint`, `make template-check` and `ansible-lint` (CI config) pass. The template was additionally parsed as YAML with the Jinja expressions neutralised: 114 keys, all four new values present and correct, `BACKGROUND_JOBS` absent.

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

(`BLOCK_SPAM_USER_MESSAGES: true` changes runtime behaviour for user-to-user messages that look like spam; everything else is behaviour-neutral.)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: this change was written by Claude Code (model `claude-opus-5`) as part of an orchestrated run coordinated by OpenCode (model `anthropic.claude-fable-5`), reviewed and committed by a human. See the `Assisted-by:` commit trailer.
