### PR TITLE
Install npm on openaustralia server for Tailwind CSS build

### DIFF
--- a/group_vars/openaustralia.yml
+++ b/group_vars/openaustralia.yml
@@ -134,6 +134,12 @@ domains_for_certbot:
 php_version: 8.3
 php_api_version: "20230831"
 
+# Node.js major version installed from NodeSource for twfy's Tailwind CSS build
+# (deploy:npm_build_css). Matches node-version in twfy's own
+# .github/workflows/php.yml, which builds and tests the same npm run
+# build:css step in CI - keep the two in sync.
+nodejs_version: 22
+
 # Based on aws_eip.production.public_ip and CNAMES in terraform/openaustralia/dns.tf
 
 # stage is set to key

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -247,6 +247,19 @@
     update_cache: true
     cache_valid_time: 3600
 
+# npm is invoked by Capistrano's deploy:npm_build_css task to build twfy's
+# Tailwind CSS. Without this the deploy fails with "npm: command not found".
+#
+# Jammy's packaged npm/nodejs is old (12.x) - below tailwindcss's engines.node
+# >=14. If that bites, switch to NodeSource with a pinned version, like
+# php_version/xapian_version above.
+- name: Install npm (Node.js package manager, used by Capistrano deploy to build twfy's Tailwind CSS)
+  apt:
+    name: npm
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
 - name: Set default PHP version
   tags: xapian
   community.general.alternatives:

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -270,8 +270,11 @@
 
 - name: Download and dearmor the NodeSource GPG key
   tags: npm
-  shell: curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  shell: |
+    set -o pipefail
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
   args:
+    executable: /bin/bash
     creates: /etc/apt/keyrings/nodesource.gpg
 
 - name: Add the NodeSource apt repository, pinned to nodejs_version

--- a/roles/internal/openaustralia/tasks/main.yml
+++ b/roles/internal/openaustralia/tasks/main.yml
@@ -247,18 +247,46 @@
     update_cache: true
     cache_valid_time: 3600
 
-# npm is invoked by Capistrano's deploy:npm_build_css task to build twfy's
-# Tailwind CSS. Without this the deploy fails with "npm: command not found".
-#
-# Jammy's packaged npm/nodejs is old (12.x) - below tailwindcss's engines.node
-# >=14. If that bites, switch to NodeSource with a pinned version, like
-# php_version/xapian_version above.
-- name: Install npm (Node.js package manager, used by Capistrano deploy to build twfy's Tailwind CSS)
+# Node.js/npm is invoked by Capistrano's deploy:npm_build_css task to build
+# twfy's Tailwind CSS. Without this the deploy fails with "npm: command not
+# found". Jammy's packaged npm/nodejs is old (12.x) - below tailwindcss's
+# engines.node >=14 - so install from NodeSource instead, pinned to
+# nodejs_version (group_vars/openaustralia.yml), the same way xapian_version
+# and php_version are pinned.
+- name: Install prerequisites for the NodeSource apt repo
+  tags: npm
   apt:
-    name: npm
+    name:
+      - ca-certificates
+      - gnupg
+    state: present
+
+- name: Ensure /etc/apt/keyrings exists
+  tags: npm
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download and dearmor the NodeSource GPG key
+  tags: npm
+  shell: curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  args:
+    creates: /etc/apt/keyrings/nodesource.gpg
+
+- name: Add the NodeSource apt repository, pinned to nodejs_version
+  tags: npm
+  apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_{{ nodejs_version }}.x nodistro main"
+    filename: nodesource
     state: present
     update_cache: true
-    cache_valid_time: 3600
+
+- name: Install Node.js (includes npm) from NodeSource
+  tags: npm
+  apt:
+    name: nodejs
+    state: present
 
 - name: Set default PHP version
   tags: xapian


### PR DESCRIPTION
## Description

Installs Node.js/npm on the openaustralia app server, via the NodeSource apt repo pinned to `nodejs_version` (`group_vars/openaustralia.yml`, currently `22`) rather than Ubuntu jammy's stock `apt` package — jammy's packaged npm/nodejs is v12, below tailwindcss's declared `engines.node >=14`. `nodejs_version: 22` matches `node-version` in twfy's own `.github/workflows/php.yml`, which already builds the same Tailwind CSS step in CI on that version.

## Motivation and Context

The `openaustralia` umbrella repo's `Capfile` runs a `deploy:npm_build_css` task on every deploy (`npm ci` + `npm run build:css`, to build twfy's Tailwind CSS), but npm was never added as a provisioned prerequisite here. Undocumented, this could make a deploy fail with `npm: command not found`.

Fixes #702

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] `python3 -c "import yaml; yaml.safe_load(open('roles/internal/openaustralia/tasks/main.yml'))"` — YAML parses
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Not yet run against a real host (`make check-openaustralia` / `make apply-openaustralia`) — flagging so a reviewer can decide whether to dry-run before merge.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes

- Originally went with plain `apt: name: npm` for simplicity; Sentry correctly flagged that as a HIGH-severity risk (jammy's apt npm is Node 12, below tailwindcss's `>=14`), so switched to NodeSource pinned to Node 22 instead.
- The NodeSource GPG key download uses `set -o pipefail` (a second Sentry HIGH finding, since fixed) so a transient `curl` failure can't leave a corrupt key file that the `creates:` guard then treats as done forever.

---
🤖 Drafted with assistance from Claude Sonnet 5 (Claude Code)
