### PR TITLE
Prepare postal for app cutovers from cuttlefish

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,6 +65,22 @@ Shifting traffic from one environment to the other, or from a retired service to
 code is installed by a cutover.
 _Avoid_: blue/green deployment, release, switch
 
+### Mail
+
+**Mail server**:
+A per-application sending unit inside Postal, owning its own credentials, sending domains, suppression list and
+webhooks. Not a host - they all live on one host.
+_Avoid_: app (cuttlefish's word for the same idea), SMTP server (that's the listener they share)
+
+**Suppression list**:
+The per-mail-server list of addresses Postal declines to send to after delivery failures. Mail to a suppressed
+address is held, not silently dropped.
+_Avoid_: deny list (cuttlefish's word), blocklist, blacklist
+
+**Track domain**:
+The per-service hostname that link redirects and open pixels in that service's mail are served from.
+_Avoid_: custom tracking domain (cuttlefish's word)
+
 ### OAF's own words
 
 **OAF collection**:

--- a/docs/POSTAL.md
+++ b/docs/POSTAL.md
@@ -14,8 +14,23 @@ Postal is assembled with Terraform (`terraform/postal/` - Linode instance, rever
 
 1. Create a global admin user: SSH to the server and run `postal make-user`
 2. Add the DKIM record for the return path domain: run `postal default-dkim-record` on the server and add the TXT record it prints (`postal._domainkey.rp.postal.oaf.org.au`) to `terraform/postal/dns.tf`
-3. Log into <https://postal.oaf.org.au>, create an organisation and a mail server per application, and add each sending domain (which will show the per-domain SPF/DKIM records to add to that domain's `dns.tf`)
-4. Generate SMTP credentials for postal's own system emails and set `postal_system_smtp_username`/`postal_system_smtp_password` (vaulted) in `group_vars/postal.yml`
+3. Log into <https://postal.oaf.org.au> and create one organisation (OAF) with a mail server per application:
+   `theyvoteforyou`, `openaustralia`, `morph`, `metabase`, `planningalerts` and `planningalerts-comments`
+   (PlanningAlerts uses a second mail server for the comment emails it sends to councils - see
+   [docs/adr/0003-planningalerts-gets-two-postal-mail-servers.md](adr/0003-planningalerts-gets-two-postal-mail-servers.md))
+4. On each mail server, add its sending domain (which will show the per-domain SPF/DKIM records to add to that
+   domain's `dns.tf`), generate SMTP credentials, enable click/open tracking with a `track.<domain>` track domain
+   (skip tracking for metabase - it only sends internal mail), and for the two PlanningAlerts mail servers add a
+   webhook pointing at the app's Postal event endpoint. `theyvoteforyou` gets a second credential for its staging
+   stage and `morph` gets a second credential for Discourse (discuss.morph.io)
+5. Generate SMTP credentials for postal's own system emails and set `postal_system_smtp_username`/`postal_system_smtp_password` (vaulted) in `group_vars/postal.yml`
+
+## How applications connect
+
+Applications submit mail to `postal.oaf.org.au` port **2525** (AWS EC2 blocks outbound port 25 by default, so the
+host redirects 2525 to postal's SMTP listener on 25 - see `redirect-smtp-port` in the role). The SMTP server does
+STARTTLS with Caddy's Let's Encrypt certificate (synced across by `sync-smtp-certificate`, daily via cron), so
+clients should verify the certificate - no `tls_certcheck off` style workarounds.
 
 ## Upgrades
 

--- a/docs/POSTAL.md
+++ b/docs/POSTAL.md
@@ -22,8 +22,10 @@ Postal is assembled with Terraform (`terraform/postal/` - Linode instance, rever
    domain's `dns.tf`), generate SMTP credentials, enable click/open tracking with a `track.<domain>` track domain
    (skip tracking for metabase - it only sends internal mail), and for the two PlanningAlerts mail servers add a
    webhook pointing at the app's Postal event endpoint. `theyvoteforyou` gets a second credential for its staging
-   stage and `morph` gets a second credential for Discourse (discuss.morph.io)
-5. Generate SMTP credentials for postal's own system emails and set `postal_system_smtp_username`/`postal_system_smtp_password` (vaulted) in `group_vars/postal.yml`
+   stage and `morph` gets a second credential for Discourse (discuss.morph.io). Each `track.<domain>` hostname
+   also needs a server block in the role's `Caddyfile.j2` (Caddy terminates SSL for track domains) alongside the
+   CNAME in that domain's `dns.tf`
+5. Generate SMTP credentials for postal's own system emails and set `postal_system_smtp_username`/`postal_system_smtp_password` (vaulted) in `group_vars/postal.yml`. Until this is done postal can't send its own system emails (e.g. password resets). The credential must belong to a mail server with oaf.org.au as a sending domain, so system mail from `postal@oaf.org.au` is DKIM-signed and DMARC-aligned
 
 ## How applications connect
 

--- a/docs/POSTAL.md
+++ b/docs/POSTAL.md
@@ -19,12 +19,14 @@ Postal is assembled with Terraform (`terraform/postal/` - Linode instance, rever
    (PlanningAlerts uses a second mail server for the comment emails it sends to councils - see
    [docs/adr/0003-planningalerts-gets-two-postal-mail-servers.md](adr/0003-planningalerts-gets-two-postal-mail-servers.md))
 4. On each mail server, add its sending domain (which will show the per-domain SPF/DKIM records to add to that
-   domain's `dns.tf`), generate SMTP credentials, enable click/open tracking with a `track.<domain>` track domain
-   (skip tracking for metabase - it only sends internal mail), and for the two PlanningAlerts mail servers add a
-   webhook pointing at the app's Postal event endpoint. `theyvoteforyou` gets a second credential for its staging
-   stage and `morph` gets a second credential for Discourse (discuss.morph.io). Each `track.<domain>` hostname
-   also needs a server block in the role's `Caddyfile.j2` (Caddy terminates SSL for track domains) alongside the
-   CNAME in that domain's `dns.tf`
+   domain's `dns.tf`), generate SMTP credentials, enable click/open tracking with an `email3.<domain>` track
+   domain (following the `email`/`email2` cuttlefish convention; skip tracking for metabase - it only sends
+   internal mail - and for planningalerts-comments - official correspondence to councils isn't tracked), and for
+   the two PlanningAlerts mail servers add a webhook pointing at the app's Postal event endpoint.
+   `theyvoteforyou` gets a second credential for its staging stage and `morph` gets a second credential for
+   Discourse (discuss.morph.io). Each track domain hostname needs a CNAME to `track.postal.oaf.org.au` in that
+   domain's `dns.tf` and an entry in `postal_track_domains` (role defaults), which makes Caddy serve it with a
+   Let's Encrypt certificate
 5. Generate SMTP credentials for postal's own system emails and set `postal_system_smtp_username`/`postal_system_smtp_password` (vaulted) in `group_vars/postal.yml`. Until this is done postal can't send its own system emails (e.g. password resets). The credential must belong to a mail server with oaf.org.au as a sending domain, so system mail from `postal@oaf.org.au` is DKIM-signed and DMARC-aligned
 
 ## How applications connect

--- a/docs/adr/0003-planningalerts-gets-two-postal-mail-servers.md
+++ b/docs/adr/0003-planningalerts-gets-two-postal-mail-servers.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+date: 2026-08-24
+---
+
+# PlanningAlerts gets two Postal mail servers
+
+Every other application gets one Postal mail server, but PlanningAlerts gets two: `planningalerts` (alert emails
+and other transactional mail) and `planningalerts-comments` (the comment emails it sends to councils).
+
+Comment emails must never be silently suppressed - a council has to receive the public comments made on its
+applications, which is why the app set cuttlefish's `X-Cuttlefish-Ignore-Deny-List` header on them. Postal has no
+per-message bypass: its suppression list applies per mail server, and mail to a suppressed address is held rather
+than sent. PlanningAlerts' alert emails to subscribers are by far OAF's highest-volume mail and produce a steady
+stream of hard bounces, so on a shared mail server a council address could end up suppressed by alert traffic
+alone.
+
+Splitting the mail servers makes that structurally impossible: alert bounces land on `planningalerts`'s
+suppression list and can never touch council delivery. The remaining case - a council's own address bouncing a
+comment email - degrades to loud-and-manual instead of silent: `MessageHeld` webhook events from
+`planningalerts-comments` go to the app's Slack notifier for a human to act on.
+
+## Consequences
+
+- The app carries two SMTP credentials: the default mailer configuration uses `planningalerts`, and the comment
+  mailer overrides it to use `planningalerts-comments`.
+- Both mail servers send from planningalerts.org.au, so the domain is added (with its SPF/DKIM records in
+  `terraform/planningalerts/dns.tf`) on both.
+- Both mail servers' webhooks point at the same PlanningAlerts event endpoint.
+- Alternatives rejected: one mail server with automated clearing of council addresses from the suppression list
+  (needs an API surface Postal may not offer, and is a moving part that can fail silently); one mail server with
+  purely manual suppression-list operations (silent failure window between bounce and human).

--- a/roles/internal/postal/defaults/main.yml
+++ b/roles/internal/postal/defaults/main.yml
@@ -35,5 +35,6 @@ postal_docker_log_max_file: "5"
 postal_track_domains:
   - email3.theyvoteforyou.org.au
   - email3.openaustralia.org
+  - email3.openaustralia.org.au
   - email3.morph.io
   - email3.planningalerts.org.au

--- a/roles/internal/postal/defaults/main.yml
+++ b/roles/internal/postal/defaults/main.yml
@@ -27,3 +27,13 @@ postal_smtp_from_address: postal@oaf.org.au
 # Stop docker container logs filling the disk
 postal_docker_log_max_size: 50m
 postal_docker_log_max_file: "5"
+
+# Per-application click/open tracking hostnames, served by Caddy (which
+# obtains a Let's Encrypt certificate for each). Each one needs a CNAME to
+# track.{{ postal_web_hostname }} in its domain's dns.tf and a track domain
+# on the application's mail server in the postal web interface.
+postal_track_domains:
+  - email3.theyvoteforyou.org.au
+  - email3.openaustralia.org
+  - email3.morph.io
+  - email3.planningalerts.org.au

--- a/roles/internal/postal/defaults/main.yml
+++ b/roles/internal/postal/defaults/main.yml
@@ -9,6 +9,12 @@ postal_version: 3.3.7
 postal_mariadb_image: mariadb:11.4
 postal_caddy_image: caddy:2
 
+# Postal's SMTP server listens on 25, but AWS EC2 blocks outbound port 25 by
+# default so the apps submit mail on this port instead (as they did with
+# cuttlefish). The host redirects it to 25 with iptables. If you change this,
+# clean up the old iptables rules on the server by hand (or reboot it).
+postal_smtp_submission_port: 2525
+
 # Postal requires this to be at least 10x the size of the largest
 # message you intend to send
 postal_mariadb_innodb_log_file_size: 256M

--- a/roles/internal/postal/tasks/main.yml
+++ b/roles/internal/postal/tasks/main.yml
@@ -119,6 +119,44 @@
     path: /opt/postal/config/signing.key
     mode: '0644'
 
+- name: Install the SMTP certificate sync script
+  template:
+    src: sync-smtp-certificate.sh.j2
+    dest: /usr/local/bin/sync-smtp-certificate
+    mode: '0755'
+
+- name: Sync the SMTP certificate
+  command: sync-smtp-certificate
+  register: postal_smtp_certificate_sync
+  changed_when: postal_smtp_certificate_sync.stdout == "updated"
+
+# Caddy renews the Let's Encrypt certificate automatically; this picks up
+# the renewed certificate for the SMTP server
+- name: Sync the SMTP certificate daily
+  cron:
+    name: Sync postal SMTP certificate
+    special_time: daily
+    job: /usr/local/bin/sync-smtp-certificate > /dev/null
+
+- name: Install the SMTP submission port redirect script
+  template:
+    src: redirect-smtp-port.sh.j2
+    dest: /usr/local/bin/redirect-smtp-port
+    mode: '0755'
+
+- name: Install the SMTP submission port redirect service
+  template:
+    src: redirect-smtp-port.service.j2
+    dest: /etc/systemd/system/redirect-smtp-port.service
+    mode: '0644'
+
+- name: Enable the SMTP submission port redirect
+  systemd:
+    name: redirect-smtp-port
+    enabled: true
+    state: started
+    daemon_reload: true
+
 - name: Initialize the postal database schema
   shell: postal initialize && touch /opt/postal/.initialized
   args:

--- a/roles/internal/postal/tasks/main.yml
+++ b/roles/internal/postal/tasks/main.yml
@@ -156,6 +156,9 @@
     enabled: true
     state: started
     daemon_reload: true
+  # In check mode the unit file above hasn't actually been installed yet,
+  # so systemd can't find the service
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Initialize the postal database schema
   shell: postal initialize && touch /opt/postal/.initialized

--- a/roles/internal/postal/templates/Caddyfile.j2
+++ b/roles/internal/postal/templates/Caddyfile.j2
@@ -3,7 +3,9 @@
   reverse_proxy 127.0.0.1:5000
 }
 
-track.{{ postal_web_hostname }} {
+# Click/open tracking hosts: postal's own track domain plus each
+# application's track domain (see postal_track_domains)
+{{ (["track." + postal_web_hostname] + postal_track_domains) | join(", ") }} {
   reverse_proxy 127.0.0.1:5000 {
     header_up X-Postal-Track-Host "1"
   }

--- a/roles/internal/postal/templates/postal.yml.j2
+++ b/roles/internal/postal/templates/postal.yml.j2
@@ -21,6 +21,10 @@ message_db:
 
 smtp_server:
   default_bind_address: "::"
+  # Served with the certificate at /config/smtp.cert + smtp.key (postal's
+  # default paths), synced from Caddy's Let's Encrypt certificate by
+  # /usr/local/bin/sync-smtp-certificate
+  tls_enabled: true
 
 dns:
   # These records are managed in terraform/postal/dns.tf
@@ -35,9 +39,10 @@ smtp:
   # SMTP server used to send messages from the postal management system
   # itself to its users (e.g. password resets). Point this at postal's own
   # SMTP server with credentials generated in the web interface once the
-  # installation is up and running.
+  # installation is up and running. Port {{ postal_smtp_submission_port }} is redirected to the SMTP
+  # listener on 25 by /usr/local/bin/redirect-smtp-port.
   host: 127.0.0.1
-  port: 2525
+  port: {{ postal_smtp_submission_port }}
   username: {{ postal_system_smtp_username | default('') }}
   password: {{ postal_system_smtp_password | default('') }}
   from_name: {{ postal_smtp_from_name }}

--- a/roles/internal/postal/templates/redirect-smtp-port.service.j2
+++ b/roles/internal/postal/templates/redirect-smtp-port.service.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Redirect SMTP submission port {{ postal_smtp_submission_port }} to postal's SMTP listener
+After=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/redirect-smtp-port
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/internal/postal/templates/redirect-smtp-port.sh.j2
+++ b/roles/internal/postal/templates/redirect-smtp-port.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/sh
+# {{ ansible_managed }}
+#
+# Redirect the alternative SMTP submission port to postal's SMTP listener on
+# port 25. AWS EC2 blocks outbound port 25 by default, so the apps submit
+# mail on {{ postal_smtp_submission_port }} instead (as they did with cuttlefish).
+#
+# The OUTPUT rule covers local connections too, so postal's own system emails
+# (sent to 127.0.0.1:{{ postal_smtp_submission_port }}, see postal.yml) take the same path.
+set -e
+
+add_rule() {
+  binary="$1"
+  shift
+  "$binary" -t nat -C "$@" 2> /dev/null || "$binary" -t nat -A "$@"
+}
+
+for binary in iptables ip6tables; do
+  add_rule "$binary" PREROUTING -p tcp --dport {{ postal_smtp_submission_port }} -j REDIRECT --to-ports 25
+  add_rule "$binary" OUTPUT -o lo -p tcp --dport {{ postal_smtp_submission_port }} -j REDIRECT --to-ports 25
+done

--- a/roles/internal/postal/templates/sync-smtp-certificate.sh.j2
+++ b/roles/internal/postal/templates/sync-smtp-certificate.sh.j2
@@ -17,7 +17,8 @@ caddy_cert_dir="/opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencry
 updated=""
 
 if [ -f "$caddy_cert_dir/$hostname.crt" ]; then
-  if ! cmp -s "$caddy_cert_dir/$hostname.crt" "$config_dir/smtp.cert"; then
+  if ! cmp -s "$caddy_cert_dir/$hostname.crt" "$config_dir/smtp.cert" \
+    || ! cmp -s "$caddy_cert_dir/$hostname.key" "$config_dir/smtp.key"; then
     # 644 rather than something stricter because the certificate and key are
     # read by a non-root user inside the postal containers (like signing.key)
     install -m 644 "$caddy_cert_dir/$hostname.crt" "$config_dir/smtp.cert"

--- a/roles/internal/postal/templates/sync-smtp-certificate.sh.j2
+++ b/roles/internal/postal/templates/sync-smtp-certificate.sh.j2
@@ -1,0 +1,44 @@
+#!/bin/sh
+# {{ ansible_managed }}
+#
+# Postal's SMTP server serves STARTTLS with the certificate at
+# /opt/postal/config/smtp.cert + smtp.key (postal's default paths). Caddy
+# already obtains and renews a Let's Encrypt certificate for
+# {{ postal_web_hostname }} for the web interface, so this script copies it
+# across whenever it changes. On a fresh install, before Caddy has obtained
+# the certificate, it generates a self-signed one so the SMTP server can
+# start; the real certificate replaces it on the next (daily) run.
+set -e
+
+config_dir=/opt/postal/config
+hostname="{{ postal_web_hostname }}"
+caddy_cert_dir="/opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/$hostname"
+
+updated=""
+
+if [ -f "$caddy_cert_dir/$hostname.crt" ]; then
+  if ! cmp -s "$caddy_cert_dir/$hostname.crt" "$config_dir/smtp.cert"; then
+    # 644 rather than something stricter because the certificate and key are
+    # read by a non-root user inside the postal containers (like signing.key)
+    install -m 644 "$caddy_cert_dir/$hostname.crt" "$config_dir/smtp.cert"
+    install -m 644 "$caddy_cert_dir/$hostname.key" "$config_dir/smtp.key"
+    updated=yes
+  fi
+elif [ ! -f "$config_dir/smtp.cert" ]; then
+  openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -subj "/CN=$hostname" \
+    -keyout "$config_dir/smtp.key" -out "$config_dir/smtp.cert" 2> /dev/null
+  chmod 644 "$config_dir/smtp.cert" "$config_dir/smtp.key"
+  updated=yes
+fi
+
+if [ -n "$updated" ]; then
+  # Postal only reads the certificate at startup. Skip the restart during
+  # initial provisioning, when postal isn't running yet.
+  if [ -n "$(docker ps -q -f name=postal-smtp)" ]; then
+    postal restart
+  fi
+  echo updated
+else
+  echo unchanged
+fi

--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -71,6 +71,24 @@ resource "cloudflare_record" "email3" {
   value   = "track.postal.oaf.org.au"
 }
 
+# DKIM record for mail sent through postal. The value comes from the
+# domain's page in the postal web interface.
+resource "cloudflare_record" "postal_domainkey" {
+  zone_id = cloudflare_zone.main.id
+  name    = "postal-ZQ5IfL._domainkey.morph.io"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC2ZHwdkNVs5v+cqB/MiLyeAnhzwwP5H303r+QjDgW4VF8SLVTmgItFWT3mf/pEY+xZHEwNLAFmrYApggHIAtT1BakHWP7pS7pUd5dSXcQQwDVhqIdswkDcvUqur6ik4LEfbTjNQwEYCkcNEDyV1bXlNYxKYCN8kcDrwiwtW3ofMQIDAQAB;"
+}
+
+# Custom Return-Path (MAIL FROM) host for mail sent through postal, so the
+# Return-Path domain aligns with the From domain for DMARC
+resource "cloudflare_record" "psrp" {
+  zone_id = cloudflare_zone.main.id
+  name    = "psrp.morph.io"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "helpscout_dkim_strong1" {
   zone_id = cloudflare_zone.main.id
   name    = "strong1._domainkey.morph.io"
@@ -103,7 +121,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.main.id
   name    = "morph.io"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com include:spf.postal.oaf.org.au -all"
 }
 
 resource "cloudflare_record" "google_site_verification" {

--- a/terraform/morph/dns.tf
+++ b/terraform/morph/dns.tf
@@ -63,6 +63,14 @@ resource "cloudflare_record" "email2" {
   value   = "cuttlefish.oaf.org.au"
 }
 
+# Click/open tracking for mail sent through postal
+resource "cloudflare_record" "email3" {
+  zone_id = cloudflare_zone.main.id
+  name    = "email3.morph.io"
+  type    = "CNAME"
+  value   = "track.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "helpscout_dkim_strong1" {
   zone_id = cloudflare_zone.main.id
   name    = "strong1._domainkey.morph.io"

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -97,7 +97,25 @@ resource "cloudflare_record" "spf" {
   zone_id = var.oaf_org_au_zone_id
   name    = "oaf.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com include:spf.postal.oaf.org.au ~all"
+}
+
+# DKIM record for mail sent through postal (currently metabase). The value
+# comes from the domain's page in the postal web interface.
+resource "cloudflare_record" "postal_domainkey" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "postal-vdyoRV._domainkey.oaf.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDnfMUJVx836kba6Xgg2EB5ShOSKnx7gft7TvrstAOdtZeRXJ2ksWYJTDcKq6G15WsWCWrMgAw56x3ViOUmbNMaCxpgwCMtS5qAPmcMy2GKotgJv9yzOcDHhbcvdRYeQNCHGDiQheRjBOLKHkkRgOlhRt4UMuNmQ/ahM5Ld0cr5HwIDAQAB;"
+}
+
+# Custom Return-Path (MAIL FROM) host for mail sent through postal, so the
+# Return-Path domain aligns with the From domain for DMARC
+resource "cloudflare_record" "psrp" {
+  zone_id = var.oaf_org_au_zone_id
+  name    = "psrp.oaf.org.au"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
 }
 
 resource "cloudflare_record" "google_site_verification" {

--- a/terraform/oaf/dns.tf
+++ b/terraform/oaf/dns.tf
@@ -106,7 +106,7 @@ resource "cloudflare_record" "postal_domainkey" {
   zone_id = var.oaf_org_au_zone_id
   name    = "postal-vdyoRV._domainkey.oaf.org.au"
   type    = "TXT"
-  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDnfMUJVx836kba6Xgg2EB5ShOSKnx7gft7TvrstAOdtZeRXJ2ksWYJTDcKq6G15WsWCWrMgAw56x3ViOUmbNMaCxpgwCMtS5qAPmcMy2GKotgJv9yzOcDHhbcvdRYeQNCHGDiQheRjBOLKHkkRgOlhRt4UMuNmQ/ahM5Ld0cr5HwIDAQAB;"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDnfMUJVx836kba6Xgg2EB5Sh0SKnx7gft7TvrstAOdtZeRXJ2ksWYJTDcKq6G15WsWCWrMgAw56x3ViOUmbNMaCxpgwCMtS5qAPmcMy2GKotgJv9yzOcDHhbcvdRYeQNCHGDiQheRjBOLKHkkRgOlhRt4UMuNmQ/ahM5Ld0cr5HwIDAQAB;"
 }
 
 # Custom Return-Path (MAIL FROM) host for mail sent through postal, so the

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -109,7 +109,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.org.id
   name    = "openaustralia.org"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com include:spf.postal.oaf.org.au ~all"
 }
 
 resource "cloudflare_record" "google_site_verification_postmaster_tools" {
@@ -140,6 +140,39 @@ resource "cloudflare_record" "email3" {
   name    = "email3.openaustralia.org"
   type    = "CNAME"
   value   = "track.postal.oaf.org.au"
+}
+
+# DKIM records for mail sent through postal, one per sending domain
+# (openaustralia.org and openaustralia.org.au). The values come from the
+# domain's page in the postal web interface.
+resource "cloudflare_record" "postal_domainkey" {
+  zone_id = cloudflare_zone.org.id
+  name    = "postal-aNeELg._domainkey.openaustralia.org"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDAAMU6hzIYEZtl0Dw46hyJPBzDdKdQFRlvdBMk5vz3MJgxtK1NocROcRbaPbZ0u8QQ7pZz4VIYhBJoYVSPf/4AybNppS7j92NqVTFUvLWl0zRw2Cv6WfVn6wM44PAdKoB5e143ShJwpWbjhSf3bu02RfO7nIWhhxdRugNIfZa+3QIDAQAB;"
+}
+
+resource "cloudflare_record" "alt_postal_domainkey" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "postal-JDp2Xk._domainkey.openaustralia.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpuRfx4R2kptnPHy6PUbmLi4GzYXGUaT2/sNSb+gR405IGMZuM51dfCo26zdoet8hKJM4CR/1cP/iZmC7J1ntEkeGLtiXWoWSFoQ6afF5T0M/oFDNl6EieehOWcRFI2h7j55sCqsRxCnsE9O80b1yrYrWua+VRXpNe2+bBDsAtHwIDAQAB;"
+}
+
+# Custom Return-Path (MAIL FROM) hosts for mail sent through postal, so the
+# Return-Path domain aligns with the From domain for DMARC
+resource "cloudflare_record" "psrp" {
+  zone_id = cloudflare_zone.org.id
+  name    = "psrp.openaustralia.org"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
+}
+
+resource "cloudflare_record" "alt_psrp" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "psrp.openaustralia.org.au"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
 }
 
 resource "cloudflare_record" "google_domainkey" {
@@ -265,7 +298,7 @@ resource "cloudflare_record" "alt_spf" {
   zone_id = cloudflare_zone.org_au.id
   name    = "openaustralia.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com ~all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com include:spf.postal.oaf.org.au ~all"
 }
 
 resource "cloudflare_record" "alt_google_site_verification" {

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -142,6 +142,13 @@ resource "cloudflare_record" "email3" {
   value   = "track.postal.oaf.org.au"
 }
 
+resource "cloudflare_record" "alt_email3" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "email3.openaustralia.org.au"
+  type    = "CNAME"
+  value   = "track.postal.oaf.org.au"
+}
+
 # DKIM records for mail sent through postal, one per sending domain
 # (openaustralia.org and openaustralia.org.au). The values come from the
 # domain's page in the postal web interface.

--- a/terraform/openaustralia/dns.tf
+++ b/terraform/openaustralia/dns.tf
@@ -134,6 +134,14 @@ resource "cloudflare_record" "cuttlefish_domainkey2" {
   value   = "k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnTduUSfwRbdTef45qgzmJ75zTtwiFgtadq/KFfY18/1plQiSSvzpOTNZQjuPW+5X9AeHQhPGtrxLd26ho/V/8FTj2YiAkpi0uwjPBMiERNhOYT9AJzImNpTmFaa9Sq2JXnhYJQHZhlEVu2iE3ZQEZ+3gIbgvS23vFSYwv3n3HwcbAo3epYCekVglKBZvbGvChXZvmN90wz5ovTv74VPOiq96xPWkzcbA5CEiEGfJT8VqNdciQlbEy3Mpijyj/2qPvwZzDCG2xVS47FUr7xYXPRd/JUx7qDw+xlaFUQuT9S6/6zYWwJW7qJ4REIPvC/paORPfnsyqk8c6MIOH9nMXzQIDAQAB"
 }
 
+# Click/open tracking for mail sent through postal
+resource "cloudflare_record" "email3" {
+  zone_id = cloudflare_zone.org.id
+  name    = "email3.openaustralia.org"
+  type    = "CNAME"
+  value   = "track.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "google_domainkey" {
   zone_id = cloudflare_zone.org.id
   name    = "google._domainkey.openaustralia.org"

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -57,6 +57,15 @@ resource "cloudflare_record" "email2" {
   value   = "cuttlefish.oaf.org.au"
 }
 
+# Click/open tracking for mail sent through postal (the planningalerts
+# mail server only - comment emails to councils are not tracked)
+resource "cloudflare_record" "email3" {
+  zone_id = cloudflare_zone.main.id
+  name    = "email3.planningalerts.org.au"
+  type    = "CNAME"
+  value   = "track.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "donate" {
   zone_id = cloudflare_zone.main.id
   name    = "donate.planningalerts.org.au"

--- a/terraform/planningalerts/dns.tf
+++ b/terraform/planningalerts/dns.tf
@@ -66,6 +66,33 @@ resource "cloudflare_record" "email3" {
   value   = "track.postal.oaf.org.au"
 }
 
+# DKIM records for mail sent through postal - one per mail server
+# (planningalerts and planningalerts-comments, see ADR 0003). The values
+# come from the domain's page on each mail server in the postal web
+# interface.
+resource "cloudflare_record" "postal_domainkey" {
+  zone_id = cloudflare_zone.main.id
+  name    = "postal-E79yJc._domainkey.planningalerts.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBw6JQtx7W9F+pDNu74ZqC7xiDnmp6qPJNY6NIAF9tANWtZb9DqOQFtdqqFqgzFoeo8Sl6L9VUca3I7Jv2Ta1bIPkZjizDl3kUBrfGXUlrc6ZjQxcQACI5LBCcfnge42JoAIJ/1iRBsuuI8i8rxHSVsGxPqIF2C0U8DgWYqn39SwIDAQAB;"
+}
+
+resource "cloudflare_record" "postal_domainkey2" {
+  zone_id = cloudflare_zone.main.id
+  name    = "postal-EhMmez._domainkey.planningalerts.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqJL4C7BCQuDPH7CoAiUibRaOIpgyAUYeWLNwQuruCQNpZXk2hPkfRfXzk27eh4/lTQsZMCsZKogqPK+5iPZi3yyvCqJrvzs5q6MR1XqDamQTRHEuZYNayePzUFtlPTEZ8zm4fhDccakFbeKH+eiKObF14Q8gGmhOTX0jgWyy6HQIDAQAB;"
+}
+
+# Custom Return-Path (MAIL FROM) host for mail sent through postal, so the
+# Return-Path domain aligns with the From domain for DMARC
+resource "cloudflare_record" "psrp" {
+  zone_id = cloudflare_zone.main.id
+  name    = "psrp.planningalerts.org.au"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "donate" {
   zone_id = cloudflare_zone.main.id
   name    = "donate.planningalerts.org.au"
@@ -106,7 +133,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.main.id
   name    = "planningalerts.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com a:cuttlefish.oaf.org.au -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com a:cuttlefish.oaf.org.au include:spf.postal.oaf.org.au -all"
 }
 
 resource "cloudflare_record" "google_site_verification" {

--- a/terraform/postal/dns.tf
+++ b/terraform/postal/dns.tf
@@ -31,10 +31,6 @@ resource "cloudflare_record" "spf" {
 # through postal. Aligning this with the sending server fixes the DMARC
 # alignment failures caused by cuttlefish using oaf.org.au as the
 # Return-Path for every domain (issue #364).
-#
-# NOTE: postal._domainkey.rp.postal.oaf.org.au (TXT) also needs to be
-# added here once the server is initialized. The value comes from running
-# `postal default-dkim-record` on the server.
 
 resource "cloudflare_record" "rp_a" {
   zone_id = var.zone_id
@@ -63,6 +59,16 @@ resource "cloudflare_record" "rp_spf" {
   name    = "rp.postal.oaf.org.au"
   type    = "TXT"
   value   = "v=spf1 a mx include:spf.postal.oaf.org.au ~all"
+}
+
+# DKIM key for bounce messages postal itself sends from the return path
+# domain. The value comes from running `postal default-dkim-record` on the
+# server (it's the public half of /opt/postal/config/signing.key).
+resource "cloudflare_record" "rp_dkim" {
+  zone_id = var.zone_id
+  name    = "postal._domainkey.rp.postal.oaf.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuda8B3fcPmqoE1r/PVob9StyXtDMcfGmgJBqKbYdYHEDyxr9J2FU2vmHvGLXL/cfaHhZprLy/n4iDEphnA+zYMc+QlYzqgiZH7LdN44SN/fKACouEhqJ52+LLa2u7LD6rKXX6JO6Lg7aGYFw6QdWbkyrftRGOK8cA1N+CS8+ieSWZ82dw72kr2LaZ/l62wiViv3jdckl9bav93qbKlr+TnRjGL7VFjQfyy2uwGFm+V2fuQZNootKv5gKdm5Tdj3WY8rCzlLVC/XTULwraVDx8EDKVEhw5ntDJiuG7OVok4wCsoFseA9iODtZh6s2LOx+W04akQ6PAl5DQVq79kM/JwIDAQAB;"
 }
 
 # Route domain

--- a/terraform/postal/main.tf
+++ b/terraform/postal/main.tf
@@ -74,6 +74,18 @@ resource "linode_firewall" "main" {
     ipv6     = ["::/0"]
   }
 
+  # AWS EC2 blocks outbound port 25 by default, so the apps submit mail on
+  # 2525 (as they did with cuttlefish). The host redirects 2525 to postal's
+  # SMTP listener on 25 (see roles/internal/postal).
+  inbound {
+    label    = "allow-smtp-alt"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "2525"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
   inbound {
     label    = "allow-http"
     action   = "ACCEPT"

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -76,6 +76,14 @@ resource "cloudflare_record" "email2" {
   value   = "cuttlefish.oaf.org.au"
 }
 
+# Click/open tracking for mail sent through postal
+resource "cloudflare_record" "email3" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "email3.theyvoteforyou.org.au"
+  type    = "CNAME"
+  value   = "track.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "shopify" {
   zone_id = cloudflare_zone.org_au.id
   name    = "swag.theyvoteforyou.org.au"

--- a/terraform/theyvoteforyou/dns.tf
+++ b/terraform/theyvoteforyou/dns.tf
@@ -84,6 +84,24 @@ resource "cloudflare_record" "email3" {
   value   = "track.postal.oaf.org.au"
 }
 
+# DKIM record for mail sent through postal. The value comes from the
+# domain's page in the postal web interface.
+resource "cloudflare_record" "postal_domainkey" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "postal-T5ymbY._domainkey.theyvoteforyou.org.au"
+  type    = "TXT"
+  value   = "v=DKIM1; t=s; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJDDy7YHdeSSYUlrWIfTf9UtnYO3F/bJTiHsPBisUi44Y1sOZkwSpCDucVUuVzP7kgazO6SAzJpvKaRSNzksbWoERWTowflZ+AxlbxeS8GbonA3M6jYtSAApv1BUz0WsCYH2BHo/h8vPL6STioi/UAWopTq1L8edHqE5nFVy4lgQIDAQAB;"
+}
+
+# Custom Return-Path (MAIL FROM) host for mail sent through postal, so the
+# Return-Path domain aligns with the From domain for DMARC
+resource "cloudflare_record" "psrp" {
+  zone_id = cloudflare_zone.org_au.id
+  name    = "psrp.theyvoteforyou.org.au"
+  type    = "CNAME"
+  value   = "rp.postal.oaf.org.au"
+}
+
 resource "cloudflare_record" "shopify" {
   zone_id = cloudflare_zone.org_au.id
   name    = "swag.theyvoteforyou.org.au"
@@ -125,7 +143,7 @@ resource "cloudflare_record" "spf" {
   zone_id = cloudflare_zone.org_au.id
   name    = "theyvoteforyou.org.au"
   type    = "TXT"
-  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com -all"
+  value   = "v=spf1 include:_spf1.oaf.org.au include:_spf.google.com include:spf.postal.oaf.org.au -all"
 }
 
 # TODO: Remove this once the one below is up and running


### PR DESCRIPTION
## Description

Gets the postal server ready for applications to start migrating off cuttlefish (part of #365, per ADR 0002):

- **SMTP submission on port 2525**: AWS EC2 blocks outbound port 25 by default, so apps submit on 2525 (the same port they used with cuttlefish). The v3 install helper runs postal with `network_mode: host`, so this is an iptables NAT redirect (2525 → the SMTP listener on 25) applied by a boot-persistent systemd oneshot. The `OUTPUT` rule also makes postal's own system mail (`127.0.0.1:2525` in `postal.yml`) reach the listener. Matching inbound 2525 rule added to the Linode firewall in `terraform/postal/`.
- **STARTTLS on the SMTP server**: `smtp_server.tls_enabled: true`, with the certificate synced daily from Caddy's Let's Encrypt cert (self-signed fallback on first provision so the SMTP server can always start). Apps can verify TLS properly — no more `tls_certcheck off` workarounds when they migrate.
- **Docs**: `docs/POSTAL.md` now spells out the per-application mail server setup (including PlanningAlerts' second `planningalerts-comments` mail server — see new ADR 0003), the connection contract for apps, and per-server credentials/tracking/webhook steps. `CONTEXT.md` gains *mail server*, *suppression list* and *track domain*.

## Motivation and Context

Cuttlefish forces an oaf.org.au Return-Path that breaks DMARC alignment (#365, #364). Postal is assembled and provisioned but not yet reachable by the apps: nothing listens on a port EC2 hosts can reach, and the SMTP listener has no TLS. This unblocks the per-app cutovers.

## How Has This Been Tested?

- [x] Ran automated tests on my own system — `make yaml-lint`, `make ansible-lint`, `make template-check`, `make tf-validate` all pass; both shell script templates rendered and checked with shellcheck; rendered `postal.yml` parses as valid YAML
- [ ] Checked affected area manually on my own / staging system — needs `tf-apply-target MODULE=postal` + `apply-postal` (will do after review)
- [ ] Confirmed it passed the GitHub actions tests

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI disclosure: this change was written with an AI assistant (Claude Code, model `anthropic.claude-fable-5`), as disclosed in the commit trailer.