### PR TITLE
add xml output path to config

### DIFF
--- a/roles/internal/openaustralia/templates/parser_configuration.yml.j2
+++ b/roles/internal/openaustralia/templates/parser_configuration.yml.j2
@@ -40,3 +40,5 @@ write_xml_senators: true
 
 # Morph API key
 morph_api_key: {{ morph_api_key }}
+
+xml_path: /srv/www/{{ stage }}/shared/pwdata


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add config for where the parser output should write.

## Motivation and Context

It's writing to the wrong place right not (the default)

see https://github.com/openaustralia/openaustralia/issues/924

code is here, that reads this config: https://github.com/openaustralia/openaustralia-parser/blob/304f5f89301c3f6660a03e9d33500782a71440dd/lib/hansard_parser.rb#L39