### PR TITLE
Remove make check-oaf and apply-oaf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-.PHONY: all ansible-lint apply-metabase apply-oaf requirements apply-openaustralia \
-        apply-planningalerts apply-postal apply-righttoknow  apply-theyvoteforyou \
-        aws-check \
-        check-host check-metabase check-oaf check-openaustralia check-planningalerts check-postal check-righttoknow \
-        check-theyvoteforyou check-target \
-        scan-oaf scan-openaustralia scan-planningalerts \
-        clean clobber help letsencrypt lint op-check retry roles \
-        show-facts show-inventory show-rds-facts show-vars stage_required tf-apply tf-apply-target \
-        tf-env-check tf-init tf-plan tf-plan-target tf-secrets \
-        update-github-ssh-keys vagrant venv yaml-lint template-check
+.PHONY: all ansible-lint apply-metabase apply-openaustralia apply-planningalerts \
+        apply-righttoknow apply-theyvoteforyou aws-check \
+        check-host check-metabase check-openaustralia check-planningalerts check-postal \
+        check-righttoknow check-target check-theyvoteforyou \
+        clean clobber generate-certificates help letsencrypt lint op-check \
+        requirements retry roles \
+        scan-oaf scan-openaustralia scan-planningalerts server-status setup \
+        show-aws-inventory show-facts show-inventory show-rds-facts show-vars ssh-config stage_required \
+        template-check tf-apply tf-apply-target tf-check-fmt tf-env-check tf-init tf-plan tf-plan-target \
+        tf-secrets tf-validate update-github-ssh-keys vagrant venv yaml-lint
 
 _STAGE := $(if $(filter-out all,$(STAGE)),_$(STAGE),)
 
@@ -81,7 +81,6 @@ help:
 	@echo "  check-righttoknow STAGE=<stage>     Dry-run Ansible for righttoknow production/staging/all host/s"
 	@echo "  check-planningalerts                Dry-run Ansible for planningalerts hosts"
 	@echo "  check-theyvoteforyou                Dry-run Ansible for theyvoteforyou host"
-	@echo "  check-oaf                           Dry-run Ansible for oaf host"
 	@echo "  check-openaustralia                 Dry-run Ansible for openaustralia host"
 	@echo "  check-metabase                      Dry-run Ansible for metabase host"
 	@echo "  check-postal                        Dry-run Ansible for postal host"
@@ -89,7 +88,6 @@ help:
 	@echo "  apply-righttoknow STAGE=<stage>     Apply Ansible changes to righttoknow production/staging/all host/s"
 	@echo "  apply-planningalerts                Apply Ansible changes to planningalerts hosts"
 	@echo "  apply-theyvoteforyou                Apply Ansible changes to theyvoteforyou host"
-	@echo "  apply-oaf                           Apply Ansible changes to oaf host"
 	@echo "  apply-openaustralia                 Apply Ansible changes to openaustralia host"
 	@echo "  apply-metabase                      Apply Ansible changes to metabase host"
 	@echo "  apply-postal                        Apply Ansible changes to postal host"
@@ -360,8 +358,6 @@ check-planningalerts: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l planningalerts$(_STAGE) --check --diff
 check-theyvoteforyou: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l theyvoteforyou$(_STAGE) --check --diff
-check-oaf: requirements # stage_required
-	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l oaf$(_STAGE) --check --diff
 check-openaustralia: requirements # stage_required
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l openaustralia$(_STAGE) --check --diff
 check-metabase: requirements # stage_required
@@ -382,10 +378,6 @@ apply-theyvoteforyou: requirements # stage_required
 	bin/tag-provisioning --wip theyvoteforyou "$(STAGE)" "$(TAGS)" "$(SKIP_TAGS)"
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l theyvoteforyou$(_STAGE) --diff
 	bin/tag-provisioning theyvoteforyou "$(STAGE)" "$(TAGS)" "$(SKIP_TAGS)"
-apply-oaf: requirements # stage_required
-	bin/tag-provisioning --wip oaf "$(STAGE)" "$(TAGS)" "$(SKIP_TAGS)"
-	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l oaf$(_STAGE) --diff
-	bin/tag-provisioning oaf "$(STAGE)" "$(TAGS)" "$(SKIP_TAGS)"
 apply-openaustralia: requirements # stage_required
 	bin/tag-provisioning --wip openaustralia "$(STAGE)" "$(TAGS)" "$(SKIP_TAGS)"
 	.venv/bin/ansible-playbook $(ANSIBLE_OPTS) -i ./inventory site.yml -l openaustralia$(_STAGE) --diff

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all ansible-lint apply-metabase apply-openaustralia apply-planningalerts \
-        apply-righttoknow apply-theyvoteforyou aws-check \
+        apply-postal apply-righttoknow apply-theyvoteforyou aws-check \
         check-host check-metabase check-openaustralia check-planningalerts check-postal \
         check-righttoknow check-target check-theyvoteforyou \
         clean clobber generate-certificates help letsencrypt lint op-check \


### PR DESCRIPTION
## Description

Removes the `check-oaf`/`apply-oaf` Makefile targets (and their `.PHONY`/`help` entries) -
there is no `oaf` Ansible group/host for them to run against, so they were dead targets that
would fail if invoked.

## Motivation and Context

Spotted while working through the Makefile as part of the Cloudflare Tunnel stack (#266) -
these two targets referenced a service that doesn't exist in this repo's inventory.

## How Has This Been Tested?

- [x] `make help` still lists every remaining target correctly
- [x] Checked affected area manually on my own / staging system (`make help` output reviewed by hand)
- [x] Ran automated tests on my own system (full `make lint` - yaml-lint, ansible-lint,
      template-check, tf-check-fmt - all pass on this branch)
- [x] Confirmed it passed the GitHub actions tests

Note: `make tf-validate`/`tf-plan`/`tf-apply` currently fail repo-wide from this branch onward,
purely because this branch is stacked on top of #650, which has an unrelated regression (see that
PR's "Known issue found via testing") - nothing in this Makefile-only change is the cause.

## Screenshots (if appropriate):

N/A - Makefile-only change.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

**AI-assisted contribution**: this pull request was opened by Claude Code (model:
claude-sonnet-5) at the user's request, drafting this description from the existing commit
on the branch. The code change itself (the commit removing the `check-oaf`/`apply-oaf`
targets) was authored directly by the human, not generated by AI.

