### PR TITLE
deploy-user: fix corrupted authorized_keys (blank line + YAML-folding bug)

### DIFF
--- a/roles/internal/deploy-user/tasks/main.yml
+++ b/roles/internal/deploy-user/tasks/main.yml
@@ -62,6 +62,10 @@
     exclusive: true
     key: "{{ permitted_keys_for_account }}"
   vars:
+    # This block's last content line ("{{ line }} {{ result.item }}") ends with a real
+    # newline of its own - trim_blocks only trims the newline right after a {% %} tag,
+    # not this one, so the block still comes out newline-terminated regardless of
+    # {%- / -%} on the surrounding for-tags. Trimmed at the point of use below instead.
     github_keys: |-
       {% for result in github_keys_fetched.results -%}
       {% for line in result.content.splitlines() if line | trim %}
@@ -74,12 +78,22 @@
     # define openaustralia_deploy_ci_keys, and only ever added to the
     # deploy account - not ubuntu or root.
     deploy_ci_keys: "{{ (openaustralia_deploy_ci_keys | default([])) | map(attribute='public_key') | list }}"
-    permitted_keys_for_account: >-
-      {{
-        ([github_keys] + (deploy_ci_keys if item == 'deploy' else [])
-         + [terraform_key_root if item == 'root' else terraform_key_plain])
-        | join('\n')
-      }}
+    # github_keys's untrimmed trailing newline used to leave a blank line right after
+    # the GitHub users' keys once joined with the rest below - the authorized_key
+    # module rejects that blank entry, and then reports every key after it as part of
+    # that one bad entry. `| trim` here removes it; `select` (with no test) is a second,
+    # defensive layer that drops any other empty entries before joining.
+    #
+    # This has to be all on one line. A >- folded block scalar here (even one that
+    # reads as "one logical line" to a human) still preserves real newlines around any
+    # more-indented continuation line per YAML's folding rules, and that combination -
+    # real newlines embedded in the Jinja *expression text itself*, immediately before
+    # a join('\n') call - makes Ansible's templating literally double-escape that one
+    # join into a two-character \n in the output instead of a real line break, corrupting
+    # authorized_keys with two keys glued onto the same line. Reproduced and confirmed
+    # against a real Ansible run (not just plain Jinja2, which does not show this) -
+    # folding the expression back onto one line is what actually fixes it.
+    permitted_keys_for_account: "{{ ([github_keys | trim] + (deploy_ci_keys if item == 'deploy' else []) + [terraform_key_root if item == 'root' else terraform_key_plain]) | select | join('\n') }}"
   loop:
     - deploy
     - ubuntu


### PR DESCRIPTION
## What

`Set authorized_keys for local accounts` was failing with `invalid key specified` for the `deploy` and `ubuntu` accounts, and silently corrupting `root`'s authorized_keys (two keys glued onto one line, with a literal `\n` between them instead of a real line break).

## Why - two separate bugs stacked here

1. **`github_keys`'s trailing newline.** Its for-loop template's last content line (`{{ line }} {{ result.item }}`) ends with a real newline of its own - `trim_blocks` only trims the newline right after a `{% %}` tag, not this one. Joining that with the rest via `join('\n')` left a blank line right after the GitHub users' keys, which the `authorized_key` module rejects - and then reports every key after that point as part of the one bad entry, which is why the error bundled the CI deploy keys and the terraform key together for `deploy`.

2. **The `>-` folded block scalar.** `permitted_keys_for_account` was written across several unevenly-indented lines for readability. YAML's folding rules only fold line breaks between *equally*-indented lines - breaks next to a more-indented continuation line are preserved as real newlines. That meant the Jinja expression Ansible actually received still had real newlines embedded in its own text, immediately before the `join('\n')` call - and Ansible's templating turned that one `join` into a literal two-character `\n` in the rendered output instead of a real line break. This only showed up in real Ansible templating, not plain Jinja2 tested in isolation.

## Fix

- `| trim` on `github_keys` at the point of use, plus `| select` (no test) as a second, defensive layer against any other empty entry ending up in the list.
- Rewrote `permitted_keys_for_account` as a single line instead of a folded block scalar - the YAML-folding interaction above is why the multi-line version broke.

## Testing

Reproduced both bugs and the fix locally first (pure Jinja/Ansible templating logic, no AWS/live host needed), then Brenda re-ran the real `ansible-playbook --check --diff` against `openaustralia.org.au` and confirmed the fix.

Assisted-by: Claude Code:claude-sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
