### PR TITLE
Generate the Vagrant host list from Terraform, and pin Ansible group priorities

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,13 @@ _Avoid_: uninstall role, teardown role
 One machine, whether EC2 or Linode.
 _Avoid_: server, box, instance, node
 
+**Location group**:
+The Ansible group that says where a host lives and answers the questions that follow from it - `ansible_user`, how
+to reach the database, which domain the host is under. `ec2` for the real hosts, `vagrant` for local boxes, and a
+sibling for each future dev environment. Exactly one per host, at `ansible_group_priority` 0 so it loses to the
+service groups and beats `development`.
+_Avoid_: environment (it means something else here), platform, provider
+
 ### Stages and environments
 
 **Stage**:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,12 +6,90 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+require "English" # for $CHILD_STATUS
+require "json"
+
 BASE_DOMAIN = "test"
 IP_NETWORK = "192.168.56"
 STANDARD_ALIASES = %w[www test www.test]
 
+# The group that says where these hosts live, standing in for "ec2" on the real ones. Renaming
+# rather than keeping "ec2" matters: group_vars/ec2.yml sets ansible_user, terraform.pem and an
+# RDS-derived db_host, and shares five keys with group_vars/development.yml which it would win.
+# Local boxes must not be in it.
+LOCATION_GROUP = "vagrant"
+
+# Cap per-host memory. Production runs to 16GB for theyvoteforyou and over 36GB in total.
+MAX_MEMORY = (ENV["VAGRANT_MEMORY"] || 4096).to_i
+
+# Stand-ins for the AWS managed services, which have no aws_instance in Terraform for
+# bin/dev-hosts to find. group_vars/development.yml pins mysql_host to .10 and both
+# postgresql_host and planningalerts_db_host to .11, so those two node numbers must not move.
+#
+# FIXME in #574 (Upgrade Ansible to a supported version): jammy is the newest box Ansible 2.10
+# can manage at all. It vendors six 1.12.0, whose meta path importer only implements
+# find_module/load_module, and Python 3.12 removed the import system's fallback to those. Every
+# module task then dies on the guest with "No module named 'ansible.module_utils.six.moves'",
+# starting at the first gather_facts. 24.04 ships Python 3.12 and 26.04 ships 3.14, so both are
+# out until #574 lands. roles/internal/postgresql also hardcodes the jammy-pgdg apt repo, which
+# needs widening at the same time. Restore these two once Ansible is new enough:
+#   "mysql" => { node: 10, box: "bento/ubuntu-26.04", memory: 2048, groups: ["mysql"] },
+#   "postgresql" => { node: 11, box: "bento/ubuntu-26.04", memory: 2048, groups: ["postgresql"] },
+LOCAL_ONLY = {
+  # MySQL 8.0.46, the jammy package (AWS has 8.4 as of Aug 2026)
+  "mysql" => { node: 10, box: "ubuntu/jammy64", memory: 2048, groups: ["mysql"] },
+  # PostgreSQL 15 from the pgdg repo, matching AWS as of Aug 2026
+  "postgresql" => { node: 11, box: "ubuntu/jammy64", memory: 2048, groups: ["postgresql"] },
+  # Redis 6.0.16, (AWS has 6.2.6 as of Aug 2026)
+  "redis" => { node: 13, box: "ubuntu/jammy64", memory: 1024, groups: ["redis"] }
+}.freeze
+
+# Extra hostsupdater aliases, keyed by full hostname. Purely a local browsing convenience, so
+# they are not derived from Terraform. These are the names certificates/generate-certificates.sh
+# issues dev certs for.
+ALIASES = {
+  "openaustralia.#{BASE_DOMAIN}" => STANDARD_ALIASES + %w[data software],
+  "staging.righttoknow.#{BASE_DOMAIN}" => STANDARD_ALIASES,
+  "prod.righttoknow.#{BASE_DOMAIN}" => STANDARD_ALIASES,
+  "theyvoteforyou.#{BASE_DOMAIN}" => STANDARD_ALIASES
+}.freeze
+
 unless File.exist?(".venv/bin/ansible") && File.exist?("terraform.pem") && Dir.exist?("roles/external") && File.exist?(".make/vagrant-plugins")
   warn "WARNING: Run `make vagrant` first to install requirements."
+end
+
+# Hosts Terraform declares, translated for local use. bin/dev-hosts exits non-zero rather than
+# emitting a partial list, so a failure here is a real one worth stopping for.
+def terraform_hosts
+  # Anchored on __dir__, not the cwd: vagrant walks up the tree to find this file, so it is
+  # routinely run from a subdirectory.
+  command = "#{File.expand_path('bin/dev-hosts', __dir__)} --tld=#{BASE_DOMAIN} " \
+            "--ec2=#{LOCATION_GROUP} --max-memory=#{MAX_MEMORY}"
+  output = `#{command}`
+  raise "#{command} failed - see its output above" unless $CHILD_STATUS.success?
+
+  JSON.parse(output)
+end
+
+# Full hostname => box, memory, node number and Ansible groups, for every host to define.
+def all_hosts
+  hosts = {}
+  LOCAL_ONLY.each do |name, details|
+    hosts["#{name}.#{BASE_DOMAIN}"] = details.merge(groups: details[:groups] + [LOCATION_GROUP])
+  end
+
+  # .10-.13 belong to LOCAL_ONLY above, so start clear of them. Nothing references these
+  # addresses, unlike mysql_host and postgresql_host, so they may shift as hosts come and go.
+  node = 20
+  terraform_hosts.sort_by { |host| host["name"] }.each do |host|
+    hostname = host["log_name"] || host["name"]
+    hostname += ".#{BASE_DOMAIN}" unless hostname.end_with?(".#{BASE_DOMAIN}")
+    hosts[hostname] = {
+      node: node, box: host["vagrant_box"], memory: host["memory_mb"], groups: host["groups"]
+    }
+    node += 1
+  end
+  hosts
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -63,58 +141,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  # noble (24.04 LTS) "standard" support ends in April 2029 (Yet to be used)
-  # jammy (22.04 LTS) "standard" support ends in April 2027
-  # focal (20.04 LTS) "standard" support ends in April 2025 EOL!
-  # bionic (18.04 LTS) "standard" support ends in April 2023 EOL!
-  # xenial (16.04 LTS) "standard" support ended in April 2021 EOL!
-  hosts = {
-    # Services required by the servers
-    "mysql" => { node: 10,
-                 box: "ubuntu/jammy64",
-                 groups: ["mysql"] },
-    # TODO: Do we want to seperate out the postgres for PA and everything else
-    "postgresql" => { node: 11,
-                      box: "ubuntu/jammy64",
-                      groups: ["postgresql"] },
-    "au.proxy" => { node: 12,
-                    box: "ubuntu/xenial64",
-                    groups: ["proxy"] },
-    "redis" => { node: 13,
-                 box: "ubuntu/jammy64",
-                 groups: ["redis"] },
-
-    # Servers
-    "web.metabase.oaf" => { node: 20,
-                            box: "ubuntu/jammy64",
-                            groups: %w[metabase requires_postgresql] },
-    "oaf" => { node: 21,
-               box: "ubuntu/bionic64",
-               groups: ["oaf"] },
-    "openaustralia" => { node: 22,
-                         box: "ubuntu/jammy64",
-                         aliases: STANDARD_ALIASES + %w[data software],
-                         groups: %w[openaustralia requires_mysql] },
-    "web.planningalerts" => { node: 24,
-                              box: "ubuntu/jammy64",
-                              groups: %w[planningalerts requires_postgresql] },
-    "staging.righttoknow" => { node: 25,
-                               box: "ubuntu/bionic64",
-                               aliases: STANDARD_ALIASES,
-                               groups: %w[righttoknow righttoknow_staging requires_postgresql] },
-    "prod.righttoknow" => { node: 25,
-                            box: "ubuntu/bionic64",
-                            aliases: STANDARD_ALIASES,
-                            groups: %w[righttoknow righttoknow_production requires_postgresql] },
-    "theyvoteforyou" => { node: 26,
-                          box: "ubuntu/focal64",
-                          aliases: STANDARD_ALIASES,
-                          groups: %w[theyvoteforyou requires_mysql] },
-    # FIXME: Has not been constructed, and is not in any (extra) group
-    # "vpn.oaf" => { node: 27,
-    #                       box: "ubuntu/jammy64",
-    #                       groups: [] },
-  }
+  # Boxes come from bin/dev-hosts, which decodes the Ubuntu release from the name of each
+  # instance's ami variable in terraform/. Support dates, for reference when a box looks old:
+  # noble (24.04 LTS) to April 2029, jammy (22.04 LTS) to April 2027, focal (20.04 LTS) EOL
+  # April 2025, bionic (18.04 LTS) EOL April 2023, xenial (16.04 LTS) EOL April 2021.
+  hosts = all_hosts
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
@@ -130,9 +161,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       # Empty list just so ansible doesn't complain it doesn't know about these cloud servers
       "ec2" => [],
+
+      # Same 0 as [ec2:vars] in inventory/ec2-hosts. No effect while "ec2" is empty here, but it
+      # keeps the two inventories agreeing on where the location group sits in the merge order.
+      "ec2:vars" => { "ansible_group_priority" => 0 },
+
+      # Lose to the more specific groups deterministically rather than by alphabet, which would
+      # otherwise have "vagrant" beat them while "devc" or "local" quietly lost. 0 matches
+      # [ec2:vars] in inventory/ec2-hosts, so a dev box resolves its vars in the same order a
+      # real host does, and it keeps a future group_vars/vagrant.yml from beating
+      # group_vars/development.yml, which is what pins mysql_host, postgresql_host, db_host and
+      # rds_admin_password locally. Priority has to be set in the inventory, not group_vars,
+      # since it governs how group_vars files merge.
+      "#{LOCATION_GROUP}:vars" => { "ansible_group_priority" => 0 }
     }
     hosts.each do |hostname, details|
-      hostname = "#{hostname}.#{BASE_DOMAIN}"
       ansible.groups["development"] << hostname
       ansible.groups["catch_all_mail"] << hostname
       details[:groups]&.each do |group|
@@ -149,23 +192,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider "virtualbox" do |v|
-    # Middle ground - see README.md for tuning
-    v.memory = (ENV["VAGRANT_MEMORY"] || 2048).to_i
-    v.cpus   = (ENV["VAGRANT_CPUS"] || 2).to_i
+    # Per-host memory is set below; this is only the fallback and the CPU count.
+    v.cpus = (ENV["VAGRANT_CPUS"] || 2).to_i
   end
 
   # Use this so that you don't need to give the machine name for all vagrant
   # commands. Set this to whatever you're most working on at the moment.
-  primary_host = ENV.fetch("DEFAULT_VAGRANT_HOST", "metabase.oaf.#{BASE_DOMAIN}")
+  primary_host = ENV.fetch("DEFAULT_VAGRANT_HOST", "staging.righttoknow.#{BASE_DOMAIN}")
 
   hosts.each do |hostname, details|
-    hostname = "#{hostname}.#{BASE_DOMAIN}"
     config.vm.define hostname, primary: (hostname == primary_host) do |host|
       host.vm.box = details[:box]
       host.vm.network :private_network, ip: "#{IP_NETWORK}.#{details[:node]}"
       host.vm.hostname = hostname
+      # Sized from the production instance_type, capped at MAX_MEMORY.
+      host.vm.provider "virtualbox" do |v|
+        v.memory = details[:memory]
+      end
       # For each host set up some common aliases
-      host.hostsupdater.aliases = details[:aliases].map { |a| "#{a}.#{hostname}" } if details[:aliases]
+      aliases = ALIASES[hostname]
+      host.hostsupdater.aliases = aliases.map { |a| "#{a}.#{hostname}" } if aliases
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,15 +15,16 @@ STANDARD_ALIASES = %w[www test www.test]
 
 # The group that says where these hosts live, standing in for "ec2" on the real ones. Renaming
 # rather than keeping "ec2" matters: group_vars/ec2.yml sets ansible_user, terraform.pem and an
-# RDS-derived db_host, and shares five keys with group_vars/development.yml which it would win.
-# Local boxes must not be in it.
+# RDS-derived db_host. It shares base_domain, devsite and newrelic_license_key with
+# group_vars/development.yml, and db_host and planningalerts_db_host with group_vars/vagrant.yml,
+# and would win all five. Local boxes must not be in it.
 LOCATION_GROUP = "vagrant"
 
 # Cap per-host memory. Production runs to 16GB for theyvoteforyou and over 36GB in total.
 MAX_MEMORY = (ENV["VAGRANT_MEMORY"] || 4096).to_i
 
 # Stand-ins for the AWS managed services, which have no aws_instance in Terraform for
-# bin/dev-hosts to find. group_vars/development.yml pins mysql_host to .10 and both
+# bin/dev-hosts to find. group_vars/vagrant.yml pins mysql_host to .10 and both
 # postgresql_host and planningalerts_db_host to .11, so those two node numbers must not move.
 #
 # FIXME in #574 (Upgrade Ansible to a supported version): jammy is the newest box Ansible 2.10
@@ -155,24 +156,38 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Uncomment the following line if you want some verbose output from ansible
     ansible.verbose = "vv"
 
+    # Every box below is in development, in LOCATION_GROUP, and in whichever groups name what it
+    # runs, so the merge order between those has to be pinned rather than left to Ansible's
+    # fallback of sorting same-depth groups by name. Ansible combines group_vars in
+    # `sorted(groups, key=lambda g: (g.depth, g.priority, g.name))` order, last one winning
+    # (ansible/inventory/helpers.py), so the numbers below read low-to-high as least-to-most
+    # specific:
+    #
+    #   -1  development             what every dev environment shares, whatever runs it
+    #    0  vagrant, ec2            where the host lives - the location group
+    #    1  metabase, righttoknow   service groups, at Ansible's default
+    #
+    # Names would give the wrong answer at every level: "vagrant" sorts after "development" only
+    # by luck, and a future "devcontainer" or "cloud" location group sorts before it and would
+    # quietly lose; "ec2" sorts before every service group but "vagrant" sorts after most of
+    # them. Priority has to be set in the inventory, not group_vars, since it governs how
+    # group_vars files merge - see the matching sections in inventory/ec2-hosts.
     ansible.groups = {
-      "development" => [],
       "catch_all_mail" => [],
 
-      # Empty list just so ansible doesn't complain it doesn't know about these cloud servers
-      "ec2" => [],
+      # group_vars/development.yml - base_domain, devsite and the local test credentials.
+      "development" => [],
+      "development:vars" => { "ansible_group_priority" => -1 },
 
-      # Same 0 as [ec2:vars] in inventory/ec2-hosts. No effect while "ec2" is empty here, but it
-      # keeps the two inventories agreeing on where the location group sits in the merge order.
+      # Empty list just so ansible doesn't complain it doesn't know about these cloud servers.
+      # The priority has no effect while the group is empty, but it keeps the two inventories
+      # agreeing on where a location group sits.
+      "ec2" => [],
       "ec2:vars" => { "ansible_group_priority" => 0 },
 
-      # Lose to the more specific groups deterministically rather than by alphabet, which would
-      # otherwise have "vagrant" beat them while "devc" or "local" quietly lost. 0 matches
-      # [ec2:vars] in inventory/ec2-hosts, so a dev box resolves its vars in the same order a
-      # real host does, and it keeps a future group_vars/vagrant.yml from beating
-      # group_vars/development.yml, which is what pins mysql_host, postgresql_host, db_host and
-      # rds_admin_password locally. Priority has to be set in the inventory, not group_vars,
-      # since it governs how group_vars files merge.
+      # group_vars/vagrant.yml - the VirtualBox private-network addresses of the boxes standing
+      # in for RDS. Beats development, loses to the service groups.
+      LOCATION_GROUP => [],
       "#{LOCATION_GROUP}:vars" => { "ansible_group_priority" => 0 }
     }
     hosts.each do |hostname, details|

--- a/bin/dev-hosts
+++ b/bin/dev-hosts
@@ -32,8 +32,9 @@
 # Renaming rather than dropping "ec2" is the point: it is the group that says where a host
 # lives, and group_vars/ec2.yml is where ansible_user, terraform.pem and the RDS-derived
 # db_host come from. A dev host needs all of those answered differently, so it wants the same
-# group under a different name, e.g. group_vars/test.yml. Note such a group needs
-# ansible_group_priority set in the inventory to win against the service groups.
+# group under a different name, e.g. group_vars/vagrant.yml. Note such a group needs
+# ansible_group_priority set in the inventory - 0, the same as "ec2", so it loses to the
+# service groups by number rather than by however its name happens to sort.
 #
 # ${var.env_name} is always dropped: blue/green is a production concern and means nothing
 # locally. The doubled dot it leaves is collapsed, so web1.${var.env_name}.planningalerts
@@ -68,9 +69,10 @@ MEMORY_MB = {
   "large" => 8192, "xlarge" => 16_384, "2xlarge" => 32_768
 }.freeze
 
+# Ubuntu has stopped releasing vagrant boxes, use bento from 24.04 onwards
 VAGRANT_BOX = {
   "16.04" => "ubuntu/xenial64", "18.04" => "ubuntu/bionic64", "20.04" => "ubuntu/focal64",
-  "22.04" => "ubuntu/jammy64", "24.04" => "ubuntu/noble64", "26.04" => "ubuntu/resolute64"
+  "22.04" => "ubuntu/jammy64", "24.04" => "bento/ubuntu-24.04", "26.04" => "bento/ubuntu-26.04"
 }.freeze
 
 COUNT_INDEX = /\$\{\s*count\.index\s*\+\s*1\s*\}/

--- a/bin/dev-hosts
+++ b/bin/dev-hosts
@@ -1,0 +1,336 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Report the development hosts to create, as JSON, derived from what Terraform declares for the
+# real ones. For the Vagrantfile now, and the dev inventories (local, devcontainer, cloud) later.
+#
+# Terraform is the source of the host list because it is the one place that already knows every
+# host and its Ansible groups. Nothing here drives Terraform, and Terraform will not be used to
+# create these hosts.
+#
+# Reads only the .tf files. No AWS credentials, no `terraform init`, no state.
+#
+# Usage:
+#   bin/dev-hosts                        # JSON array on stdout
+#   bin/dev-hosts --table                # human-readable summary
+#   bin/dev-hosts --tld=test             # rewrite [oaf.]org.au -> test, and ec2 group -> test
+#   bin/dev-hosts --count=2              # two hosts for each Terraform `count` resource
+#   bin/dev-hosts --tld=test --ec2=      # ...but drop the ec2 group instead of renaming it
+#
+# Options:
+#   --tld=DOMAIN   Replace a trailing ".oaf.org.au" or ".org.au" on log_name and
+#                  public_hostname with ".DOMAIN". Leaves name alone, which carries no domain.
+#   --count=N      How many hosts to emit for each resource using Terraform's `count`.
+#                  Defaults to 1, which is what a development setup wants.
+#   --ec2=GROUP    Rename the "ec2" group to GROUP. Defaults to the --tld value, so
+#                  --tld=test also turns the ec2 group into "test". An empty --ec2= drops the
+#                  group instead, and with neither option it is left alone.
+#   --max-memory=N Cap memory_mb at N MB, default 4096. Production sizes run to 16GB for
+#                  theyvoteforyou and total over 36GB, which no development machine wants.
+#                  production_memory_mb keeps the uncapped figure.
+#
+# Renaming rather than dropping "ec2" is the point: it is the group that says where a host
+# lives, and group_vars/ec2.yml is where ansible_user, terraform.pem and the RDS-derived
+# db_host come from. A dev host needs all of those answered differently, so it wants the same
+# group under a different name, e.g. group_vars/test.yml. Note such a group needs
+# ansible_group_priority set in the inventory to win against the service groups.
+#
+# ${var.env_name} is always dropped: blue/green is a production concern and means nothing
+# locally. The doubled dot it leaves is collapsed, so web1.${var.env_name}.planningalerts
+# becomes web1.planningalerts.
+#
+# Fields per host:
+#   name             Name tag, the short name.
+#   log_name         LogName tag. inventory/aws_ec2.yml uses this for `hostnames:`, so it is
+#                    what `-l` and backup paths key off.
+#   public_hostname  PublicHostname tag.
+#   groups           AnsibleGroups tag, split on commas, with "ec2" renamed or dropped per
+#                    --ec2 above. Every other group is verbatim.
+#   ubuntu           Ubuntu release, decoded from the *name* of the ami variable rather than by
+#                    resolving an AMI id, so this needs no API call. nil if undecodable.
+#   vagrant_box      Ubuntu release mapped to its Vagrant box, nil if unknown.
+#   memory_mb        RAM to give the development host: the production instance_type's memory,
+#                    capped at --max-memory. Ready to hand straight to a provider.
+#   production_memory_mb  What the production instance_type actually has, uncapped.
+#
+# Exits non-zero, printing every problem it found and no JSON, if any host comes out unusable:
+# a name still holding a Terraform expression this script cannot substitute, an Ubuntu release
+# it cannot decode, or an instance_type missing from its memory table. Producing a half-usable
+# host list quietly would just move the failure somewhere harder to diagnose.
+
+require "json"
+
+TF_DIR = File.expand_path("../terraform", __dir__)
+
+# instance_type suffix -> RAM in MB, for the t3 family this repo uses.
+MEMORY_MB = {
+  "nano" => 512, "micro" => 1024, "small" => 2048, "medium" => 4096,
+  "large" => 8192, "xlarge" => 16_384, "2xlarge" => 32_768
+}.freeze
+
+VAGRANT_BOX = {
+  "16.04" => "ubuntu/xenial64", "18.04" => "ubuntu/bionic64", "20.04" => "ubuntu/focal64",
+  "22.04" => "ubuntu/jammy64", "24.04" => "ubuntu/noble64", "26.04" => "ubuntu/resolute64"
+}.freeze
+
+COUNT_INDEX = /\$\{\s*count\.index\s*\+\s*1\s*\}/
+ENV_NAME = /\$\{\s*var\.env_name\s*\}/
+OAF_DOMAIN = /\.(?:oaf\.)?org\.au\z/
+
+# Drop comments without being fooled by a '#' inside a quoted string.
+def strip_comment(line)
+  out = +""
+  in_string = false
+  index = 0
+  while index < line.length
+    char = line[index]
+    if in_string
+      if char == "\\"
+        out << char << (line[index + 1] || "")
+        index += 2
+        next
+      end
+      in_string = false if char == '"'
+      out << char
+    elsif char == '"'
+      in_string = true
+      out << char
+    elsif char == "#" || (char == "/" && line[index + 1] == "/")
+      break
+    else
+      out << char
+    end
+    index += 1
+  end
+  out
+end
+
+# Yield [kind, labels, body_lines] for each top-level block, tracking brace depth so sibling
+# resources (aws_eip and aws_ebs_volume both carry their own `tags`) are never confused for the
+# instance, and nested blocks (root_block_device) stay inside their parent.
+def each_block(path)
+  depth = 0
+  header = nil
+  body = []
+  File.readlines(path, chomp: true).each do |raw|
+    line = strip_comment(raw)
+    if depth.zero?
+      next unless (match = line.match(/^(\w+)\s+((?:"[^"]*"\s*)*)\{/))
+
+      header = [match[1], match[2].scan(/"([^"]*)"/).flatten]
+      body = []
+      depth = line.count("{") - line.count("}")
+      yield(*header, body) if depth.zero?
+      next
+    end
+    depth += line.count("{") - line.count("}")
+    if depth.zero?
+      yield(*header, body)
+    else
+      body << line
+    end
+  end
+end
+
+# The lines of the first `tags = {` block, ignoring any nested-block tags that follow.
+def tags_of(body)
+  start = body.index { |line| line.match?(/^\s*tags\s*=\s*\{/) }
+  return {} unless start
+
+  depth = 0
+  collected = {}
+  body[start..].each do |line|
+    depth += line.count("{") - line.count("}")
+    if (match = line.match(/^\s*(\w+)\s*=\s*"([^"]*)"/))
+      collected[match[1]] = match[2]
+    end
+    break if depth.zero? && collected.any?
+  end
+  collected
+end
+
+def value_of(body, key)
+  body.each do |line|
+    match = line.match(/^\s*#{key}\s*=\s*(.+?)\s*$/)
+    return match[1] if match
+  end
+  nil
+end
+
+# module "proxy" { ami = var.ubuntu_16_ami } -> {"proxy" => "var.ubuntu_16_ami"}
+def module_ami_vars
+  path = File.join(TF_DIR, "main.tf")
+  return {} unless File.exist?(path)
+
+  found = {}
+  each_block(path) do |kind, labels, body|
+    next unless kind == "module"
+
+    ami = value_of(body, "ami")
+    found[labels.first] = ami if ami
+  end
+  found
+end
+
+# Any literal AMI name mentioning an Ubuntu release, for the packer-built planningalerts images
+# whose release only appears in the image name (e.g. planningalerts-puma-ubuntu-22.04-v4).
+def ami_name_releases
+  Dir.glob(File.join(TF_DIR, "**", "*.tf")).flat_map do |path|
+    File.read(path).scan(/ami_name\s*=\s*"([^"]*ubuntu-(\d\d\.\d\d)[^"]*)"/i).map(&:last)
+  end.uniq
+end
+
+def decode_ubuntu(ami_expression, mod, module_amis, fallbacks)
+  return nil unless ami_expression
+
+  # Resolve `var.ami` through the module block in main.tf, one hop.
+  expression = ami_expression == "var.ami" ? (module_amis[mod] || ami_expression) : ami_expression
+
+  if (match = expression.match(/ubuntu_(\d+)_(?:\d+_)?ami/))
+    major = match[1]
+    return major.length == 2 ? "#{major}.04" : nil
+  end
+  # data.aws_ami.* - the release is only in the image name, so fall back to that.
+  return fallbacks.first if expression.start_with?("data.aws_ami") && fallbacks.length == 1
+
+  nil
+end
+
+# Substitute the interpolations we understand, then tidy the dots dropping env_name leaves behind.
+def expand(value, index)
+  return nil if value.nil?
+
+  value.gsub(COUNT_INDEX, index.to_s)
+       .gsub(ENV_NAME, "")
+       .gsub(/\.{2,}/, ".")
+       .sub(/\A\./, "")
+       .sub(/\.\z/, "")
+end
+
+def retld(host, tld)
+  return host if host.nil? || tld.nil?
+
+  host.sub(OAF_DOMAIN, ".#{tld}")
+end
+
+# nil leaves "ec2" alone, "" drops it, anything else renames it.
+def rename_ec2(groups, replacement)
+  return groups if replacement.nil?
+  return groups - ["ec2"] if replacement.empty?
+
+  groups.map { |group| group == "ec2" ? replacement : group }
+end
+
+# Anything that would make this host unusable downstream. Reported, not raised, so one run
+# lists everything needing attention rather than stopping at the first.
+def problems_with(host)
+  found = []
+  %w[name log_name public_hostname].each do |field|
+    value = host[field]
+    next unless value&.include?("${")
+
+    found << "unresolved expression in #{field}: #{value.inspect} " \
+             "- teach #{File.basename(__FILE__)} to substitute it"
+  end
+  if host["ubuntu"].nil?
+    found << "cannot decode an Ubuntu release from ami #{host['ami_expression'].inspect} " \
+             "- add the variable name to decode_ubuntu"
+  elsif host["vagrant_box"].nil?
+    found << "no box mapped for Ubuntu #{host['ubuntu']} - add it to VAGRANT_BOX"
+  end
+  if host["memory_mb"].nil?
+    found << "no memory known for instance_type #{host['instance_type'].inspect} " \
+             "- add it to MEMORY_MB"
+  end
+  found
+end
+
+table = ARGV.include?("--table")
+tld = ARGV.grep(/\A--tld=/).first&.split("=", 2)&.last
+replicas = (ARGV.grep(/\A--count=/).first&.split("=", 2)&.last || "1").to_i
+ec2_arg = ARGV.grep(/\A--ec2=/).first&.split("=", 2)&.last
+ec2_group = ec2_arg.nil? ? tld : ec2_arg
+max_memory = (ARGV.grep(/\A--max-memory=/).first&.split("=", 2)&.last || "4096").to_i
+
+if ARGV.include?("--help") || ARGV.include?("-h")
+  doc = File.readlines(__FILE__)
+            .drop(2)                                  # shebang and frozen_string_literal
+            .drop_while { |line| line.strip.empty? }  # the blank line after them
+            .take_while { |line| line.start_with?("#") }
+            .map { |line| line.sub(/^# ?/, "") }
+  puts doc.join
+  exit 0
+end
+
+module_amis = module_ami_vars
+fallbacks = ami_name_releases
+hosts = []
+
+Dir.glob(File.join(TF_DIR, "**", "*.tf")).each do |path|
+  # First path component under terraform/, so terraform/planningalerts/env/main.tf reports
+  # "planningalerts" rather than the "env" submodule directory.
+  mod = path.sub("#{TF_DIR}/", "").split("/").first
+  mod = "(root)" if mod.end_with?(".tf")
+
+  each_block(path) do |kind, labels, body|
+    next unless kind == "resource" && labels.first == "aws_instance"
+
+    tags = tags_of(body)
+    name = tags["Name"] || tags["LogName"]
+    next unless name
+
+    ami = value_of(body, "ami")
+    release = decode_ubuntu(ami, mod, module_amis, fallbacks)
+    size = value_of(body, "instance_type")&.delete('"')
+    production_memory = size && MEMORY_MB[size.split(".").last]
+    count_expression = value_of(body, "count")
+
+    # One host unless Terraform uses `count`, in which case --count decides how many.
+    indexes = count_expression ? (1..replicas) : [1]
+    indexes.each do |index|
+      hosts << {
+        "name" => expand(name, index),
+        "log_name" => retld(expand(tags["LogName"], index), tld),
+        "public_hostname" => retld(expand(tags["PublicHostname"], index), tld),
+        "resource" => labels.last,
+        "module" => mod,
+        "file" => path.sub(%r{^#{Regexp.escape(File.dirname(TF_DIR))}/}, ""),
+        "groups" => rename_ec2(
+          (tags["AnsibleGroups"] || "").split(",").map(&:strip).reject(&:empty?), ec2_group
+        ),
+        "stage" => tags["Stage"],
+        "ami_expression" => ami,
+        "ubuntu" => release,
+        "vagrant_box" => release && VAGRANT_BOX[release],
+        "instance_type" => size,
+        "memory_mb" => production_memory && [production_memory, max_memory].min,
+        "production_memory_mb" => production_memory,
+        "count" => count_expression
+      }
+    end
+  end
+end
+
+hosts.sort_by! { |host| host["name"] }
+
+complaints = hosts.flat_map do |host|
+  problems_with(host).map { |problem| "#{host['file']}: #{host['name']}: #{problem}" }
+end
+
+unless complaints.empty?
+  warn "#{File.basename(__FILE__)}: #{complaints.length} problem(s), refusing to emit a " \
+       "partial host list:"
+  complaints.each { |complaint| warn "  #{complaint}" }
+  exit 1
+end
+
+if table
+  format = "%-26s %-30s %-14s %-16s %7s  %s\n"
+  printf(format, "NAME", "LOG_NAME", "MODULE", "BOX", "MEM_MB", "GROUPS")
+  hosts.each do |host|
+    printf(format, host["name"], host["log_name"] || "-", host["module"],
+           host["vagrant_box"] || "?", host["memory_mb"] || "?", host["groups"].join(","))
+  end
+else
+  puts JSON.pretty_generate(hosts)
+end

--- a/group_vars/development.yml
+++ b/group_vars/development.yml
@@ -1,10 +1,15 @@
+# Sets variables for development systems
+# (which are NOT using the live ec2 resources)
+#
+# Whatever every dev environment shares, whichever tool runs it. The location group holds the
+# rest - group_vars/vagrant.yml today, a sibling file per environment later - so this file must
+# stay free of anything specific to one of them. Priority -1, below the location group: see the
+# `Vagrantfile` and inventory/ec2-hosts.
+---
 base_domain: test
 
-mysql_host: 192.168.56.10
-postgresql_host: 192.168.56.11
-planningalerts_db_host: 192.168.56.11
-
-db_host: "{{ postgresql_host if 'requires_postgresql' in group_names else mysql_host }}"
+# mysql_host, postgresql_host, planningalerts_db_host and db_host come from the location group,
+# since their addresses depend on how the environment is built.
 
 newrelic_license_key: null
 devsite: true

--- a/group_vars/ec2.yml
+++ b/group_vars/ec2.yml
@@ -1,3 +1,4 @@
+# Sets variables applicable for live systems running on ec2
 ---
 base_domain: org.au
 

--- a/group_vars/vagrant.yml
+++ b/group_vars/vagrant.yml
@@ -1,0 +1,16 @@
+# Sets variables for **vagrant** development systems
+# (which are NOT using the live ec2 resources)
+#
+# The location group, standing in for `ec2` on the real hosts: it answers the same questions
+# about where a host lives, differently. These hosts are also in `development`, which holds
+# what every dev environment shares regardless of the tool running it.
+#
+# Priority 0, the same as `ec2` - above development, below the service groups. Set in the
+# `Vagrantfile` inventory, since priority governs how group_vars files merge and so cannot be
+# read from one.
+---
+mysql_host: 192.168.56.10
+postgresql_host: 192.168.56.11
+planningalerts_db_host: 192.168.56.11
+
+db_host: "{{ postgresql_host if 'requires_postgresql' in group_names else mysql_host }}"

--- a/inventory/aws_ec2.yml
+++ b/inventory/aws_ec2.yml
@@ -31,6 +31,11 @@ keyed_groups:
   # e.g. planningalerts hosts (never in `ec2`) aren't forced into it.
   - key: tags.AnsibleGroups.split(',')
     separator: ''
+# NOTE: group variables cannot be set from here. This plugin's config has no directive for them,
+# and the keyed_groups/groups below only ever reach InventoryData.set_variable for a *host*, so
+# `ansible_group_priority` for the groups this file populates lives in inventory/ec2-hosts
+# instead - see the comment on [ec2:vars] there. Groups merge by name across inventory sources,
+# so that file governs these groups even though it holds none of their hosts.
 groups:
   # Every host reaching this point already passed the filters/exclude_filters above, so
   # membership here IS "explicitly declared SSM-ready" - safe to use unconditionally, e.g. in

--- a/inventory/ec2-hosts
+++ b/inventory/ec2-hosts
@@ -4,8 +4,49 @@
 #
 # Other inventory files:
 
-# KEEP EMPTY - see `Vagrantfile` for development inventory
+# The ec2 group says where a host lives and requires_* says what it needs, so where either sets
+# the same variable as a service group, the service group is the more specific answer and must
+# win. Ansible combines group_vars in `sorted(groups, key=lambda g: (g.depth, g.priority,
+# g.name))` order, last one winning (ansible/inventory/helpers.py), so the priorities below read
+# low-to-high as least-to-most specific and give that outcome deterministically:
+#
+#   -1  development                    what every dev environment shares (Vagrantfile only)
+#    0  ec2, requires_*, vagrant       where the host lives, what it needs
+#    1  metabase, righttoknow, ...     service groups, at Ansible's default
+#
+# Names would decide it otherwise, and only by luck: "ec2" happens to sort before every service
+# group, but the Vagrantfile's "vagrant" sorts after most of them, and a future "devcontainer"
+# or "cloud" would land somewhere else again. See the matching block in the `Vagrantfile`.
+#
+# This has to live in an inventory rather than in group_vars/ec2.yml, since it decides how
+# group_vars files merge and so cannot be read from one. The aws_ec2 plugin config where these
+# hosts come from is no use either: it has no directive for group variables, and its
+# keyed_groups/groups only ever reach InventoryData.set_variable for a *host*. A source with no
+# hosts of its own still governs the group, because groups merge by name across inventory
+# sources.
+#
+# No-op as at 2026-08-21: group_vars/ec2.yml and group_vars/requires_*.yml share no keys with
+# any service group. This exists to stop a future overlap being resolved by alphabet.
+#
+# KEEP EMPTY - hosts come from inventory/aws_ec2.yml. The groups still have to be declared here,
+# because the ini plugin rejects a [group:vars] section for a group it has not seen.
+[ec2]
+[requires_postgresql]
+[requires_mysql]
+
+[ec2:vars]
+ansible_group_priority=0
+[requires_postgresql:vars]
+ansible_group_priority=0
+[requires_mysql:vars]
+ansible_group_priority=0
+
+# KEEP EMPTY - see `Vagrantfile` for development inventory, which sets the same priority on its
+# own copy of this group. Vagrant never reads this file, so the priority here only matters if a
+# host is ever added to [development] in a static inventory.
 [development]
+[development:vars]
+ansible_group_priority=-1
 
 # KEEP EMPTY - used by `Vagrantfile` to set up rds equivalents
 [mysql]


### PR DESCRIPTION
## Description

Created bin/dev-hosts so Vagrantfile can read inventory details from terraform to fix and avoid
future divergence between development and live.

Sorts out which Ansible group answers which variable for a dev box, and explicitly lowers priority
of more general groups.

**Details:**

- **`bin/dev-hosts`** reads the `.tf` files (no AWS credentials, no `terraform init`, no state)
  and reports each host as JSON: name, `LogName`, `PublicHostname`, its `AnsibleGroups`, the
  Ubuntu release decoded from the name of its `ami` variable, and memory sized from the
  production `instance_type`. It exits non-zero listing every problem rather than emitting a
  partial list. `bin/dev-hosts --table` is the readable version.
- **`Vagrantfile`** builds its host list from that instead of a hand-maintained hash, so adding
  a host in Terraform no longer means editing it here too. Per-host memory replaces the single
  `VAGRANT_MEMORY` figure, capped at 4GB by default.
- **`group_vars/development.yml` splits in two.** The VirtualBox private-network addresses move
  to a new `group_vars/vagrant.yml`; `development.yml` keeps only what any dev environment
  needs whatever runs it. A devcontainer or cloud dev environment can then add its own sibling
  file without touching either.
- **`ansible_group_priority` is pinned** so the merge order between those groups is decided by
  number rather than by however a group name happens to sort:

  | priority | groups | |
  |---|---|---|
  | `-1` | `development` | what every dev environment shares |
  | `0` | `ec2`, `vagrant`, `requires_mysql`, `requires_postgresql` | where the host lives, what it needs |
  | `1` (Ansible default) | `metabase`, `righttoknow`, ... | service groups |

  Set in both inventories, since Vagrant generates its own and never reads
  `inventory/ec2-hosts`.
- `bin/dev-hosts` maps Ubuntu 24.04 and 26.04 to the bento boxes; Ubuntu has stopped publishing
  its own.
- Adds **Location group** to `CONTEXT.md`.

## Motivation and Context

Towards #555 - making it easier for a contributor to test Ansible playbooks locally. The
Vagrant host list had drifted from Terraform, and `group_vars/development.yml` had claimed the
generic name for some content that is specific to Vagrant (`mysql_host: 192.168.56.10` is a
VirtualBox private-network address), which blocked adding a second dev environment alongside it.

The priority change is protective, but a **no-op as things stand** - `group_vars/ec2.yml`,
`group_vars/requires_*.yml` and `group_vars/development.yml` share no keys with any service
group. It is there to stop a future overlap being resolved by the alphabet. Ansible merges
group vars in `sorted(groups, key=lambda g: (g.depth, g.priority, g.name))` order, last one
winning (`ansible/inventory/helpers.py`), so without the numbers a group named `devcontainer`
or `cloud` would lose to `development` while `vagrant` happens to beat it.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

- `bin/dev-hosts --table --tld=test --ec2=vagrant` lists all seven Terraform-declared hosts with
  their boxes, memory and groups.
- `ansible-inventory -i ./inventory --graph` parses cleanly and the groups are unchanged for the
  real hosts.
- The priority ordering was checked against the installed Ansible in a throwaway inventory: with
  `development` and a `devcontainer` location group both at `0`, `development` wins (the wrong
  way round); at `-1` the location group wins. Service groups beat both either way.
- `make yaml-lint` and `make template-check` pass; `ruby -c` clean on the `Vagrantfile` and
  `bin/dev-hosts`.
- Not yet run end to end with `vagrant up` - the boxes themselves are unchanged for 22.04 and
  below, and 24.04/26.04 stay blocked on #574 (Ansible 2.10 cannot manage a Python 3.12 guest).

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Stacked on #644 - review that first. Base will be repointing to `main` once it merges as part of the stack.

AI-assisted: drafted and reviewed with Claude Code (claude-opus-5[1m]).
I directed the design and have reviewed the code changes.
