### PR TITLE
Update RTK ruby_version_production to 3.4.10

### DIFF
--- a/roles/internal/righttoknow/defaults/main.yml
+++ b/roles/internal/righttoknow/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for righttoknow
 ruby_version_staging: 3.4.10
-ruby_version_production: 3.2.9
+ruby_version_production: 3.4.10
 
 # Keep in step with `BUNDLED WITH` in Alaveteli's Gemfile.lock. An older bundler
 # in the same major series does still install the bundle (2.4.19 handles


### PR DESCRIPTION
## Description
Update the `ruby_version_production` to 3.4.10 in the defaults configuration for the Right to Know OAF collection.

## Motivation and Context

This change is required to ensure compatibility with the latest features and improvements in Ruby 3.4.10.

Related to https://github.com/openaustralia/righttoknow/issues/1045

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

This has also been tested in Staging - See #637

## Screenshots (if appropriate):
N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

## Related pull requests

This is one release in three parts. All three need to merge and go out together, in this order:

1. openaustralia/infrastructure#675 - sets `ruby_version_production` to 3.4.10. Merge, then provision production so Ruby 3.4.10 is installed and `shared/rbenv-version` is updated.
2. openaustralia/infrastructure#664 - renders `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE` and `SENTRY_JS_LOADER_URL` into production `general.yml`, and wraps the RTK cron jobs in `sentry monitor run`. Merge, then provision production.
3. openaustralia/righttoknow#1059 - the theme release, `staging` into `production`, deployed with Capistrano once both provision runs are done.

Why the order matters: production currently runs Ruby 3.2.9 and the release branch is on 3.4.10, so deploying #1059 before #675 has been provisioned would bundle against the wrong Ruby. Sentry is less severe, deploying #1059 before #664 is safe but inert, since `lib/sentry_config.rb` leaves the SDK disabled when no DSN is configured, so errors, traces and cron check-ins would silently go nowhere until production is provisioned.
