### PR TITLE
Add Stripe custom email domain DNS records

### DIFF
--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -213,6 +213,47 @@ resource "cloudflare_record" "spf_include" {
   value   = "v=spf1 ip4:192.0.78.154 ip4:192.0.78.197 ip4:192.0.78.177 ip4:192.0.78.220 ip4:${var.openaustralia_production_ip} ip4:${var.righttoknow_production_ip} ip4:${var.righttoknow_staging_ip} ip4:${var.cuttlefish_ip} -all"
 }
 
+# Stripe custom email domain, so Stripe sends invoices, receipts and
+# failed-payment notices from oaf.org.au rather than stripe.com. Records come
+# from Stripe Dashboard > Settings > Business > Customer emails.
+# The stripe-verification value is account-scoped, so oaf.org.au and
+# righttoknow.org.au share it; the DKIM selectors are per-domain.
+# Stripe also asks for a _dmarc record, but DMARC is already delegated to Suped
+# above with relaxed alignment (adkim=r, aspf=r), which is all Stripe requires.
+resource "cloudflare_record" "stripe_domain_verification" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "oaf.org.au"
+  type    = "TXT"
+  value   = "stripe-verification=415aef2a8e23c6eba13ed66f493149e56cd54e3993d0ceca46261bb308490d1b"
+}
+
+resource "cloudflare_record" "stripe_dkim" {
+  for_each = toset([
+    "sy3choeuozwrc5nff46a4d5chl6in7hr",
+    "2zmfo57rkzmwlfw4boa5fdu7ejmnrulb",
+    "ngpfnppr33fmdaadwenl3cqxjwrdb6wv",
+    "7nnargc6s4l4jabhwdp3utqupozz6xul",
+    "fz32jcuxb7ytwxflfnuzymb5rqm3snco",
+    "emavrbm6a24zowyv2pgfrqn3ma2xebfh",
+  ])
+
+  zone_id = var.oaf_org_au_zone_id
+  name    = "${each.key}._domainkey.oaf.org.au"
+  type    = "CNAME"
+  value   = "${each.key}.dkim.custom-email-domain.stripe.com"
+  proxied = false
+}
+
+# Stripe's MAIL FROM domain. This also carries the SPF policy authorising Stripe
+# to send, which is why the apex v=spf1 record above needs no Stripe include.
+resource "cloudflare_record" "stripe_bounce" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "bounce.oaf.org.au"
+  type    = "CNAME"
+  value   = "custom-email-domain.stripe.com"
+  proxied = false
+}
+
 ## openaustraliafoundation.org.au
 
 # A records

--- a/terraform/righttoknow/dns.tf
+++ b/terraform/righttoknow/dns.tf
@@ -140,6 +140,50 @@ resource "cloudflare_record" "dmarc" {
   value   = "righttoknow.org.au.dmarc.dns.suped.com"
 }
 
+# Stripe custom email domain, so Stripe sends Alaveteli Pro invoices, receipts
+# and failed-payment notices from righttoknow.org.au rather than stripe.com.
+# Records come from Stripe Dashboard > Settings > Business > Customer emails.
+# The stripe-verification value is account-scoped, so righttoknow.org.au and
+# oaf.org.au share it; the DKIM selectors are per-domain.
+# Stripe also asks for a _dmarc record, but DMARC is already delegated to Suped
+# above with relaxed alignment (adkim=r, aspf=r), which is all Stripe requires.
+# IMPORTANT: this domain runs p=reject, so mail failing alignment is rejected
+# outright, not quarantined. All of the records below must be in place and
+# correct before the sending domain is switched to righttoknow.org.au in Stripe.
+resource "cloudflare_record" "stripe_domain_verification" {
+  zone_id = cloudflare_zone.main.id
+  name    = "righttoknow.org.au"
+  type    = "TXT"
+  value   = "stripe-verification=415aef2a8e23c6eba13ed66f493149e56cd54e3993d0ceca46261bb308490d1b"
+}
+
+resource "cloudflare_record" "stripe_dkim" {
+  for_each = toset([
+    "nlx7sfzfiroo4hytihut2kgvztnryc76",
+    "x4mkfgrhlsd4q5tmnj236cdc6byq2agx",
+    "ff65wqx6gyecc63llzlvbkyxdb7z5rej",
+    "m5yhf53zlj62cfxwcsa22hisundglybg",
+    "jsmdzumgvcxk57k24y766fnquadblxja",
+    "4ahvdrbjm3mohehchmvdccidcy5g7cnq",
+  ])
+
+  zone_id = cloudflare_zone.main.id
+  name    = "${each.key}._domainkey.righttoknow.org.au"
+  type    = "CNAME"
+  value   = "${each.key}.dkim.custom-email-domain.stripe.com"
+  proxied = false
+}
+
+# Stripe's MAIL FROM domain. This also carries the SPF policy authorising Stripe
+# to send, which is why the apex v=spf1 record above needs no Stripe include.
+resource "cloudflare_record" "stripe_bounce" {
+  zone_id = cloudflare_zone.main.id
+  name    = "bounce.righttoknow.org.au"
+  type    = "CNAME"
+  value   = "custom-email-domain.stripe.com"
+  proxied = false
+}
+
 # Staging environment DNS records
 resource "cloudflare_record" "staging" {
   zone_id = cloudflare_zone.main.id


### PR DESCRIPTION
## Description

Adds the DNS records Stripe requires to verify `oaf.org.au` and `righttoknow.org.au` as custom email domains, eight per domain.

- A `stripe-verification=` TXT record on each apex. The token is account-scoped rather than domain-scoped, so both domains carry the same string.
- Six DKIM CNAMEs per domain, delegated to `<selector>.dkim.custom-email-domain.stripe.com`. These are per-domain. Built with `for_each` over the selector list so the 32-character selector is derived into the value rather than repeated, which removes the main failure mode here: a name/value mismatch between two opaque strings.
- A `bounce` CNAME per domain. This is Stripe's MAIL FROM domain, and it also carries the SPF policy authorising Stripe to send.

Two records that Stripe's dialog lists are deliberately not included:

- `_dmarc`. Both domains already delegate DMARC to Suped by CNAME, and both published policies use relaxed alignment (`adkim=r`, `aspf=r`), which is Stripe's only hard requirement here. Adding a TXT record would conflict with the existing delegation.
- An apex SPF include. Stripe's envelope sender is `bounce.<domain>`, so its SPF policy comes from the bounce CNAME target, not from the apex `v=spf1` record.

The records go inline in the two existing per-domain DNS files rather than into a new DNS-only module. HelpScout is the existing precedent, being a third-party sender that needs DKIM CNAMEs on both of these domains, and it sits inline in both files. A module spanning both zones would also need a new output added to `terraform/righttoknow/outputs.tf`, because `cloudflare_zone.main` for `righttoknow.org.au` is declared inside that module and isn't exported.

## Motivation and Context

Stripe has both domains registered as custom email domains on the OAF Statement account, but neither could verify because none of the required DNS records existed. `oaf.org.au` had been sitting in "Verification failed" since 30 July and `righttoknow.org.au` in "Verifying" since 24 August. Confirmed with `dig` against 1.1.1.1: no `stripe-verification=` TXT on either apex, no Stripe DKIM CNAMEs, and no `bounce` record on either domain. Every record here is a fresh create, nothing to import.

Verifying the domains is what lets Stripe send invoices, receipts and failed-payment notices from our own domains instead of `stripe.com`. Right to Know already uses this Stripe account for Alaveteli Pro subscriptions, so those subscription emails currently come from `stripe.com`.

No open issue covers this.

### Two follow-ups this PR deliberately does not do

`righttoknow.org.au` runs `p=reject` (`oaf.org.au` is `p=none`). Once the sending domain is switched in Stripe, mail that fails alignment on that domain is rejected outright rather than quarantined. The DKIM and bounce records give relaxed alignment on both DKIM and SPF, so it should pass, but this record set needs to show Verified in Stripe before anyone flips the sending domain. Changing the sending domain is a separate, customer-visible decision.

After apply, `oaf.org.au` needs a manual nudge in the Stripe dashboard, since it's in "Verification failed" rather than "Verifying": **⋯ → Show DNS configuration → Try verifying now**. `righttoknow.org.au` is already polling and should pick the records up on its own. Stripe emails on success, and verification can take up to 72 hours.

## How Has This Been Tested?

Not applied. This stops at a reviewed plan deliberately, so the live DNS change is a separate, explicit step.

- `make tf-check-fmt` — PASSED
- `make tf-validate` — Success, configuration is valid
- `make tf-plan-target MODULE=oaf` — 8 to add, 0 to change, 0 to destroy
- `make tf-plan-target MODULE=righttoknow` — 8 to add, 0 to change, 0 to destroy

The zero changes and zero destroys on both modules are the meaningful result: nothing here collided with an existing record, which was the main risk given how many TXT records already sit on both apexes.

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The first box is unticked because the records aren't applied yet, so there is nothing live to check. The third is pending CI on this PR.

Unrelated drift noticed while checking, flagged rather than fixed here: Cloudflare holds a few apex TXT records that Terraform doesn't manage, so `tf-plan` neither shows nor removes them. On `oaf.org.au`, an `anthropic-domain-verification-p0y541=` and a `brave-ledger-verification=`. On `righttoknow.org.au`, a second `google-site-verification=OIYDsVIt92shaPnL4btnOMek8xYYAS85EcW5C0GgfTM`.

## Screenshots (if appropriate):

N/A.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The per-record rationale that would otherwise want a doc lives in comments above the resources, matching how the existing Suped DMARC and SPF-include records are documented in these files.

---

AI assistance: written with Claude Code using the model `claude-opus-5`, which read the records from the Stripe dashboard, wrote the Terraform and ran the fmt/validate/plan checks above. Reviewed and committed by @benrfairless.
